### PR TITLE
If there are only zero or one tickLocations, the scale is not display…

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Logarithmic.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Logarithmic.java
@@ -131,5 +131,11 @@ class AxisTickCalculator_Logarithmic extends AxisTickCalculator_ {
       tickStep = tickStep * Utils.pow(10, 1);
       firstPosition = tickStep + Utils.pow(10, i);
     }
+    if (tickLocations.size() <= 1) {
+      tickLabels.add(numberLogFormatter.format(minValue));
+      tickLocations.add(margin);
+      tickLabels.add(numberLogFormatter.format(maxValue));
+      tickLocations.add(margin + tickSpace);
+    }
   }
 }


### PR DESCRIPTION
…ed at all. This can happen if you have a very small range of values but want them in a logarithmic chart. In that case, add min and max values to get some idea of the scale.