### PR TITLE
Fix for issue #77 - keep preferredSize constant

### DIFF
--- a/xchart/src/main/java/com/xeiam/xchart/Chart.java
+++ b/xchart/src/main/java/com/xeiam/xchart/Chart.java
@@ -16,6 +16,7 @@
 package com.xeiam.xchart;
 
 import java.awt.Graphics2D;
+import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -33,6 +34,7 @@ import com.xeiam.xchart.internal.style.Theme;
 public class Chart {
 
   private final ChartPainter chartPainter;
+  private final Dimension preferredSize;
 
   /**
    * Constructor
@@ -43,6 +45,7 @@ public class Chart {
   public Chart(int width, int height) {
 
     chartPainter = new ChartPainter(width, height);
+    preferredSize = new Dimension(width, height);
   }
 
   /**
@@ -67,6 +70,7 @@ public class Chart {
   public Chart(int width, int height, Theme theme) {
 
     chartPainter = new ChartPainter(width, height);
+    preferredSize = new Dimension(width, height);
     chartPainter.getStyleManager().setTheme(theme);
   }
 
@@ -274,6 +278,10 @@ public class Chart {
   public Map<String, Series> getSeriesMap() {
 
     return chartPainter.getAxisPair().getSeriesMap();
+  }
+
+  public Dimension getPreferredSize() {
+    return preferredSize;
   }
 
 }

--- a/xchart/src/main/java/com/xeiam/xchart/XChartPanel.java
+++ b/xchart/src/main/java/com/xeiam/xchart/XChartPanel.java
@@ -92,7 +92,7 @@ public class XChartPanel extends JPanel {
   @Override
   public Dimension getPreferredSize() {
 
-    return new Dimension(chart.getWidth(), chart.getHeight());
+    return chart.getPreferredSize();
   }
 
   private class SaveAction extends AbstractAction {


### PR DESCRIPTION
It seems that the "resizing loop" is created by returning a non-constant dimension by `getPreferredSize()`.  The chart still scales to the horizontally available space with `BoxLayout.Y_AXIS` as I would expect it to do.

I haven't run the tests though...
