### PR TITLE
Custom theme for charts

### DIFF
--- a/xchart/src/main/java/com/xeiam/xchart/Chart.java
+++ b/xchart/src/main/java/com/xeiam/xchart/Chart.java
@@ -15,17 +15,15 @@
  */
 package com.xeiam.xchart;
 
-import java.awt.Graphics2D;
+import com.xeiam.xchart.StyleManager.ChartTheme;
+import com.xeiam.xchart.internal.chartpart.ChartPainter;
+import com.xeiam.xchart.internal.style.Theme;
+
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
-
-import com.xeiam.xchart.StyleManager.ChartTheme;
-import com.xeiam.xchart.internal.chartpart.ChartPainter;
-import com.xeiam.xchart.internal.style.GGPlot2Theme;
-import com.xeiam.xchart.internal.style.MatlabTheme;
-import com.xeiam.xchart.internal.style.XChartTheme;
 
 /**
  * An XChart Chart
@@ -56,18 +54,20 @@ public class Chart {
    * @param chartTheme
    */
   public Chart(int width, int height, ChartTheme chartTheme) {
+    this(width, height, chartTheme.newInstance(chartTheme));
+  }
+
+  /**
+   * Constructor
+   *
+   * @param width
+   * @param height
+   * @param theme instance of Theme class
+   */
+  public Chart(int width, int height, Theme theme) {
 
     chartPainter = new ChartPainter(width, height);
-
-    if (chartTheme == ChartTheme.XChart) {
-      chartPainter.getStyleManager().setTheme(new XChartTheme());
-    }
-    else if (chartTheme == ChartTheme.GGPlot2) {
-      chartPainter.getStyleManager().setTheme(new GGPlot2Theme());
-    }
-    else if (chartTheme == ChartTheme.Matlab) {
-      chartPainter.getStyleManager().setTheme(new MatlabTheme());
-    }
+    chartPainter.getStyleManager().setTheme(theme);
   }
 
   /**

--- a/xchart/src/main/java/com/xeiam/xchart/StyleManager.java
+++ b/xchart/src/main/java/com/xeiam/xchart/StyleManager.java
@@ -15,14 +15,14 @@
  */
 package com.xeiam.xchart;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Stroke;
-import java.util.Locale;
-import java.util.TimeZone;
-
+import com.xeiam.xchart.internal.style.GGPlot2Theme;
+import com.xeiam.xchart.internal.style.MatlabTheme;
 import com.xeiam.xchart.internal.style.Theme;
 import com.xeiam.xchart.internal.style.XChartTheme;
+
+import java.awt.*;
+import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * The StyleManager is used to manage all things related to styling of the vast number of Chart components
@@ -46,7 +46,22 @@ public class StyleManager {
 
   public enum ChartTheme {
 
-    XChart, GGPlot2, Matlab
+    XChart, GGPlot2, Matlab;
+
+    public Theme newInstance(ChartTheme chartTheme) {
+
+      switch (chartTheme) {
+        case GGPlot2:
+          return new GGPlot2Theme();
+
+        case Matlab:
+          return new MatlabTheme();
+
+        case XChart:
+        default:
+          return new XChartTheme();
+      }
+    }
   }
 
   /** the default Theme */


### PR DESCRIPTION
As 2.2.1 there are no way to apply custom theme

Changes in this commit are about to pass custom Theme in Chart constructor, eg

``` java
Chart chart = new Chart(width, height, new ThemePrinterChart());
```
