### PR TITLE
Added zoom & custom plot parts & coordinate conversion

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/ExampleChartTester.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/ExampleChartTester.java
@@ -66,6 +66,7 @@ import org.knowm.xchart.demo.charts.pie.PieChart02;
 import org.knowm.xchart.demo.charts.pie.PieChart03;
 import org.knowm.xchart.demo.charts.pie.PieChart04;
 import org.knowm.xchart.demo.charts.pie.PieChart05;
+import org.knowm.xchart.demo.charts.pie.PieChart06;
 import org.knowm.xchart.demo.charts.radar.RadarChart01;
 import org.knowm.xchart.demo.charts.realtime.RealtimeChart01;
 import org.knowm.xchart.demo.charts.realtime.RealtimeChart02;
@@ -311,6 +312,7 @@ public class ExampleChartTester extends JPanel implements TreeSelectionListener 
     exList.add(new PieChart03());
     exList.add(new PieChart04());
     exList.add(new PieChart05());
+    exList.add(new PieChart06());
 
     // Line
     exList.add(new LineChart01());

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForCoordinateLookup.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForCoordinateLookup.java
@@ -1,0 +1,66 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.swing.JTabbedPane;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.demo.ExampleChartTester;
+import org.knowm.xchart.internal.chartpart.Chart;
+
+public class TestForCoordinateLookup {
+
+  static final int WIDTH = 465;
+  static final int HEIGHT = 320;
+
+  public static class CoordinatePrinter extends MouseAdapter {
+
+    private Chart chart;
+
+    public CoordinatePrinter(Chart chart) {
+
+      this.chart = chart;
+    }
+
+    public void mousePressed(MouseEvent e) {
+
+      double chartX = chart.getChartXFromCoordinate(e.getX());
+      double chartY = chart.getChartYFromCoordinate(e.getY());
+
+      double screenX = chart.getScreenXFromChart(chartX);
+      double screenY = chart.getScreenYFromChart(chartY);
+      System.out.println(
+          String.format("Mouse click: (%d, %d) Chart value: (%.3f, %.3f) Mouse point from chart value: (%.1f, %.1f)",
+              e.getX(), e.getY(), chartX, chartY, screenX, screenY));
+    }
+  }
+
+  public static void main(String[] args) {
+
+    ExampleChartTester tester = new ExampleChartTester() {
+
+      @Override
+      protected void addCharts(JTabbedPane tabbedPane, Map<String, Chart> chartMap) {
+
+        for (Entry<String, Chart> e : chartMap.entrySet()) {
+
+          Chart chart = e.getValue();
+          if (chart == null) {
+            continue;
+          }
+          chart.getStyler().setToolTipsEnabled(true);
+          XChartPanel chartPanel = new XChartPanel(chart);
+          CoordinatePrinter mouseListener = new CoordinatePrinter(chart);
+          chartPanel.addMouseListener(mouseListener);
+          tabbedPane.addTab(e.getKey(), chartPanel);
+        }
+      }
+
+    };
+
+    tester.createAndShowGUI();
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForCustomChartParts.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForCustomChartParts.java
@@ -1,0 +1,129 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.BasicStroke;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.WindowConstants;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.internal.chartpart.components.ChartImage;
+import org.knowm.xchart.internal.chartpart.components.ChartLine;
+import org.knowm.xchart.internal.chartpart.components.ChartText;
+import org.knowm.xchart.style.markers.None;
+
+public class TestForCustomChartParts {
+
+  static final int WIDTH = 465;
+  static final int HEIGHT = 320;
+
+  public static XYChart getChart() {
+
+    // Create Chart
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+
+    // Customize Chart
+    chart.getStyler().setChartTitleVisible(false);
+    chart.getStyler().setLegendVisible(false);
+
+    double start = 0;
+    double end = 1;
+    double increment = 0.01;
+
+    List<Double> xData = new ArrayList<Double>();
+    List<Double> yData = new ArrayList<Double>();
+
+    double x = start;
+
+    while (x <= end) {
+
+      double y = Math.exp(2 * x - (7 * x * x * x));
+      xData.add(x);
+      yData.add(y);
+      x += increment;
+
+    }
+    // Series
+    XYSeries series = chart.addSeries("series1", xData, yData);
+    series.setMarker(new None());
+
+    return chart;
+  }
+
+  public static void main(String[] args) {
+
+    final XYChart chart = getChart();
+
+    javax.swing.SwingUtilities.invokeLater(new Runnable() {
+
+      @Override
+      public void run() {
+
+        JFrame frame = new JFrame("Advanced Example");
+        frame.setLayout(new BorderLayout());
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+
+        final XChartPanel chartPanel = new XChartPanel<XYChart>(chart);
+
+        XYSeries series = chart.getSeriesMap().get("series1");
+
+        int width = 2;
+        BasicStroke stroke = new BasicStroke(width, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL,
+            10.0f, new float[] { 3.0f, 0.0f }, 0.0f);
+
+        // draw a horizontal line at series max point
+        ChartLine maxY = new ChartLine(series.getYMax(), false, false);
+        maxY.setColor(Color.GREEN);
+        maxY.setStroke(stroke);
+        maxY.init(chartPanel);
+        
+        // draw a horizontal line at series min point
+        ChartLine minY = new ChartLine(series.getYMin(), false, false);
+        minY.setColor(Color.RED);
+        minY.setStroke(stroke);
+        minY.init(chartPanel);
+        
+        // draw a vertical line at 0.45
+        ChartLine xLine = new ChartLine(0.45, true, false);
+        xLine.setColor(Color.MAGENTA);
+        xLine.setStroke(stroke);
+        xLine.init(chartPanel);
+        
+        // draw a vertical line at 100 pixels
+        ChartLine xLinePixel = new ChartLine(100, true, true);
+        xLinePixel.setColor(Color.BLACK);
+        xLinePixel.setStroke(stroke);
+        xLinePixel.init(chartPanel);
+
+        // add text near to max line
+        ChartText maxText = new ChartText("Max", 0.0, series.getYMax(), false);
+        maxText.init(chartPanel);
+        
+        try {
+          URL url = new URL("https://raw.githubusercontent.com/knowm/XChart/develop/etc/XChart_64_64.png");
+          BufferedImage image = ImageIO.read(url);
+          ChartImage chartImage = new ChartImage(image, 0, 1, false);
+          chartImage.init(chartPanel);
+        } catch (IOException e) {
+          e.printStackTrace();
+        } 
+      
+        frame.add(chartPanel, BorderLayout.CENTER);
+
+        frame.pack();
+        frame.setVisible(true);
+      }
+    });
+  }
+
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForSelectionZoom.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForSelectionZoom.java
@@ -1,0 +1,60 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.swing.JTabbedPane;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.demo.ExampleChartTester;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.SelectionZoom;
+
+public class TestForSelectionZoom {
+
+  static final int WIDTH = 465;
+  static final int HEIGHT = 320;
+
+  public static void main(String[] args) {
+
+    ExampleChartTester tester = new ExampleChartTester() {
+
+      @Override
+      protected void addCharts(JTabbedPane tabbedPane, Map<String, Chart> chartMap) {
+
+        for (Entry<String, Chart> e : chartMap.entrySet()) {
+
+          Chart chart = e.getValue();
+          if (chart == null) {
+            continue;
+          }
+          chart.getStyler().setToolTipsEnabled(true);
+          XChartPanel chartPanel = new XChartPanel(chart);
+          if (chart instanceof XYChart) {
+            SelectionZoom sz = new SelectionZoom();
+            sz.init(chartPanel);
+          }
+          tabbedPane.addTab(e.getKey(), chartPanel);
+        }
+      }
+
+      @Override
+      protected boolean skipExampleChart(ExampleChart exampleChart) {
+
+        if (exampleChart.getClass().getSimpleName().startsWith("RealtimeChart")) {
+          return true;
+        }
+        Chart chart = exampleChart.getChart();
+        if (chart instanceof XYChart) {
+          return false;
+        }
+        return true;
+      }
+
+    };
+
+    tester.createAndShowGUI();
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
 import org.knowm.xchart.internal.chartpart.Chart;
@@ -446,6 +447,35 @@ public class XYChart extends Chart<XYStyler, XYSeries> {
       if (series.getMarkerColor() == null) { // wasn't set manually
         series.setMarkerColor(seriesColorMarkerLineStyle.getColor());
       }
+    }
+  }
+  
+  public void resetFilter() {
+    
+    for (XYSeries series : getSeriesMap().values()) {
+      series.resetFilter();
+    }
+  }
+  
+  public boolean filterXByScreen(int screenXmin, int screenXmax) {
+    
+    // convert screen coordinates to axis values
+    double minValue = getChartXFromCoordinate(screenXmin);
+    double maxValue = getChartXFromCoordinate(screenXmax);
+    boolean filtered = false;
+    for (XYSeries series : getSeriesMap().values()) {
+      boolean f = series.filterXByValue(minValue, maxValue);
+      if (f) {
+        filtered = true;
+      }
+    }
+    return filtered;
+  }
+  
+  public void filterXByIndex(int startIndex, int endIndex) {
+    
+    for (XYSeries series : getSeriesMap().values()) {
+      series.filterXByIndex(startIndex, endIndex);
     }
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.internal.chartpart;
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.text.Format;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -33,7 +34,8 @@ public abstract class Chart<ST extends Styler, S extends Series> {
   private String xAxisTitle = "";
   private String yAxisTitle = "";
   private Map<Integer, String> yAxisGroupTitleMap = new HashMap<Integer, String>();
-
+  protected ArrayList<ChartPart> plotParts = new ArrayList<ChartPart>();
+  
   /**
    * Constructor
    *
@@ -222,5 +224,63 @@ public abstract class Chart<ST extends Styler, S extends Series> {
   Format getYAxisFormat() {
 
     return axisPair.getYAxis().getAxisTickCalculator().getAxisFormat();
+  }
+  
+  public ArrayList<ChartPart> getPlotParts() {
+
+    return plotParts;
+  }
+  
+  public void addPlotPart(ChartPart chartPart) {
+    
+    plotParts.add(chartPart);
+  }
+  
+  public double getChartXFromCoordinate(int screenX) {
+    
+    if (axisPair == null) {
+      return Double.NaN;
+    }
+    return axisPair.getXAxis().getChartValue(screenX);
+  }
+  
+  public double getChartYFromCoordinate(int screenY) {
+    
+    if (axisPair == null) {
+      return Double.NaN;
+    }
+    return axisPair.getYAxis().getChartValue(screenY);
+  }
+  
+  public double getChartYFromCoordinate(int screenY, int yIndex) {
+    
+    if (axisPair == null) {
+      return Double.NaN;
+    }
+    return axisPair.getYAxis(yIndex).getChartValue(screenY);
+  }
+  
+  public double getScreenXFromChart(double xValue) {
+    
+    if (axisPair == null) {
+      return Double.NaN;
+    }
+    return axisPair.getXAxis().getScreenValue(xValue);
+  }
+  
+  public double getScreenYFromChart(double yValue) {
+    
+    if (axisPair == null) {
+      return Double.NaN;
+    }
+    return axisPair.getYAxis().getScreenValue(yValue);
+  }
+  
+  public double getScreenYFromChart(double yValue, int yIndex) {
+    
+    if (axisPair == null) {
+      return Double.NaN;
+    }
+    return axisPair.getYAxis(yIndex).getScreenValue(yValue);
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartPart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartPart.java
@@ -8,7 +8,7 @@ import java.awt.geom.Rectangle2D;
  *
  * @author timmolter
  */
-interface ChartPart {
+public interface ChartPart {
 
   BasicStroke SOLID_STROKE =
       new BasicStroke(

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
@@ -49,6 +49,10 @@ public abstract class PlotContent_<ST extends Styler, S extends Series> implemen
 
     chart.toolTips.paint(g);
 
+    for (ChartPart part : chart.getPlotParts()) {
+      part.paint(g);
+    }
+    
     g.setClip(saveClip);
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/SelectionZoom.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/SelectionZoom.java
@@ -1,0 +1,180 @@
+package org.knowm.xchart.internal.chartpart;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.geom.Rectangle2D;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.internal.chartpart.components.ChartButton;
+
+public class SelectionZoom extends MouseAdapter implements ChartPart, ActionListener {
+  protected XChartPanel<XYChart> chartPanel;
+  protected XYChart chart;
+
+  protected Rectangle bounds;
+  protected Color selectionColor;
+  protected boolean resetByDoubleClick;
+  protected boolean resetByButton;
+  protected ChartButton resetButton;
+
+  protected int x, x2;
+  protected boolean filtered;
+
+  public SelectionZoom() {
+
+    x = -1;
+    x2 = -1;
+    selectionColor = new Color(0, 0, 192, 128);
+    resetByDoubleClick = true;
+    resetByButton = true;
+    resetButton = new ChartButton("Reset Zoom");
+  }
+
+  public void init(XChartPanel<XYChart> chartPanel) {
+
+    this.chartPanel = chartPanel;
+    chart = chartPanel.getChart();
+    chartPanel.addMouseListener(this);
+    chartPanel.addMouseMotionListener(this);
+    chart.addPlotPart(this);
+    resetButton.init(chartPanel);
+    resetButton.setVisible(false);
+    resetButton.addActionListener(this);
+  }
+
+  protected void resetZoom() {
+
+    chart.resetFilter();
+    filtered = false;
+    resetButton.setVisible(false);
+
+    x = -1;
+    x2 = -1;
+    repaint();
+  }
+
+  protected void repaint() {
+
+    chartPanel.invalidate();
+    chartPanel.repaint();
+  }
+
+  @Override
+  public Rectangle2D getBounds() {
+
+    return bounds;
+  }
+
+  @Override
+  public void paint(Graphics2D g) {
+
+    if (x == -1 || x2 == -1) {
+      return;
+    }
+    g.setColor(selectionColor);
+    int xStart = Math.min(x, x2);
+    int width = Math.abs(x - x2);
+    bounds = g.getClipBounds();
+    g.fillRect(xStart, 0, width, (int) (bounds.height + bounds.getY()));
+  }
+
+  public void mousePressed(MouseEvent e) {
+
+    x = e.getX();
+    repaint();
+  }
+
+  public void mouseDragged(MouseEvent e) {
+
+    x2 = e.getX();
+    repaint();
+  }
+
+  public void mouseReleased(MouseEvent e) {
+
+    if (bounds != null && x2 != -1) {
+      int smallPoint;
+      int bigPoint;
+      if (x2 < x) {
+        smallPoint = x2;
+        bigPoint = x;
+      } else {
+        smallPoint = x;
+        bigPoint = x2;
+      }
+
+      filtered = chart.filterXByScreen(smallPoint, bigPoint);
+      resetButton.setVisible(filtered && resetByButton);
+    }
+
+    x = -1;
+    x2 = -1;
+    repaint();
+  }
+
+  @Override
+  public void mouseClicked(MouseEvent e) {
+
+    if (!filtered) {
+      return;
+    }
+    if (resetByDoubleClick && e.getClickCount() == 2) {
+      resetZoom();
+      return;
+    }
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+
+    // reset button pressed
+    resetZoom();
+  }
+
+  public Color getSelectionColor() {
+
+    return selectionColor;
+  }
+
+  public void setSelectionColor(Color selectionColor) {
+
+    this.selectionColor = selectionColor;
+  }
+
+  public boolean isResetByDoubleClick() {
+
+    return resetByDoubleClick;
+  }
+
+  public void setResetByDoubleClick(boolean resetByDoubleClick) {
+
+    this.resetByDoubleClick = resetByDoubleClick;
+  }
+
+  public boolean isResetByButton() {
+
+    return resetByButton;
+  }
+
+  public void setResetByButton(boolean resetByButton) {
+
+    this.resetByButton = resetByButton;
+    resetButton.setVisible(filtered && resetByButton);
+  }
+
+  public ChartButton getResetButton() {
+
+    return resetButton;
+  }
+
+  public void setResetButton(ChartButton resetButton) {
+
+    this.resetButton = resetButton;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartButton.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartButton.java
@@ -1,0 +1,356 @@
+package org.knowm.xchart.internal.chartpart.components;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.font.FontRenderContext;
+import java.awt.font.TextLayout;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+
+import javax.swing.event.EventListenerList;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.ChartPart;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+public class ChartButton extends MouseAdapter implements ChartPart {
+
+  protected XChartPanel chartPanel;
+  protected Chart chart;
+  protected Rectangle bounds;
+
+  // properties
+  protected Color color = new Color(114, 147, 203);
+  protected Color hoverColor = new Color(57, 106, 177);
+  protected String text;
+  protected boolean visible = true;
+  protected Color fontColor;
+  protected Font textFont;
+  protected Color borderColor;
+  protected int margin = 6;
+  protected ActionEvent action;
+
+  // button position
+  protected LegendPosition position = LegendPosition.InsideN;
+
+  protected double xOffset = 0;
+  protected double yOffset = 0;
+
+  // internal
+  private Shape buttonRect;
+  private boolean mouseOver;
+
+  public ChartButton(String text) {
+
+    this.text = text;
+  }
+
+  protected EventListenerList listenerList = new EventListenerList();
+
+  public void addActionListener(ActionListener l) {
+
+    listenerList.add(ActionListener.class, l);
+  }
+
+  public void removeActionListener(ActionListener l) {
+
+    listenerList.remove(ActionListener.class, l);
+  }
+
+  protected void fireActionPerformed() {
+
+    Object[] listeners = listenerList.getListenerList();
+    for (int i = listeners.length - 2; i >= 0; i -= 2) {
+      if (action == null) {
+        action = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, text);
+      }
+
+      ((ActionListener) listeners[i + 1]).actionPerformed(action);
+    }
+  }
+
+  public void init(XChartPanel<XYChart> chartPanel) {
+
+    this.chartPanel = chartPanel;
+    chart = chartPanel.getChart();
+    if (fontColor == null) {
+      fontColor = chart.getStyler().getChartFontColor();
+    }
+    if (textFont == null) {
+      textFont = chart.getStyler().getLegendFont();
+    }
+    if (borderColor == null) {
+      borderColor = chart.getStyler().getLegendBorderColor();
+    }
+    chartPanel.addMouseListener(this);
+    chartPanel.addMouseMotionListener(this);
+    chart.addPlotPart(this);
+  }
+
+  @Override
+  public Rectangle2D getBounds() {
+
+    return bounds;
+  }
+
+  @Override
+  public void mouseClicked(MouseEvent e) {
+
+    if (!visible) {
+      return;
+    }
+
+    if (buttonRect == null) {
+      return;
+    }
+    if (buttonRect.contains(e.getX(), e.getY())) {
+      fireActionPerformed();
+    }
+  }
+
+  @Override
+  public void mouseMoved(MouseEvent e) {
+
+    if (!visible) {
+      return;
+    }
+    if (buttonRect == null) {
+      return;
+    }
+    if (buttonRect.contains(e.getX(), e.getY())) {
+      mouseOver = true;
+      repaint();
+    } else {
+      if (mouseOver) {
+        mouseOver = false;
+        repaint();
+      }
+    }
+  }
+
+  protected void repaint() {
+
+    chartPanel.invalidate();
+    chartPanel.repaint();
+  }
+
+  protected void calculatePosition(Rectangle2D textBounds) {
+
+    double textHeight = textBounds.getHeight();
+    double textWidth = textBounds.getWidth();
+    double widthAdjustment = textWidth + margin * 3;
+    double heightAdjustment = textHeight + margin * 3;
+
+    double boundsWidth = bounds.getWidth();
+    double boundsHeight = bounds.getHeight();
+
+    if (position != null) {
+      switch (position) {
+      case InsideNW:
+        xOffset = bounds.getX() + margin;
+        yOffset = bounds.getY() + margin;
+        break;
+      case InsideNE:
+        xOffset = bounds.getX() + boundsWidth - widthAdjustment;
+        yOffset = bounds.getY() + margin;
+        break;
+      case InsideSE:
+        xOffset = bounds.getX() + boundsWidth - widthAdjustment;
+        yOffset = bounds.getY() + boundsHeight - heightAdjustment;
+        break;
+      case InsideSW:
+        xOffset = bounds.getX() + margin;
+        yOffset = bounds.getY() + boundsHeight - heightAdjustment;
+        break;
+      case InsideN:
+        xOffset = bounds.getX() + boundsWidth / 2 - textWidth / 2 - margin;
+        yOffset = bounds.getY() + margin;
+        break;
+      case InsideS:
+        xOffset = bounds.getX() + boundsWidth / 2 - textWidth / 2 - margin;
+        yOffset = bounds.getY() + boundsHeight - heightAdjustment;
+        break;
+
+      default:
+        break;
+      }
+    }
+  }
+
+  @Override
+  public void paint(Graphics2D g) {
+
+    if (!visible) {
+      return;
+    }
+    bounds = g.getClipBounds();
+
+    double boundsWidth = bounds.getWidth();
+    if (boundsWidth < 30) {
+      return;
+    }
+
+    Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+    g.setColor(fontColor);
+    g.setFont(textFont);
+
+    FontRenderContext frc = g.getFontRenderContext();
+    TextLayout tl = new TextLayout(text, textFont, frc);
+    Shape shape = tl.getOutline(null);
+
+    Rectangle2D textBounds = shape.getBounds2D();
+    calculatePosition(textBounds);
+    double textHeight = textBounds.getHeight();
+    double textWidth = textBounds.getWidth();
+
+    buttonRect = new Rectangle2D.Double(xOffset, yOffset, textWidth + margin * 2, textHeight + margin * 2);
+    if (mouseOver) {
+      g.setColor(hoverColor);
+    } else {
+      g.setColor(color);
+    }
+    g.fill(buttonRect);
+    g.setStroke(SOLID_STROKE);
+    g.setColor(borderColor);
+    g.draw(buttonRect);
+
+    double startx = xOffset + margin;
+    double starty = yOffset + margin;
+
+    g.setColor(fontColor);
+
+    AffineTransform orig = g.getTransform();
+    AffineTransform at = new AffineTransform();
+    at.translate(startx, starty + textHeight);
+    g.transform(at);
+    g.fill(shape);
+    g.setTransform(orig);
+
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldHint);
+  }
+
+  public Color getColor() {
+
+    return color;
+  }
+
+  public void setColor(Color color) {
+
+    this.color = color;
+  }
+
+  public Color getHoverColor() {
+
+    return hoverColor;
+  }
+
+  public void setHoverColor(Color hoverColor) {
+
+    this.hoverColor = hoverColor;
+  }
+
+  public String getText() {
+
+    return text;
+  }
+
+  public void setText(String text) {
+
+    this.text = text;
+  }
+
+  public boolean isVisible() {
+
+    return visible;
+  }
+
+  public void setVisible(boolean visible) {
+
+    this.visible = visible;
+    if (!visible) {
+      mouseOver = false;
+    }
+  }
+
+  public Color getFontColor() {
+
+    return fontColor;
+  }
+
+  public void setFontColor(Color fontColor) {
+
+    this.fontColor = fontColor;
+  }
+
+  public Font getTextFont() {
+
+    return textFont;
+  }
+
+  public void setTextFont(Font textFont) {
+
+    this.textFont = textFont;
+  }
+
+  public Color getBorderColor() {
+
+    return borderColor;
+  }
+
+  public void setBorderColor(Color borderColor) {
+
+    this.borderColor = borderColor;
+  }
+
+  public int getMargin() {
+
+    return margin;
+  }
+
+  public void setMargin(int margin) {
+
+    this.margin = margin;
+  }
+
+  public ActionEvent getAction() {
+
+    return action;
+  }
+
+  public void setAction(ActionEvent action) {
+
+    this.action = action;
+  }
+
+  public double getxOffset() {
+
+    return xOffset;
+  }
+
+  public void setxOffset(double xOffset) {
+
+    this.xOffset = xOffset;
+  }
+
+  public double getyOffset() {
+
+    return yOffset;
+  }
+
+  public void setyOffset(double yOffset) {
+
+    this.yOffset = yOffset;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartImage.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartImage.java
@@ -1,0 +1,154 @@
+package org.knowm.xchart.internal.chartpart.components;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.ChartPart;
+
+public class ChartImage implements ChartPart {
+
+  protected XChartPanel chartPanel;
+  protected Chart chart;
+  protected Rectangle bounds;
+
+  // properties
+  protected boolean visible = true;
+  protected Color fontColor;
+  protected Font textFont;
+  // button position
+  protected double xValue;
+  protected double yValue;
+  protected boolean valueInScreenCoordinate = false;
+  protected Image image;
+
+  // internal
+  int startx;
+  int starty;
+
+  public ChartImage(Image image, double xValue, double yValue, boolean valueInScreenCoordinate) {
+
+    this.image = image;
+    this.xValue = xValue;
+    this.yValue = yValue;
+    this.valueInScreenCoordinate = valueInScreenCoordinate;
+  }
+
+  public void init(XChartPanel<XYChart> chartPanel) {
+
+    this.chartPanel = chartPanel;
+    chart = chartPanel.getChart();
+    if (fontColor == null) {
+      fontColor = chart.getStyler().getChartFontColor();
+    }
+    if (textFont == null) {
+      textFont = chart.getStyler().getLegendFont();
+    }
+    chart.addPlotPart(this);
+  }
+
+  @Override
+  public Rectangle2D getBounds() {
+
+    return bounds;
+  }
+
+  protected void calculatePosition() {
+
+    if (valueInScreenCoordinate) {
+      startx = (int) xValue;
+      starty = (int) yValue;
+    } else {
+      startx = (int) (chart.getScreenXFromChart(xValue) + 0.5) - image.getWidth(null) / 2;
+      starty = (int) (chart.getScreenYFromChart(yValue) + 0.5) - image.getHeight(null) / 2;
+    }
+  }
+
+  @Override
+  public void paint(Graphics2D g) {
+
+    if (!visible) {
+      return;
+    }
+    bounds = g.getClipBounds();
+
+    calculatePosition();
+    g.drawImage(image, startx, starty, null);
+  }
+
+  public boolean isVisible() {
+
+    return visible;
+  }
+
+  public void setVisible(boolean visible) {
+
+    this.visible = visible;
+  }
+
+  public Color getFontColor() {
+
+    return fontColor;
+  }
+
+  public void setFontColor(Color fontColor) {
+
+    this.fontColor = fontColor;
+  }
+
+  public Font getTextFont() {
+
+    return textFont;
+  }
+
+  public void setTextFont(Font textFont) {
+
+    this.textFont = textFont;
+  }
+
+  public double getxValue() {
+
+    return xValue;
+  }
+
+  public void setxValue(double xValue) {
+
+    this.xValue = xValue;
+  }
+
+  public double getyValue() {
+
+    return yValue;
+  }
+
+  public void setyValue(double yValue) {
+
+    this.yValue = yValue;
+  }
+
+  public boolean isValueInScreenCoordinate() {
+
+    return valueInScreenCoordinate;
+  }
+
+  public void setValueInScreenCoordinate(boolean valueInScreenCoordinate) {
+
+    this.valueInScreenCoordinate = valueInScreenCoordinate;
+  }
+
+  public Image getImage() {
+
+    return image;
+  }
+
+  public void setImage(Image image) {
+
+    this.image = image;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartLine.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartLine.java
@@ -1,0 +1,122 @@
+package org.knowm.xchart.internal.chartpart.components;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.ChartPart;
+
+public class ChartLine implements ChartPart {
+
+  protected XChartPanel chartPanel;
+  protected Chart chart;
+  protected Rectangle bounds;
+
+  // properties
+  protected boolean visible = true;
+  protected Color color = new Color(114, 147, 203);
+  protected BasicStroke stroke = SOLID_STROKE;
+
+  protected double value;
+  protected boolean vertical;
+  protected boolean valueInScreenCoordinate = false;
+
+  public ChartLine(double value, boolean vertical, boolean valueInScreenCoordinate) {
+
+    super();
+    this.value = value;
+    this.vertical = vertical;
+    this.valueInScreenCoordinate = valueInScreenCoordinate;
+  }
+
+  public void init(XChartPanel<XYChart> chartPanel) {
+
+    this.chartPanel = chartPanel;
+    chart = chartPanel.getChart();
+    chart.addPlotPart(this);
+  }
+
+  @Override
+  public Rectangle2D getBounds() {
+
+    return bounds;
+  }
+
+  @Override
+  public void paint(Graphics2D g) {
+
+    if (!visible) {
+      return;
+    }
+
+    bounds = g.getClipBounds();
+    int x1 = 0, x2 = 0, y1 = 0, y2 = 0;
+
+    if (vertical) {
+      y1 = (int) bounds.getY();
+      y2 = (int) (bounds.getY() + bounds.getHeight());
+    } else {
+      x1 = (int) bounds.getX();
+      x2 = (int) (bounds.getX() + bounds.getWidth());
+    }
+
+    if (valueInScreenCoordinate) {
+      if (vertical) {
+        x1 = (int) value;
+        x2 = x1;
+      } else {
+        y1 = (int) value;
+        y2 = y1;
+      }
+    } else {
+      if (vertical) {
+        x1 = (int) chart.getScreenXFromChart(value);
+        x2 = x1;
+      } else {
+        y1 = (int) chart.getScreenYFromChart(value);
+        y2 = y1;
+      }
+    }
+
+    
+    g.setStroke(stroke);
+    g.setColor(color);
+    g.drawLine(x1, y1, x2, y2);
+  }
+
+  public Color getColor() {
+
+    return color;
+  }
+
+  public void setColor(Color color) {
+
+    this.color = color;
+  }
+
+  public boolean isVisible() {
+
+    return visible;
+  }
+
+  public void setVisible(boolean visible) {
+
+    this.visible = visible;
+  }
+
+  public BasicStroke getStroke() {
+  
+    return stroke;
+  }
+
+  public void setStroke(BasicStroke stroke) {
+  
+    this.stroke = stroke;
+  }
+  
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartText.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartText.java
@@ -1,0 +1,178 @@
+package org.knowm.xchart.internal.chartpart.components;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.font.FontRenderContext;
+import java.awt.font.TextLayout;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.ChartPart;
+
+public class ChartText implements ChartPart {
+
+  protected XChartPanel chartPanel;
+  protected Chart chart;
+  protected Rectangle bounds;
+
+  // properties
+  protected String text;
+  protected boolean visible = true;
+  protected Color fontColor;
+  protected Font textFont;
+  // button position
+  protected double xValue;
+  protected double yValue;
+  protected boolean valueInScreenCoordinate = false;
+
+  // internal
+  double startx;
+  double starty;
+
+  public ChartText(String text, double xValue, double yValue, boolean valueInScreenCoordinate) {
+
+    this.text = text;
+    this.xValue = xValue;
+    this.yValue = yValue;
+    this.valueInScreenCoordinate = valueInScreenCoordinate;
+  }
+
+  public void init(XChartPanel<XYChart> chartPanel) {
+
+    this.chartPanel = chartPanel;
+    chart = chartPanel.getChart();
+    if (fontColor == null) {
+      fontColor = chart.getStyler().getChartFontColor();
+    }
+    if (textFont == null) {
+      textFont = chart.getStyler().getLegendFont();
+    }
+    chart.addPlotPart(this);
+  }
+
+  @Override
+  public Rectangle2D getBounds() {
+
+    return bounds;
+  }
+
+  protected void calculatePosition(Rectangle2D textBounds) {
+
+    if (valueInScreenCoordinate) {
+      startx = xValue;
+      starty = yValue;
+    } else {
+      startx = chart.getScreenXFromChart(xValue) - textBounds.getWidth() / 2;
+      starty = chart.getScreenYFromChart(yValue) + textBounds.getHeight() / 2;
+    }
+  }
+
+  @Override
+  public void paint(Graphics2D g) {
+
+    if (!visible) {
+      return;
+    }
+    bounds = g.getClipBounds();
+
+    Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+    g.setColor(fontColor);
+    g.setFont(textFont);
+
+    FontRenderContext frc = g.getFontRenderContext();
+    TextLayout tl = new TextLayout(text, textFont, frc);
+    Shape shape = tl.getOutline(null);
+
+    Rectangle2D textBounds = shape.getBounds2D();
+    calculatePosition(textBounds);
+
+    AffineTransform orig = g.getTransform();
+    AffineTransform at = new AffineTransform();
+    at.translate(startx, starty);
+    g.transform(at);
+    g.fill(shape);
+    g.setTransform(orig);
+
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldHint);
+  }
+
+  public String getText() {
+
+    return text;
+  }
+
+  public void setText(String text) {
+
+    this.text = text;
+  }
+
+  public boolean isVisible() {
+
+    return visible;
+  }
+
+  public void setVisible(boolean visible) {
+
+    this.visible = visible;
+  }
+
+  public Color getFontColor() {
+
+    return fontColor;
+  }
+
+  public void setFontColor(Color fontColor) {
+
+    this.fontColor = fontColor;
+  }
+
+  public Font getTextFont() {
+
+    return textFont;
+  }
+
+  public void setTextFont(Font textFont) {
+
+    this.textFont = textFont;
+  }
+
+  public double getxValue() {
+  
+    return xValue;
+  }
+
+  public void setxValue(double xValue) {
+  
+    this.xValue = xValue;
+  }
+
+  public double getyValue() {
+  
+    return yValue;
+  }
+
+  public void setyValue(double yValue) {
+  
+    this.yValue = yValue;
+  }
+
+  public boolean isValueInScreenCoordinate() {
+  
+    return valueInScreenCoordinate;
+  }
+
+  public void setValueInScreenCoordinate(boolean valueInScreenCoordinate) {
+  
+    this.valueInScreenCoordinate = valueInScreenCoordinate;
+  }
+
+}


### PR DESCRIPTION
### Added zoom feature for XYCharts
Fixes #234 
Partially implements #216 
Zoom can be reset by double click or reset button. Both can be disabled.
See TestForSelectionZoom.java

![image](https://user-images.githubusercontent.com/6737748/54739016-93196180-4bc7-11e9-9b45-2ac2ebb6b3b1.png)

![image](https://user-images.githubusercontent.com/6737748/54739001-85fc7280-4bc7-11e9-8765-b525d8c32a71.png)


### Added coordinate conversion.
Given mouse point (x,y) returns chart values (x,y)
Given value (x,y) returns chart pixel values (x,y)
Fixes #263 
Issuses
- Logarithmic values does not work
- In BarCharts returns absolute x values, not indices.
- Does not work in Pie, Radar, Dial charts
See TestForCoordinateLookup.java


### Added custom plot parts system.

- Added ChartButton
- Added ChartImage
- Added ChartLine
- Added ChartText

Fixes #288, fixes #281, fixes #212
See TestForCustomChartParts.java

![image](https://user-images.githubusercontent.com/6737748/54739114-eee3ea80-4bc7-11e9-9d0c-460f55f529e0.png)
