### PR TITLE
xData is null, so we need to generate xData first before we use it. g…

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
@@ -176,10 +176,11 @@ public class CategoryChart extends Chart<CategoryStyler, CategorySeries> {
 
       series = new CategorySeries(seriesName, xData, yData, errorBars, getDataType(xData));
     } else { // generate xData
+      xData = Utils.getGeneratedDataAsList(yData.size());
       series =
           new CategorySeries(
               seriesName,
-              Utils.getGeneratedDataAsList(yData.size()),
+              xData,
               yData,
               errorBars,
               getDataType(xData));


### PR DESCRIPTION
…etDataType crashes if it gets passed a null.