### PR TITLE
Customizable sum text for pie chart

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -11,13 +11,13 @@ import org.knowm.xchart.PieSeries;
 import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
 import org.knowm.xchart.style.PieStyler;
 import org.knowm.xchart.style.PieStyler.AnnotationType;
+import org.knowm.xchart.style.SumFormatter;
 
 /** @author timmolter */
 public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
     extends PlotContent_<ST, S> {
 
   private final ST pieStyler;
-  private final DecimalFormat df = new DecimalFormat("#.0");
 
   /**
    * Constructor
@@ -172,6 +172,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
 
       // add data labels
       // maybe another option to construct this label
+      DecimalFormat df = new DecimalFormat(pieStyler.getDecimalPattern());
       String annotation = series.getName() + " (" + df.format(y) + ")";
 
       double xCenter =
@@ -232,9 +233,11 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
           annotation = series.getName();
         } else if (pieStyler.getAnnotationType() == AnnotationType.LabelAndPercentage) {
           double percentage = y.doubleValue() / total * 100;
+          DecimalFormat df = new DecimalFormat(pieStyler.getDecimalPattern());
           annotation = series.getName() + " (" + df.format(percentage) + "%)";
         } else if (pieStyler.getAnnotationType() == AnnotationType.Percentage) {
           double percentage = y.doubleValue() / total * 100;
+          DecimalFormat df = new DecimalFormat(pieStyler.getDecimalPattern());
           annotation = df.format(percentage) + "%";
         } else if (pieStyler.getAnnotationType() == AnnotationType.LabelAndValue) {
             if (pieStyler.getDecimalPattern() != null) {
@@ -371,12 +374,8 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
   private void paintSum(Graphics2D g, Rectangle2D pieBounds, double total) {
     // draw total value if visible
     if (pieStyler.isSumVisible()) {
-      DecimalFormat totalDf =
-              (pieStyler.getDecimalPattern() == null)
-                      ? df
-                      : new DecimalFormat(pieStyler.getDecimalPattern());
-
-      String annotation = totalDf.format(total);
+      SumFormatter sumFormatter = pieStyler.getSumFormatter();
+      String annotation = sumFormatter.format(total);
 
       TextLayout textLayout =
               new TextLayout(

--- a/xchart/src/main/java/org/knowm/xchart/style/AbstractBaseTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AbstractBaseTheme.java
@@ -422,6 +422,18 @@ public abstract class AbstractBaseTheme implements Theme {
     return getAnnotationFont();
   }
 
+  @Override
+  public String getDecimalPattern() {
+
+    return "#.0";
+  }
+
+  @Override
+  public SumFormatter getSumFormatter(Styler styler) {
+
+    return new SumFormatter.DefaultSumFormatter(styler);
+  }
+
   // Line, Scatter, Area Charts ///////////////////////////////
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -15,6 +15,7 @@ public class PieStyler extends Styler {
   private double donutThickness;
   private boolean isSumVisible;
   private Font sumFont;
+  private SumFormatter sumFormatter;
 
   public PieStyler() {
 
@@ -38,6 +39,7 @@ public class PieStyler extends Styler {
 
     this.isSumVisible = theme.isSumVisible();
     this.sumFont = theme.getSumFont();
+    this.sumFormatter = theme.getSumFormatter(this);
   }
 
   public PieSeriesRenderStyle getDefaultSeriesRenderStyle() {
@@ -199,6 +201,22 @@ public class PieStyler extends Styler {
   public PieStyler setSumFontSize(float sumFontSize) {
 
     this.sumFont = this.sumFont.deriveFont(sumFontSize);
+    return this;
+  }
+
+  public SumFormatter getSumFormatter() {
+
+    return sumFormatter;
+  }
+
+  /**
+   * Sets the formatter for the sum.
+   *
+   * @param sumFormatter
+   */
+  public PieStyler setSumFormatter(SumFormatter sumFormatter) {
+
+    this.sumFormatter = sumFormatter;
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -108,7 +108,7 @@ public abstract class Styler {
     annotationsFont = theme.getAnnotationFont();
 
     // Formatting
-    decimalPattern = null;
+    decimalPattern = theme.getDecimalPattern();
   }
 
   public Font getBaseFont() {

--- a/xchart/src/main/java/org/knowm/xchart/style/SumFormatter.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/SumFormatter.java
@@ -1,0 +1,23 @@
+package org.knowm.xchart.style;
+
+import java.text.DecimalFormat;
+
+public interface SumFormatter {
+
+  String format(double sum);
+
+  class DefaultSumFormatter implements SumFormatter {
+
+    private final Styler styler;
+
+    public DefaultSumFormatter(Styler styler) {
+      this.styler = styler;
+    }
+
+    @Override
+    public String format(double sum) {
+      DecimalFormat totalDf = new DecimalFormat(styler.getDecimalPattern());
+      return totalDf.format(sum);
+    }
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/style/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Theme.java
@@ -149,6 +149,10 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
 
   Font getSumFont();
 
+  String getDecimalPattern();
+
+  SumFormatter getSumFormatter(Styler styler);
+
   // Line, Scatter, Area Charts ///////////////////////////////
 
   int getMarkerSize();


### PR DESCRIPTION
Motivation:
![image](https://user-images.githubusercontent.com/11398547/50550064-26966280-0c69-11e9-97f6-3dbdb98e1150.png)

If sumFormatter and decimalPattern are not defined then the original format "#.0" is used.
If decimalPattern is specified but sumFormatter not then the given format is used.