### PR TITLE
Add missing null check for pie chart

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -65,7 +65,11 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
     dummy.append(new Arc2D.Double(x, y, width, height, start + extent, -extent, Arc2D.OPEN), false);
 
     point = dummy.getCurrentPoint();
-    generalPath.lineTo(point.getX(), point.getY());
+    
+    if (point != null) {
+      generalPath.lineTo(point.getX(), point.getY());
+    }
+    
     return generalPath;
   }
 


### PR DESCRIPTION
How to reproduce
Start PieChart04 and resize the window: after a certain - small - size the console is full with NPEs.

![ok](https://user-images.githubusercontent.com/11398547/52486588-d55c8580-2bbb-11e9-9836-db7658ee057f.PNG)

![nok](https://user-images.githubusercontent.com/11398547/52486595-db526680-2bbb-11e9-9260-4a98c3669f83.PNG)


Fix
dummy.getCurrentPoint() returns null and it was carefully checked at an another place (eg. line 66) so lets add it to this place as well.


