### PR TITLE
added custom tool tips, always visible tool tips & example chart tester

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/ExampleChartTester.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/ExampleChartTester.java
@@ -1,0 +1,449 @@
+package org.knowm.xchart.demo;
+
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTree;
+import javax.swing.WindowConstants;
+import javax.swing.event.TreeSelectionEvent;
+import javax.swing.event.TreeSelectionListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreePath;
+import javax.swing.tree.TreeSelectionModel;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.RealtimeExampleChart;
+import org.knowm.xchart.demo.charts.area.AreaChart01;
+import org.knowm.xchart.demo.charts.area.AreaChart02;
+import org.knowm.xchart.demo.charts.area.AreaChart03;
+import org.knowm.xchart.demo.charts.area.AreaChart04;
+import org.knowm.xchart.demo.charts.bar.BarChart01;
+import org.knowm.xchart.demo.charts.bar.BarChart02;
+import org.knowm.xchart.demo.charts.bar.BarChart03;
+import org.knowm.xchart.demo.charts.bar.BarChart04;
+import org.knowm.xchart.demo.charts.bar.BarChart05;
+import org.knowm.xchart.demo.charts.bar.BarChart06;
+import org.knowm.xchart.demo.charts.bar.BarChart07;
+import org.knowm.xchart.demo.charts.bar.BarChart08;
+import org.knowm.xchart.demo.charts.bar.BarChart09;
+import org.knowm.xchart.demo.charts.bar.BarChart10;
+import org.knowm.xchart.demo.charts.bar.BarChart11;
+import org.knowm.xchart.demo.charts.bar.BarChart12;
+import org.knowm.xchart.demo.charts.bubble.BubbleChart01;
+import org.knowm.xchart.demo.charts.date.DateChart01;
+import org.knowm.xchart.demo.charts.date.DateChart02;
+import org.knowm.xchart.demo.charts.date.DateChart03;
+import org.knowm.xchart.demo.charts.date.DateChart04;
+import org.knowm.xchart.demo.charts.date.DateChart05;
+import org.knowm.xchart.demo.charts.date.DateChart06;
+import org.knowm.xchart.demo.charts.date.DateChart07;
+import org.knowm.xchart.demo.charts.date.DateChart08;
+import org.knowm.xchart.demo.charts.dial.DialChart01;
+import org.knowm.xchart.demo.charts.line.LineChart01;
+import org.knowm.xchart.demo.charts.line.LineChart02;
+import org.knowm.xchart.demo.charts.line.LineChart03;
+import org.knowm.xchart.demo.charts.line.LineChart04;
+import org.knowm.xchart.demo.charts.line.LineChart05;
+import org.knowm.xchart.demo.charts.line.LineChart06;
+import org.knowm.xchart.demo.charts.line.LineChart07;
+import org.knowm.xchart.demo.charts.line.LineChart08;
+import org.knowm.xchart.demo.charts.ohlc.OHLCChart01;
+import org.knowm.xchart.demo.charts.ohlc.OHLCChart02;
+import org.knowm.xchart.demo.charts.ohlc.OHLCChart03;
+import org.knowm.xchart.demo.charts.pie.PieChart01;
+import org.knowm.xchart.demo.charts.pie.PieChart02;
+import org.knowm.xchart.demo.charts.pie.PieChart03;
+import org.knowm.xchart.demo.charts.pie.PieChart04;
+import org.knowm.xchart.demo.charts.pie.PieChart05;
+import org.knowm.xchart.demo.charts.radar.RadarChart01;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart01;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart02;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart03;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart04;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart05;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart06;
+import org.knowm.xchart.demo.charts.scatter.ScatterChart01;
+import org.knowm.xchart.demo.charts.scatter.ScatterChart02;
+import org.knowm.xchart.demo.charts.scatter.ScatterChart03;
+import org.knowm.xchart.demo.charts.scatter.ScatterChart04;
+import org.knowm.xchart.demo.charts.stick.StickChart01;
+import org.knowm.xchart.demo.charts.theme.ThemeChart01;
+import org.knowm.xchart.demo.charts.theme.ThemeChart02;
+import org.knowm.xchart.demo.charts.theme.ThemeChart03;
+import org.knowm.xchart.demo.charts.theme.ThemeChart04;
+import org.knowm.xchart.internal.chartpart.Chart;
+
+/** Class containing all XChart example charts */
+public class ExampleChartTester extends JPanel implements TreeSelectionListener {
+
+  public final class ExampleChartInfo {
+
+    String exampleChartName;
+    ExampleChart exampleChart;
+
+    public ExampleChartInfo(ExampleChart exampleChart) {
+
+      this.exampleChartName = exampleChart.getClass().getSimpleName();
+      this.exampleChart = exampleChart;
+    }
+
+    public void setExampleChartName(String exampleChartName) {
+
+      this.exampleChartName = exampleChartName;
+    }
+
+    public String getExampleChartName() {
+
+      return exampleChartName;
+    }
+
+    public ExampleChart getExampleChart() {
+
+      return exampleChart;
+    }
+
+    @Override
+    public String toString() {
+
+      return this.exampleChartName;
+    }
+  }
+
+  /** The main split frame */
+  protected JSplitPane splitPane;
+
+  /** The tree */
+  protected JTree tree;
+
+  /** The tabbed pane for charts */
+  protected JTabbedPane tabbedPane;
+
+  Timer timer = new Timer();
+
+  ArrayList<ExampleChart> exampleList;
+  Set<Class> excludeSet;
+
+  /** Constructor */
+  public ExampleChartTester() {
+
+    super(new GridLayout(1, 0));
+  }
+
+  protected void init() {
+
+    // Create the nodes.
+    DefaultMutableTreeNode top = new DefaultMutableTreeNode("XChart Example Charts");
+    createNodes(top);
+    tree = new JTree(top);
+
+    // Create a tree that allows one selection at a time.
+    tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
+
+    // Listen for when the selection changes.
+    tree.addTreeSelectionListener(this);
+
+    // Create the scroll pane and add the tree to it.
+    JScrollPane treeView = new JScrollPane(tree);
+
+    // Create Chart Panel
+    tabbedPane = new JTabbedPane();
+
+    for (int i = 0; i < tree.getRowCount(); i++) {
+      tree.expandRow(i);
+    }
+    
+    // select first leaf
+    DefaultMutableTreeNode firstLeaf = top.getFirstLeaf();
+    tree.setSelectionPath(new TreePath(firstLeaf.getPath()));
+
+    // Add the scroll panes to a split pane.
+    splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
+    splitPane.setTopComponent(treeView);
+    splitPane.setBottomComponent(tabbedPane);
+
+    Dimension minimumSize = new Dimension(130, 160);
+    treeView.setMinimumSize(minimumSize);
+    splitPane.setPreferredSize(new Dimension(700, 700));
+
+    // Add the split pane to this panel.
+    add(splitPane);
+  }
+
+  @Override
+  public void valueChanged(TreeSelectionEvent e) {
+
+    DefaultMutableTreeNode node = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
+
+    if (node == null) {
+      return;
+    }
+
+    Object nodeInfo = node.getUserObject();
+    // tree leaf
+    if (node.isLeaf()) {
+      if (!(nodeInfo instanceof ExampleChartInfo)) {
+        return;
+      }
+      ExampleChartInfo chartInfo = (ExampleChartInfo) nodeInfo;
+      // displayURL(chartInfo.bookURL);
+      int tabCount = tabbedPane.getTabCount();
+      for (int i = tabCount - 1; i >= 0; i--) {
+        tabbedPane.remove(i);
+      }
+
+      Map<String, Chart> charts = getCharts(chartInfo);
+      addCharts(tabbedPane, charts);
+      // TODO repack?
+
+      // start running a simulated data feed for the sample real-time plot
+      timer.cancel(); // just in case
+      ExampleChart exampleChart = chartInfo.getExampleChart();
+      if (exampleChart instanceof RealtimeExampleChart) {
+        final RealtimeExampleChart realtimeChart = (RealtimeExampleChart) exampleChart;
+        TimerTask chartUpdaterTask = new TimerTask() {
+
+          @Override
+          public void run() {
+
+            realtimeChart.updateData();
+            // TODO
+            tabbedPane.revalidate();
+            tabbedPane.repaint();
+          }
+        };
+        timer = new Timer();
+        timer.scheduleAtFixedRate(chartUpdaterTask, 0, 500);
+      }
+    }
+  }
+
+  protected Map<String, Chart> getCharts(ExampleChartInfo chartInfo) {
+
+    Chart<?, ?> chart = chartInfo.getExampleChart().getChart();
+    HashMap<String, Chart> map = new HashMap<String, Chart>();
+    map.put(chart.getTitle(), chart);
+    return map;
+  }
+
+  protected void addCharts(JTabbedPane tabbedPane, Map<String, Chart> chartMap) {
+
+    for (Entry<String, Chart> e : chartMap.entrySet()) {
+
+      Chart chart = e.getValue();
+      if (chart == null) {
+        continue;
+      }
+      XChartPanel chartPanel = new XChartPanel(chart);
+      tabbedPane.addTab(e.getKey(), chartPanel);
+    }
+  }
+
+  /**
+   * Create the tree
+   *
+   * @param top
+   */
+  private void createNodes(DefaultMutableTreeNode top) {
+
+    ArrayList<ExampleChart> exampleList = getExampleCharts();
+
+    // categories
+    DefaultMutableTreeNode category = null;
+    // leaves
+    DefaultMutableTreeNode defaultMutableTreeNode;
+    String categoryName = "";
+
+    for (ExampleChart exampleChart : exampleList) {
+      if (skipExampleChart(exampleChart)) {
+        continue;
+      }
+      String name = exampleChart.getClass().getSimpleName();
+      name = name.substring(0, name.indexOf("Chart"));
+      if (!categoryName.equals(name)) {
+        String label = name.equals("") ? "Chart Themes" : (name + " Charts");
+        if (label.equals("Realtime Charts")) {
+          label = "Real-time Charts";
+        }
+        category = new DefaultMutableTreeNode(label);
+        top.add(category);
+        categoryName = name;
+      }
+      defaultMutableTreeNode = new DefaultMutableTreeNode(new ExampleChartInfo(exampleChart));
+      category.add(defaultMutableTreeNode);
+    }
+
+  }
+
+  protected boolean skipExampleChart(ExampleChart exampleChart) {
+
+    if (excludeSet != null && excludeSet.contains(exampleChart.getClass())) {
+      return true;
+    }
+
+    return false;
+  }
+
+  protected ArrayList<ExampleChart> getExampleCharts() {
+
+    if (exampleList != null && !exampleList.isEmpty()) {
+      return exampleList;
+    }
+
+    ArrayList<ExampleChart> exList = new ArrayList<ExampleChart>();
+    // Area
+    exList.add(new AreaChart01());
+    exList.add(new AreaChart02());
+    exList.add(new AreaChart03());
+    exList.add(new AreaChart04());
+
+    // Pie
+    exList.add(new PieChart01());
+    exList.add(new PieChart02());
+    exList.add(new PieChart03());
+    exList.add(new PieChart04());
+    exList.add(new PieChart05());
+
+    // Line
+    exList.add(new LineChart01());
+    exList.add(new LineChart02());
+    exList.add(new LineChart03());
+    exList.add(new LineChart04());
+    exList.add(new LineChart05());
+    exList.add(new LineChart06());
+    exList.add(new LineChart07());
+    exList.add(new LineChart08());
+
+    // Scatter
+    exList.add(new ScatterChart01());
+    exList.add(new ScatterChart02());
+    exList.add(new ScatterChart03());
+    exList.add(new ScatterChart04());
+
+    // Bar
+    exList.add(new BarChart01());
+    exList.add(new BarChart02());
+    exList.add(new BarChart03());
+    exList.add(new BarChart04());
+    exList.add(new BarChart05());
+    exList.add(new BarChart06());
+    exList.add(new BarChart07());
+    exList.add(new BarChart08());
+    exList.add(new BarChart09());
+    exList.add(new BarChart10());
+    exList.add(new BarChart11());
+    exList.add(new BarChart12());
+
+    // Radar
+    exList.add(new RadarChart01());
+
+    // Dial
+    exList.add(new DialChart01());
+
+    // Stick
+    exList.add(new StickChart01());
+
+    // Bubble
+    exList.add(new BubbleChart01());
+
+    // OHLC
+    exList.add(new OHLCChart01());
+    exList.add(new OHLCChart02());
+    exList.add(new OHLCChart03());
+
+    // Theme
+    exList.add(new ThemeChart01());
+    exList.add(new ThemeChart02());
+    exList.add(new ThemeChart03());
+    exList.add(new ThemeChart04());
+
+    // Date
+    exList.add(new DateChart01());
+    exList.add(new DateChart02());
+    exList.add(new DateChart03());
+    exList.add(new DateChart04());
+    exList.add(new DateChart05());
+    exList.add(new DateChart06());
+    exList.add(new DateChart07());
+    exList.add(new DateChart08());
+
+    // Real-time category
+    exList.add(new RealtimeChart01());
+    exList.add(new RealtimeChart02());
+    exList.add(new RealtimeChart03());
+    exList.add(new RealtimeChart04());
+    exList.add(new RealtimeChart05());
+    exList.add(new RealtimeChart06());
+    return exList;
+  }
+
+  public Set<Class> getExcludeSet() {
+
+    return excludeSet;
+  }
+
+  public void setExcludeSet(Set<Class> excludeSet) {
+
+    this.excludeSet = excludeSet;
+  }
+
+  public ArrayList<ExampleChart> getExampleList() {
+
+    return exampleList;
+  }
+
+  public void setExampleList(ArrayList<ExampleChart> exampleList) {
+
+    this.exampleList = exampleList;
+  }
+
+  /**
+   * Create the GUI and show it. For thread safety, this method should be
+   * invoked from the event dispatch thread.
+   */
+  public JFrame createAndShowGUI() {
+
+    final JFrame frame = new JFrame("XChart Demo");
+    frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+    init();
+
+    // Schedule a job for the event dispatch thread:
+    // creating and showing this application's GUI.
+
+    javax.swing.SwingUtilities.invokeLater(new Runnable() {
+
+      @Override
+      public void run() {
+
+        // Create and set up the window.
+
+        // Add content to the window.
+        frame.add(ExampleChartTester.this);
+
+        // Display the window.
+        frame.pack();
+        frame.setVisible(true);
+      }
+    });
+
+    return frame;
+  }
+
+  public static void main(String[] args) {
+
+    ExampleChartTester tester = new ExampleChartTester();
+    tester.createAndShowGUI();
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/ExampleChartTester.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/ExampleChartTester.java
@@ -206,7 +206,6 @@ public class ExampleChartTester extends JPanel implements TreeSelectionListener 
 
       Map<String, Chart> charts = getCharts(chartInfo);
       addCharts(tabbedPane, charts);
-      // TODO repack?
 
       // start running a simulated data feed for the sample real-time plot
       timer.cancel(); // just in case
@@ -219,7 +218,6 @@ public class ExampleChartTester extends JPanel implements TreeSelectionListener 
           public void run() {
 
             realtimeChart.updateData();
-            // TODO
             tabbedPane.revalidate();
             tabbedPane.repaint();
           }

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/RealtimeExampleChart.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/RealtimeExampleChart.java
@@ -1,0 +1,6 @@
+package org.knowm.xchart.demo.charts;
+
+public interface RealtimeExampleChart {
+  
+  public void updateData();
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart01.java
@@ -8,6 +8,7 @@ import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.RealtimeExampleChart;
 import org.knowm.xchart.style.Styler.ChartTheme;
 
 /**
@@ -19,7 +20,7 @@ import org.knowm.xchart.style.Styler.ChartTheme;
  *   <li>real-time chart updates with SwingWrapper
  *   <li>Matlab Theme
  */
-public class RealtimeChart01 implements ExampleChart<XYChart> {
+public class RealtimeChart01 implements ExampleChart<XYChart>, RealtimeExampleChart {
 
   private XYChart xyChart;
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart02.java
@@ -10,6 +10,7 @@ import org.knowm.xchart.PieChartBuilder;
 import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.RealtimeExampleChart;
 import org.knowm.xchart.style.PieStyler.AnnotationType;
 import org.knowm.xchart.style.Styler.ChartTheme;
 
@@ -23,7 +24,7 @@ import org.knowm.xchart.style.Styler.ChartTheme;
  *   <li>Matlab theme
  *   <li>Pie Chart
  */
-public class RealtimeChart02 implements ExampleChart<PieChart> {
+public class RealtimeChart02 implements ExampleChart<PieChart>, RealtimeExampleChart {
 
   private PieChart pieChart;
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart03.java
@@ -10,6 +10,7 @@ import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.RealtimeExampleChart;
 
 /**
  * Real-time XY Chart with Error Bars
@@ -21,7 +22,7 @@ import org.knowm.xchart.demo.charts.ExampleChart;
  *   <li>fixed window
  *   <li>error bars
  */
-public class RealtimeChart03 implements ExampleChart<XYChart> {
+public class RealtimeChart03 implements ExampleChart<XYChart>, RealtimeExampleChart {
 
   private XYChart xyChart;
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart04.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart04.java
@@ -10,6 +10,7 @@ import org.knowm.xchart.BubbleChart;
 import org.knowm.xchart.BubbleChartBuilder;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.RealtimeExampleChart;
 import org.knowm.xchart.style.Styler.ChartTheme;
 
 /**
@@ -23,7 +24,7 @@ import org.knowm.xchart.style.Styler.ChartTheme;
  *   <li>Bubble chart
  *   <li>GGPlot2 theme
  */
-public class RealtimeChart04 implements ExampleChart<BubbleChart> {
+public class RealtimeChart04 implements ExampleChart<BubbleChart>, RealtimeExampleChart {
 
   private BubbleChart bubbleChart;
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart05.java
@@ -11,6 +11,7 @@ import org.knowm.xchart.CategoryChartBuilder;
 import org.knowm.xchart.Histogram;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.RealtimeExampleChart;
 import org.knowm.xchart.style.Styler.ChartTheme;
 
 /**
@@ -21,7 +22,7 @@ import org.knowm.xchart.style.Styler.ChartTheme;
  * <ul>
  *   <li>real-time chart updates with SwingWrapper
  */
-public class RealtimeChart05 implements ExampleChart<CategoryChart> {
+public class RealtimeChart05 implements ExampleChart<CategoryChart>, RealtimeExampleChart {
 
   private CategoryChart categoryChart;
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart06.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/realtime/RealtimeChart06.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.demo.charts.realtime;
 import java.util.*;
 import org.knowm.xchart.*;
 import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.RealtimeExampleChart;
 import org.knowm.xchart.demo.charts.ohlc.OHLCChart01;
 import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.Styler.ChartTheme;
@@ -16,7 +17,7 @@ import org.knowm.xchart.style.Styler.ChartTheme;
  *   <li>real-time chart updates with SwingWrapper
  *   <li>Matlab Theme
  */
-public class RealtimeChart06 implements ExampleChart<OHLCChart> {
+public class RealtimeChart06 implements ExampleChart<OHLCChart>, RealtimeExampleChart {
 
   private OHLCChart ohlcChart;
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue227.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue227.java
@@ -1,0 +1,143 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.knowm.xchart.BubbleSeries;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.OHLCSeries;
+import org.knowm.xchart.PieSeries;
+import org.knowm.xchart.RadarSeries;
+import org.knowm.xchart.demo.ExampleChartTester;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.dial.DialChart01;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart01;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart02;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart03;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart04;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart05;
+import org.knowm.xchart.demo.charts.realtime.RealtimeChart06;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.series.AxesChartSeries;
+import org.knowm.xchart.internal.series.AxesChartSeriesNumericalNoErrorBars;
+import org.knowm.xchart.internal.series.Series;
+
+public class TestForIssue227 {
+
+  static final int WIDTH = 465;
+  static final int HEIGHT = 320;
+
+  public static void main(String[] args) {
+
+    ExampleChartTester tester = new ExampleChartTester() {
+
+      @Override
+      protected Map<String, Chart> getCharts(ExampleChartInfo chartInfo) {
+
+        LinkedHashMap<String, Chart> map = new LinkedHashMap<String, Chart>();
+        ExampleChart ec = chartInfo.getExampleChart();
+        Chart c = getChartWithCustomTooltip(ec);
+        if (c != null) {
+          c.getStyler().setToolTipsAlwaysVisible(true);
+          map.put("Custom tooltips always visible", c);
+        }
+
+        map.put("Custom tooltips", getChartWithCustomTooltip(ec));
+        map.put("Default tooltips", getChart(ec));
+
+        return map;
+      }
+
+    };
+
+    HashSet<Class> excludeSet = new HashSet();
+    // dial has annotation
+    excludeSet.add(DialChart01.class);
+    
+    // in real time charts tooltips must be set for each data point
+    excludeSet.add(RealtimeChart01.class);
+    excludeSet.add(RealtimeChart02.class);
+    excludeSet.add(RealtimeChart03.class);
+    excludeSet.add(RealtimeChart04.class);
+    excludeSet.add(RealtimeChart05.class);
+    excludeSet.add(RealtimeChart06.class);
+
+    tester.setExcludeSet(excludeSet);
+    tester.createAndShowGUI();
+  }
+
+  private static Chart getChartWithCustomTooltip(ExampleChart ec) {
+
+    Chart chart = getChart(ec);
+    Map<String, Series> seriesMap = chart.getSeriesMap();
+
+    boolean flag = false;
+    for (Series series : seriesMap.values()) {
+      if (series instanceof PieSeries) {
+        String[] toolTips = getToolTips(series.getName(), 1);
+        ((PieSeries)series).setToolTip(toolTips[0]);
+        flag = true;
+        continue;
+      } else if (series instanceof RadarSeries) {
+        int count = ((RadarSeries) series).getValues().length;
+        String[] toolTips = getToolTips(series.getName(), count);
+        ((RadarSeries)series).setTooltipOverrides(toolTips);
+        flag = true;
+        continue;
+      }
+      if (!(series instanceof AxesChartSeries)) {
+        System.out.println(series.getClass());
+        continue;
+      }
+      int count = 0;
+      if (series instanceof AxesChartSeriesNumericalNoErrorBars) {
+        count = ((AxesChartSeriesNumericalNoErrorBars) series).getXData().length;
+      } else if(series instanceof CategorySeries) {
+        count = ((CategorySeries) series).getYData().size();
+      } else if(series instanceof OHLCSeries) {
+        count = ((OHLCSeries) series).getOpenData().length;
+      } else if(series instanceof BubbleSeries) {
+        count = ((BubbleSeries) series).getXData().length;
+      } else {
+        System.out.println(series.getClass());
+      }
+      
+
+      if (count <= 0) {
+        continue;
+      }
+      String[] toolTips = getToolTips(series.getName(), count);
+      ((AxesChartSeries) series).setToolTips(toolTips);
+      flag = true;
+    }
+    if (!flag) {
+      System.out.println("Skipping " + ec.getClass().getSimpleName());
+      return null;
+    }
+    return chart;
+  }
+
+  private static Chart getChart(ExampleChart ec) {
+
+    Chart chart = ec.getChart();
+    chart.getStyler().setToolTipsEnabled(true);
+    return chart;
+  }
+
+  private static String[] getToolTips(String name, int count) {
+
+    //only show 10 tooltips
+    int x = (int) Math.ceil(count / 10.0);
+    String[] t = new String[count];
+    for (int i = 0; i < t.length; i++) {
+      if (i % x == 0) {
+        t[i] = "Custom tt - " + name + " Point " + (i + 1);
+      } else {
+        t[i] = null; // No tooltip
+      }
+    }
+    return t;
+  }
+
+}

--- a/xchart/src/main/java/org/knowm/xchart/PieSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/PieSeries.java
@@ -12,6 +12,7 @@ public class PieSeries extends Series {
 
   private PieSeriesRenderStyle chartPieSeriesRenderStyle = null;
   private Number value;
+  private String toolTip;
 
   /**
    * Constructor
@@ -68,5 +69,15 @@ public class PieSeries extends Series {
     Pie(),
 
     Donut();
+  }
+
+  public String getToolTip() {
+
+    return toolTip;
+  }
+  
+  public void setToolTip(String toolTip) {
+
+    this.toolTip = toolTip;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/RadarSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/RadarSeries.java
@@ -148,4 +148,9 @@ public class RadarSeries extends Series {
     // Radar charts are always rendered as a Box in the legend
     return null;
   }
+  
+  public void setTooltipOverrides(String[] tooltipOverrides) {
+
+    this.tooltipOverrides = tooltipOverrides;
+  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
@@ -44,12 +44,16 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
       xMax = Math.log10(xMax);
     }
 
+    boolean toolTipsEnabled = chart.getStyler().isToolTipsEnabled();
     Map<String, S> map = chart.getSeriesMap();
     for (S series : map.values()) {
 
       if (!series.isEnabled()) {
         continue;
       }
+
+      String[] toolTips = series.getToolTips();
+      boolean hasCustomToolTips = toolTips != null;
 
       double yMin = chart.getYAxis(series.getYAxisGroup()).getMin();
       double yMax = chart.getYAxis(series.getYAxisGroup()).getMax();
@@ -136,13 +140,27 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
           g.setStroke(series.getLineStyle());
           g.draw(bubble);
           // add data labels
-          chart.toolTips.addData(
-              bubble,
-              xOffset,
-              yOffset,
-              0,
-              chart.getXAxisFormat().format(x),
-              chart.getYAxisFormat().format(yOrig));
+          if (toolTipsEnabled) {
+            if (hasCustomToolTips) {
+              String tt = toolTips[i];
+              if (tt != null) {
+                chart.toolTips.addData(
+                    bubble,
+                    xOffset,
+                    yOffset,
+                    0,
+                    tt);
+              }
+            } else {
+              chart.toolTips.addData(
+                  bubble,
+                  xOffset,
+                  yOffset,
+                  0,
+                  chart.getXAxisFormat().format(x),
+                  chart.getYAxisFormat().format(yOrig));
+            }
+          }
         }
       }
     }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -123,11 +123,15 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
     double[] accumulatedStackOffsetPos = new double[numCategories];
     double[] accumulatedStackOffsetNeg = new double[numCategories];
 
+    boolean toolTipsEnabled = chart.getStyler().isToolTipsEnabled();
+    
     for (S series : seriesMap.values()) {
 
       if (!series.isEnabled()) {
         continue;
       }
+      String[] toolTips = series.getToolTips();
+      boolean hasCustomToolTips = toolTips != null;
 
       yMin = chart.getYAxis(series.getYAxisGroup()).getMin();
       yMax = chart.getYAxis(series.getYAxisGroup()).getMax();
@@ -474,7 +478,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
           g.draw(line);
         }
         // add data labels
-        if (chart.toolTips != null) {
+        if (toolTipsEnabled) {
           Rectangle2D.Double rect =
               new Rectangle2D.Double(xOffset, yOffset, barWidth, Math.abs(yOffset - zeroOffset));
           double yPoint;
@@ -483,13 +487,26 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
           } else {
             yPoint = yOffset;
           }
-          chart.toolTips.addData(
-              rect,
-              xOffset,
-              yPoint,
-              barWidth,
-              chart.getXAxisFormat().format(nextCat),
-              chart.getYAxisFormat().format(y));
+          
+          if (hasCustomToolTips) {
+            String tt = toolTips[categoryCounter-1];
+            if (tt != null) {
+              chart.toolTips.addData( 
+                  rect,
+                  xOffset,
+                  yPoint,
+                  barWidth,
+                  tt);
+            }
+          } else {
+            chart.toolTips.addData(
+                rect,
+                xOffset,
+                yPoint,
+                barWidth,
+                chart.getXAxisFormat().format(nextCat),
+                chart.getYAxisFormat().format(y));
+          }
         }
       }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Line_Area_Scatter.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Line_Area_Scatter.java
@@ -41,6 +41,7 @@ public class PlotContent_Category_Line_Area_Scatter<
     double yTickSpace = categoryStyler.getPlotContentSize() * getBounds().getHeight();
     double yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
 
+    boolean toolTipsEnabled = chart.getStyler().isToolTipsEnabled();
     Map<String, S> seriesMap = chart.getSeriesMap();
 
     int numCategories = seriesMap.values().iterator().next().getXData().size();
@@ -51,6 +52,9 @@ public class PlotContent_Category_Line_Area_Scatter<
       if (!series.isEnabled()) {
         continue;
       }
+      String[] toolTips = series.getToolTips();
+      boolean hasCustomToolTips = toolTips != null;
+
       Axis yAxis = chart.getYAxis(series.getYAxisGroup());
       double yMin = yAxis.getMin();
       double yMax = yAxis.getMax();
@@ -228,11 +232,22 @@ public class PlotContent_Category_Line_Area_Scatter<
           line = new Line2D.Double(xOffset - 3, topEBOffset, xOffset + 3, topEBOffset);
           g.draw(line);
         }
-        chart.toolTips.addData(
-            xOffset,
-            yOffset,
-            chart.getXAxisFormat().format(nextCat),
-            chart.getYAxisFormat().format(y));
+        
+        if (toolTipsEnabled) {
+          if (hasCustomToolTips) {
+            String tt = toolTips[categoryCounter];
+            if (tt != null) {
+              chart.toolTips.addData(xOffset, yOffset,tt);
+            }
+          } else {
+            chart.toolTips.addData(
+                xOffset,
+                yOffset,
+                chart.getXAxisFormat().format(nextCat),
+                chart.getYAxisFormat().format(y));
+          }
+        }
+        
       }
 
       // close any open path for area charts

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -58,6 +58,10 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
       if (!series.isEnabled()) {
         continue;
       }
+
+      String[] toolTips = series.getToolTips();
+      boolean hasCustomToolTips = toolTips != null;
+
       Axis yAxis = chart.getYAxis(series.getYAxisGroup());
       double yMin = yAxis.getMin();
       double yMax = yAxis.getMax();
@@ -196,19 +200,31 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
 
         // add data labels
         if (toolTipsEnabled) {
-          chart.toolTips.addData(
-              toolTipArea,
-              xOffset,
-              highOffset,
-              candleHalfWidth * 2,
-              chart.getXAxisFormat().format(x),
-              chart.getYAxisFormat().format(openOrig)
-                  + ':'
-                  + chart.getYAxisFormat().format(highOrig)
-                  + ':'
-                  + chart.getYAxisFormat().format(lowOrig)
-                  + ':'
-                  + chart.getYAxisFormat().format(closeOrig));
+          if (hasCustomToolTips) {
+            String tt = toolTips[i];
+            if (tt != null) {
+              chart.toolTips.addData(
+                  toolTipArea,
+                  xOffset,
+                  highOffset,
+                  candleHalfWidth * 2,
+                  tt);
+            }
+          } else {
+            chart.toolTips.addData(
+                toolTipArea,
+                xOffset,
+                highOffset,
+                candleHalfWidth * 2,
+                chart.getXAxisFormat().format(x),
+                chart.getYAxisFormat().format(openOrig)
+                    + ':'
+                    + chart.getYAxisFormat().format(highOrig)
+                    + ':'
+                    + chart.getYAxisFormat().format(lowOrig)
+                    + ':'
+                    + chart.getYAxisFormat().format(closeOrig));
+          }
         }
       }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -151,6 +151,8 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
     // double curValue = 0.0;
     double startAngle = pieStyler.getStartAngleInDegrees() + 90;
 
+    boolean toolTipsEnabled = chart.getStyler().isToolTipsEnabled();
+    
     map = chart.getSeriesMap();
     for (S series : map.values()) {
 
@@ -357,7 +359,14 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
               - Math.sin(Math.toRadians(angle))
                   * (pieBounds.getHeight() / 2 * pieStyler.getAnnotationDistance());
 
-      chart.toolTips.addData(labelShape, xOffset, yOffset + 10, 0, annotation);
+      if (toolTipsEnabled) {
+        String tt = series.getToolTip();
+        if (tt != null) {
+          chart.toolTips.addData(labelShape, xOffset, yOffset + 10, 0, tt);
+        } else {
+          chart.toolTips.addData(labelShape, xOffset, yOffset + 10, 0, annotation);
+        }
+      }
       startAngle += arcAngle;
     }
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -74,6 +74,10 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
       double[] errorBars = series.getExtraValues();
       Path2D.Double path = null;
 
+      boolean toolTipsEnabled = chart.getStyler().isToolTipsEnabled();
+      String[] toolTips = series.getToolTips();
+      boolean hasCustomToolTips = toolTips != null;
+      
       for (int i = 0; i < xData.length; i++) {
 
         double x = xData[i];
@@ -249,12 +253,19 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
         }
 
         // add data labels
-        if (chart.getStyler().isToolTipsEnabled()) {
-          chart.toolTips.addData(
-              xOffset,
-              yOffset,
-              chart.getXAxisFormat().format(x),
-              chart.getYAxisFormat().format(yOrig));
+        if (toolTipsEnabled) {
+          if (hasCustomToolTips) {
+            String tt = toolTips[i];
+            if (tt != null) {
+              chart.toolTips.addData(xOffset, yOffset,tt);
+            }
+          } else {
+            chart.toolTips.addData(
+                xOffset,
+                yOffset,
+                chart.getXAxisFormat().format(x),
+                chart.getYAxisFormat().format(yOrig));
+          }
         }
       }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
@@ -27,7 +27,6 @@ public class ToolTips implements MouseMotionListener {
   private double rightEdge;
   private double topEdge;
   private double bottomEdge;
-
   /**
    * Constructor
    *
@@ -104,6 +103,12 @@ public class ToolTips implements MouseMotionListener {
       return;
     }
 
+    if (styler.isToolTipsAlwaysVisible()) {
+      for (DataPoint dataPoint : dataPointList) {
+        paintToolTip(g, dataPoint);
+      }
+    }
+    
     if (dataPoint != null) { // dataPoint was created in mouse move, need to render it
       paintToolTip(g, dataPoint);
     }
@@ -176,10 +181,12 @@ public class ToolTips implements MouseMotionListener {
     double h = annotationRectangle.getHeight() + 2 * MARGIN;
     double halfHeight = h / 2;
 
-    // not the box with label, but the shape
-    // highlight shape for popup
-    g.setColor(styler.getToolTipHighlightColor());
-    g.fill(dataPoint.shape);
+    if (dataPoint == this.dataPoint) {
+      // not the box with label, but the shape
+      // highlight shape for popup
+      g.setColor(styler.getToolTipHighlightColor());
+      g.fill(dataPoint.shape);
+    }
 
     // the label in a box
     x = Math.max(x, leftEdge);

--- a/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeries.java
@@ -26,6 +26,8 @@ public abstract class AxesChartSeries extends Series {
   /** Line Width */
   private float lineWidth = -1.0f;
 
+  protected String[] toolTips;
+  
   /**
    * Constructor
    *
@@ -127,5 +129,15 @@ public abstract class AxesChartSeries extends Series {
   public DataType getyAxisDataType() {
 
     return yAxisType;
+  }
+  
+  public String[] getToolTips() {
+
+    return toolTips;
+  }
+  
+  public void setToolTips(String[] toolTips) {
+
+    this.toolTips = toolTips;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -46,6 +46,7 @@ public abstract class Styler {
   private double plotContentSize = .92;
   // Tool Tips ///////////////////////////////
   private boolean isToolTipsEnabled;
+  private boolean isToolTipsAlwaysVisible;
   private ToolTipType toolTipType;
   private Color toolTipBackgroundColor;
   private Color toolTipBorderColor;
@@ -525,6 +526,18 @@ public abstract class Styler {
     return this;
   }
 
+  public boolean isToolTipsAlwaysVisible() {
+    
+    return isToolTipsAlwaysVisible;
+  }
+
+  public Styler setToolTipsAlwaysVisible(boolean toolTipsAlwaysVisible) {
+    
+    isToolTipsAlwaysVisible = toolTipsAlwaysVisible;
+    return this;
+  }
+  
+  
   public ToolTipType getToolTipType() {
 
     return toolTipType;


### PR DESCRIPTION
- Added custom tool tip feature (issue #227)
- Added tool tips always visible option (issue #270)
- Added ExampleChartTester

### Tool tips
Custom tool tips can be set from series. A `null` value disables tool tip for that point.
- For most series use method `series.setToolTips()`
- For Pie charts use method `pieSeries.setToolTip()`
- For RadarSeries use constructor or method `radarSeries.setTooltipOverrides()`
- For DialSeries use constructor 

### Always Visible Tool tips
To make tool tips always visible use method `chart.getStyler().setToolTipsAlwaysVisible(true);`

### ExampleChartTester
ExampleChartTester is added for fast testing of new features. 
It is a customizable copy of XChartDemo. 
ExampleChart's shown charts can be controlled by methods `setExampleList` and  `setExcludeSet`.
It places charts in a tabbed pane. New charts can be added to tabbed pane by overriding `Map<String, Chart> getCharts(ExampleChartInfo chartInfo)` method.

For details see TestForIssue227 clas.

### Previews
Default tool tips:
![image](https://user-images.githubusercontent.com/6737748/41835567-c2d6f828-7860-11e8-99a8-45f31baf54b8.png)

Custom tool tips:
![image](https://user-images.githubusercontent.com/6737748/41835541-a8050454-7860-11e8-9a55-b7eda0a85663.png)

Always visible tool tips:
![image](https://user-images.githubusercontent.com/6737748/41835545-af764022-7860-11e8-888a-ad69bae88a37.png)
