### PR TITLE
Introduce cursor support

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -53,6 +53,7 @@ public class XChartPanel<T extends Chart> extends JPanel {
         XYSeries series = (XYSeries)value;
         if(series.getCursor() != null) {
           this.addMouseMotionListener(series.getCursor());
+          this.addMouseListener(series.getCursor());
         }
       }
     }

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -1,18 +1,15 @@
 package org.knowm.xchart;
 
+import java.io.*;
 import java.awt.*;
 import java.awt.event.*;
 import java.awt.print.*;
-import java.io.File;
-import java.io.IOException;
 import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
 import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
-import org.knowm.xchart.internal.chartpart.Chart;
-import org.knowm.xchart.internal.chartpart.ToolTips;
-import org.knowm.xchart.style.AxesChartStyler;
-import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.internal.chartpart.*;
+import org.knowm.xchart.style.*;
 
 /**
  * A Swing JPanel that contains a Chart
@@ -51,7 +48,14 @@ public class XChartPanel<T extends Chart> extends JPanel {
         this.addMouseMotionListener(mml);
       }
     }
-
+    for (Object value : chart.getSeriesMap().values()) {
+      if(value instanceof XYSeries) {
+        XYSeries series = (XYSeries)value;
+        if(series.getCursor() != null) {
+          this.addMouseMotionListener(series.getCursor());
+        }
+      }
+    }
     // Control+S key listener for saving chart
     KeyStroke ctrlS =
         KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
@@ -132,20 +136,22 @@ public class XChartPanel<T extends Chart> extends JPanel {
         JFrame w = (JFrame) SwingUtilities.windowForComponent(this);
         if (w.getWidth() > w.getHeight()) {
           pageFormat.setOrientation(PageFormat.LANDSCAPE);
-          paper.setImageableArea(0,0, pageFormat.getHeight(), pageFormat.getWidth());
+          paper.setImageableArea(0, 0, pageFormat.getHeight(), pageFormat.getWidth());
         } else {
-          paper.setImageableArea(0,0, pageFormat.getWidth(), pageFormat.getHeight());
+          paper.setImageableArea(0, 0, pageFormat.getWidth(), pageFormat.getHeight());
         }
         pageFormat.setPaper(paper);
         pageFormat = printJob.validatePage(pageFormat);
 
         String jobName = "XChart " + chart.getTitle().trim();
-        if (!w.getTitle().trim().isEmpty() && !w.getTitle().trim().contentEquals(chart.getTitle().trim())) {
+        if (!w.getTitle().trim().isEmpty()
+            && !w.getTitle().trim().contentEquals(chart.getTitle().trim())) {
           jobName = jobName + " " + w.getTitle().trim();
         }
         printJob.setJobName(jobName);
 
-        printJob.setPrintable(new Printer(getParent() /*start with parent to include the caption*/), pageFormat);
+        printJob.setPrintable(
+            new Printer(getParent() /*start with parent to include the caption*/), pageFormat);
 
         Dimension windowSize = w.getSize();
         Styler styler = getChart().getStyler();
@@ -165,11 +171,11 @@ public class XChartPanel<T extends Chart> extends JPanel {
           styler.setPlotBackgroundColor(Color.white);
 
           // optional for printing: higher resolution, larger markers
-          //cs.setMarkerSize(Math.max(markerSize, 5));
-          //double widthPx = (int) Math.floor(pageFormat.getImageableWidth()/72*400);
-          //double heightPx = (int) Math.floor(pageFormat.getImageableHeight()/72*400);
-          //w.setSize((int) Math.floor(widthPx), (int) Math.floor(heightPx));
-          //w.validate();
+          // cs.setMarkerSize(Math.max(markerSize, 5));
+          // double widthPx = (int) Math.floor(pageFormat.getImageableWidth()/72*400);
+          // double heightPx = (int) Math.floor(pageFormat.getImageableHeight()/72*400);
+          // w.setSize((int) Math.floor(widthPx), (int) Math.floor(heightPx));
+          // w.validate();
 
           printJob.print();
         } finally {
@@ -433,26 +439,26 @@ public class XChartPanel<T extends Chart> extends JPanel {
 
       printMenuItem = new JMenuItem(printString);
       printMenuItem.addMouseListener(
-              new MouseListener() {
+          new MouseListener() {
 
-                @Override
-                public void mouseReleased(MouseEvent e) {
+            @Override
+            public void mouseReleased(MouseEvent e) {
 
-                  showPrintDialog();
-                }
+              showPrintDialog();
+            }
 
-                @Override
-                public void mousePressed(MouseEvent e) {}
+            @Override
+            public void mousePressed(MouseEvent e) {}
 
-                @Override
-                public void mouseExited(MouseEvent e) {}
+            @Override
+            public void mouseExited(MouseEvent e) {}
 
-                @Override
-                public void mouseEntered(MouseEvent e) {}
+            @Override
+            public void mouseEntered(MouseEvent e) {}
 
-                @Override
-                public void mouseClicked(MouseEvent e) {}
-              });
+            @Override
+            public void mouseClicked(MouseEvent e) {}
+          });
       add(printMenuItem);
 
       if (chart instanceof XYChart) {

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -1,21 +1,13 @@
 package org.knowm.xchart;
 
-import java.awt.*;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.awt.Graphics2D;
 import org.knowm.xchart.internal.Utils;
-import org.knowm.xchart.internal.chartpart.AxisPair;
-import org.knowm.xchart.internal.chartpart.Chart;
-import org.knowm.xchart.internal.chartpart.Legend_Marker;
-import org.knowm.xchart.internal.chartpart.Plot_XY;
+import org.knowm.xchart.internal.chartpart.*;
 import org.knowm.xchart.internal.series.Series.DataType;
-import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyle;
-import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyleCycler;
+import org.knowm.xchart.internal.style.*;
 import org.knowm.xchart.style.Styler.ChartTheme;
-import org.knowm.xchart.style.Theme;
-import org.knowm.xchart.style.XYStyler;
+import org.knowm.xchart.style.*;
 
 public class XYChart extends Chart<XYStyler, XYSeries> {
 
@@ -442,9 +434,6 @@ public class XYChart extends Chart<XYStyler, XYSeries> {
       }
       if (series.getMarker() == null) { // wasn't set manually
         series.setMarker(seriesColorMarkerLineStyle.getMarker());
-      }
-      if (series.getMarkerColor() == null) { // wasn't set manually
-        series.setMarkerColor(seriesColorMarkerLineStyle.getColor());
       }
     }
   }

--- a/xchart/src/main/java/org/knowm/xchart/XYSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYSeries.java
@@ -2,14 +2,14 @@ package org.knowm.xchart;
 
 import org.knowm.xchart.internal.chartpart.RenderableSeries;
 import org.knowm.xchart.internal.chartpart.RenderableSeries.LegendRenderType;
-import org.knowm.xchart.internal.series.AxesChartSeriesNumericalNoErrorBars;
+import org.knowm.xchart.internal.series.*;
 
 /**
  * A Series containing X and Y data to be plotted on a Chart
  *
  * @author timmolter
  */
-public class XYSeries extends AxesChartSeriesNumericalNoErrorBars {
+public class XYSeries extends CursorSeries {
 
   private XYSeriesRenderStyle xySeriesRenderStyle = null;
 

--- a/xchart/src/main/java/org/knowm/xchart/cursors/Corsair.java
+++ b/xchart/src/main/java/org/knowm/xchart/cursors/Corsair.java
@@ -1,0 +1,16 @@
+package org.knowm.xchart.cursors;
+
+import java.awt.*;
+import java.awt.geom.Line2D.Double;
+
+public class Corsair extends Cursor {
+   public void paint(Graphics2D g, double xOffset, double yOffset, int cursorSize, double width, double height) {
+      if(dataPoint == null) return;
+      if(dataPoint.shape.contains(xOffset, yOffset)) {
+         final BasicStroke stroke = new BasicStroke(cursorSize, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER);
+         g.setStroke(stroke);
+         g.draw(new Double(0, yOffset, width, yOffset));
+         g.draw(new Double(xOffset, 0, xOffset, height));
+      }
+   }
+}

--- a/xchart/src/main/java/org/knowm/xchart/cursors/Cross.java
+++ b/xchart/src/main/java/org/knowm/xchart/cursors/Cross.java
@@ -3,10 +3,10 @@ package org.knowm.xchart.cursors;
 import java.awt.*;
 import java.awt.geom.Line2D.Double;
 
-public class Corsair extends Cursor {
+public class Cross extends Cursor {
    public void paint(Graphics2D g, double xOffset, double yOffset, int cursorSize, double width, double height) {
       if(dataPoint == null) return;
-      if(dataPoint.shape.contains(xOffset, yOffset)) {
+      if(dataPoint.getX() == xOffset) {
          final BasicStroke stroke = new BasicStroke(cursorSize, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER);
          g.setStroke(stroke);
          g.draw(new Double(0, yOffset, width, yOffset));

--- a/xchart/src/main/java/org/knowm/xchart/cursors/Cursor.java
+++ b/xchart/src/main/java/org/knowm/xchart/cursors/Cursor.java
@@ -1,0 +1,55 @@
+package org.knowm.xchart.cursors;
+
+import java.util.*;
+import java.awt.Graphics2D;
+import java.awt.event.*;
+import org.knowm.xchart.internal.chartpart.ToolTips.DataPoint;
+
+public abstract class Cursor implements MouseMotionListener {
+   protected DataPoint dataPoint;
+
+   private final List<DataPoint> dataPointList = new ArrayList<DataPoint>();
+
+   public abstract void paint(Graphics2D g, double xOffset, double yOffset, int cursorSize, double width, double height);
+
+   public void mouseDragged(MouseEvent e) {
+      // ignored
+   }
+
+   @Override
+   public void mouseMoved(MouseEvent e) {
+     DataPoint newPoint = null;
+     int x = e.getX();
+     int y = e.getY();
+     for (DataPoint dataPoint : dataPointList) {
+       if (dataPoint.shape.contains(x, y) || dataPoint.shape.contains(x, dataPoint.shape.getBounds().getCenterY())) {
+         newPoint = dataPoint;
+         break;
+       }
+     }
+
+     if (newPoint != null) {
+       // if the existing shown data point is already shown, abort
+       if (dataPoint != null) {
+         if (dataPoint.equals(newPoint)) {
+           return;
+         }
+       }
+       dataPoint = newPoint;
+       e.getComponent().repaint(); // repaint the entire XChartPanel
+     }
+     // remove the popup shape
+     //else if (dataPoint != null) {
+     //  dataPoint = null;
+     //  e.getComponent().repaint(); // repaint the entire XChartPanel
+     //}
+   }
+
+   public void prepare(Graphics2D g) {
+      dataPointList.clear();
+   }
+
+   public void addData(double xOffset, double yOffset, double x, double y) {
+      dataPointList.add(new DataPoint(xOffset, yOffset, "Real: " + x + "x" + y));
+   }
+}

--- a/xchart/src/main/java/org/knowm/xchart/cursors/Cursor.java
+++ b/xchart/src/main/java/org/knowm/xchart/cursors/Cursor.java
@@ -1,12 +1,14 @@
 package org.knowm.xchart.cursors;
 
 import java.util.*;
-import java.awt.Graphics2D;
+import java.util.List;
+import java.awt.*;
 import java.awt.event.*;
 import org.knowm.xchart.internal.chartpart.ToolTips.DataPoint;
 
-public abstract class Cursor implements MouseMotionListener {
-   protected DataPoint dataPoint;
+public abstract class Cursor implements MouseMotionListener, MouseListener {
+   DataPoint dataPoint;
+   private final List<CursorListener> cursorListeners = new ArrayList<>();
 
    private final List<DataPoint> dataPointList = new ArrayList<DataPoint>();
 
@@ -16,40 +18,112 @@ public abstract class Cursor implements MouseMotionListener {
       // ignored
    }
 
+   public void addCursorListener(CursorListener cursorListener) {
+
+      cursorListeners.add(cursorListener);
+   }
+
    @Override
    public void mouseMoved(MouseEvent e) {
-     DataPoint newPoint = null;
-     int x = e.getX();
-     int y = e.getY();
-     for (DataPoint dataPoint : dataPointList) {
-       if (dataPoint.shape.contains(x, y) || dataPoint.shape.contains(x, dataPoint.shape.getBounds().getCenterY())) {
-         newPoint = dataPoint;
-         break;
-       }
-     }
 
-     if (newPoint != null) {
-       // if the existing shown data point is already shown, abort
-       if (dataPoint != null) {
-         if (dataPoint.equals(newPoint)) {
-           return;
+      DataPoint newPoint = null;
+      int x = e.getX();
+      int y = e.getY();
+      for (DataPoint dataPoint : dataPointList) {
+         if (dataPoint.shape.contains(x, y) || dataPoint.shape.contains(x, dataPoint.shape.getBounds().getCenterY())) {
+            newPoint = dataPoint;
+            break;
          }
-       }
-       dataPoint = newPoint;
-       e.getComponent().repaint(); // repaint the entire XChartPanel
-     }
-     // remove the popup shape
-     //else if (dataPoint != null) {
-     //  dataPoint = null;
-     //  e.getComponent().repaint(); // repaint the entire XChartPanel
-     //}
+      }
+      resetDataPoint(newPoint, e.getComponent());
+   }
+
+   private void resetDataPoint(DataPoint newPoint, final Component component) {
+      if (newPoint != null) {
+         // if the existing shown data point is already shown, abort
+         if (dataPoint != null) {
+            if (dataPoint.equals(newPoint)) {
+               return;
+            }
+         }
+         dataPoint = newPoint;
+         int indexOfDataPoint = getIndexOfDataPoint();
+         if (indexOfDataPoint > -1) {
+            for (CursorListener listener : cursorListeners) {
+               listener.fireDataPointSelected(indexOfDataPoint);
+            }
+         }
+         component.repaint(); // repaint the entire XChartPanel
+      }
+      // remove the popup shape
+      //else if (dataPoint != null) {
+      //  dataPoint = null;
+      //  e.getComponent().repaint(); // repaint the entire XChartPanel
+      //}
+   }
+
+   private int getIndexOfDataPoint() {
+      int indexOf = dataPointList.indexOf(dataPoint);
+      if(indexOf == -1 && dataPoint != null) {
+         for (int i = 0; i < dataPointList.size(); i++) {
+            DataPoint point = dataPointList.get(i);
+            if (point.getX() == dataPoint.getX()) {
+               return i;
+            }
+         }
+      }
+      return indexOf;
    }
 
    public void prepare(Graphics2D g) {
+
       dataPointList.clear();
    }
 
-   public void addData(double xOffset, double yOffset, double x, double y) {
-      dataPointList.add(new DataPoint(xOffset, yOffset, "Real: " + x + "x" + y));
+   public void addData(double xOffset, double yOffset) {
+
+      dataPointList.add(new DataPoint(xOffset, yOffset));
+   }
+
+   public void mouseClicked(MouseEvent e) {
+      int indexOfDataPoint = getIndexOfDataPoint();
+      if (indexOfDataPoint > -1) {
+         for (CursorListener listener : cursorListeners) {
+            listener.fireDataPointClicked(indexOfDataPoint);
+         }
+      }
+   }
+
+   public void mousePressed(MouseEvent e) {
+
+   }
+
+   public void mouseReleased(MouseEvent e) {
+
+   }
+
+   public void mouseEntered(MouseEvent e) {
+
+   }
+
+   public void mouseExited(MouseEvent e) {
+
+   }
+
+   /**
+    Interface for listener of cursor events
+    */
+   public interface CursorListener {
+
+      /**
+       fired when the cursor is moved to a new datapoint
+       @param index the index of the datapoint which the mouse hovered
+       */
+      void fireDataPointSelected(int index);
+      /**
+       fired when the cursor is clicked on a currently selected datapoint
+       @param index the index of the datapoint which was clicked
+       */
+      void fireDataPointClicked(int index);
    }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
@@ -3,6 +3,8 @@ package org.knowm.xchart.internal.chartpart;
 import java.awt.*;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.cursors.Cursor;
 import org.knowm.xchart.internal.series.Series;
 import org.knowm.xchart.style.Styler;
 
@@ -44,6 +46,15 @@ public abstract class PlotContent_<ST extends Styler, S extends Series> implemen
     g.setClip(bounds.createIntersection(bounds));
 
     chart.toolTips.prepare(g);
+
+    for (S value : chart.getSeriesMap().values()) {
+      if(value instanceof XYSeries) {
+        Cursor cursor = ((XYSeries)value).getCursor();
+        if(cursor != null) {
+          cursor.prepare(g);
+        }
+      }
+    }
 
     doPaint(g);
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -1,9 +1,8 @@
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.*;
-import java.awt.geom.Line2D;
-import java.awt.geom.Path2D;
 import java.util.Map;
+import java.awt.Graphics2D;
+import java.awt.geom.*;
 import org.knowm.xchart.XYSeries;
 import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
 import org.knowm.xchart.internal.Utils;
@@ -203,6 +202,13 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
           series.getMarker().paint(g, xOffset, yOffset, xyStyler.getMarkerSize());
         }
 
+        // paint cursor
+        if (series.getCursor() != null) {
+          series.getCursor().addData(xOffset, yOffset, x, y);
+          g.setColor(series.getMarkerColor()); // TODO: introduce color for cursor
+          series.getCursor().paint(g, xOffset, yOffset, xyStyler.getMarkerSize(), getBounds().getWidth(), getBounds().getHeight());
+        }
+
         // paint error bars
         if (errorBars != null) {
 
@@ -252,6 +258,7 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
           g.draw(line);
         }
 
+        
         // add data labels
         if (toolTipsEnabled) {
           if (hasCustomToolTips) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -204,9 +204,9 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
 
         // paint cursor
         if (series.getCursor() != null) {
-          series.getCursor().addData(xOffset, yOffset, x, y);
-          g.setColor(series.getMarkerColor()); // TODO: introduce color for cursor
-          series.getCursor().paint(g, xOffset, yOffset, xyStyler.getMarkerSize(), getBounds().getWidth(), getBounds().getHeight());
+          series.getCursor().addData(xOffset, yOffset);
+          g.setColor(series.getCursorColor());
+          series.getCursor().paint(g, xOffset, yOffset, xyStyler.getCursorSize(), getBounds().getWidth(), getBounds().getHeight());
         }
 
         // paint error bars

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
@@ -224,6 +224,7 @@ public class ToolTips implements MouseMotionListener {
     private final String label;
     // used for popup detection & popup highlight
     public final Shape shape;
+
     // label center coordinates
     private final double x;
     private final double y;
@@ -265,5 +266,22 @@ public class ToolTips implements MouseMotionListener {
       this.shape = shape;
       this.label = label;
     }
+
+    public DataPoint(double xOffset, double yOffset) {
+
+      this(xOffset, yOffset, null);
+    }
+
+    public double getX() {
+
+      return x;
+    }
+
+    public double getY() {
+
+      return y;
+    }
+
+
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
@@ -1,18 +1,14 @@
 package org.knowm.xchart.internal.chartpart;
 
-import static org.knowm.xchart.internal.chartpart.ChartPart.SOLID_STROKE;
-
-import java.awt.*;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseMotionListener;
-import java.awt.font.FontRenderContext;
-import java.awt.font.TextLayout;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Ellipse2D;
-import java.awt.geom.Rectangle2D;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.*;
+import java.awt.*;
+import java.awt.event.*;
+import java.awt.font.*;
+import java.awt.geom.*;
 import org.knowm.xchart.style.Styler;
+
+import static org.knowm.xchart.internal.chartpart.ChartPart.SOLID_STROKE;
 
 /** Data labels can be put on all labels or configured to popup like a tooltip from a mouse over. */
 public class ToolTips implements MouseMotionListener {
@@ -221,13 +217,13 @@ public class ToolTips implements MouseMotionListener {
     return this;
   }
 
-  static class DataPoint {
+  public static class DataPoint {
 
     // width of data point (used for bar charts)
     final double w;
     private final String label;
     // used for popup detection & popup highlight
-    private final Shape shape;
+    public final Shape shape;
     // label center coordinates
     private final double x;
     private final double y;
@@ -239,7 +235,7 @@ public class ToolTips implements MouseMotionListener {
      * @param y
      * @param label
      */
-    DataPoint(double x, double y, String label) {
+    public DataPoint(double x, double y, String label) {
 
       double halfSize = MARGIN * 1.5;
       double markerSize = MARGIN * 3;

--- a/xchart/src/main/java/org/knowm/xchart/internal/series/CursorSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/series/CursorSeries.java
@@ -1,0 +1,26 @@
+package org.knowm.xchart.internal.series;
+
+import org.knowm.xchart.cursors.Cursor;
+
+public abstract class CursorSeries extends AxesChartSeriesNumericalNoErrorBars {
+   /**
+    Constructor
+    @param name
+    @param xData
+    @param yData
+    @param extraValues
+    @param xAxisDataType */
+   public CursorSeries(String name, double[] xData, double[] yData, double[] extraValues, DataType xAxisDataType) {
+      super(name, xData, yData, extraValues, xAxisDataType);
+   }
+
+   public Cursor getCursor() {
+      return cursor;
+   }
+
+   public void setCursor(Cursor cursor) {
+      this.cursor = cursor;
+   }
+
+   private Cursor cursor;
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/series/CursorSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/series/CursorSeries.java
@@ -1,8 +1,12 @@
 package org.knowm.xchart.internal.series;
 
+import java.awt.Color;
 import org.knowm.xchart.cursors.Cursor;
 
 public abstract class CursorSeries extends AxesChartSeriesNumericalNoErrorBars {
+   private Cursor cursor;
+   private Color cursorColor = Color.DARK_GRAY;
+
    /**
     Constructor
     @param name
@@ -22,5 +26,11 @@ public abstract class CursorSeries extends AxesChartSeriesNumericalNoErrorBars {
       this.cursor = cursor;
    }
 
-   private Cursor cursor;
+   public Color getCursorColor() {
+      return cursorColor;
+   }
+
+   public void setCursorColor(Color cursorColor) {
+      this.cursorColor = cursorColor;
+   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/AbstractBaseTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AbstractBaseTheme.java
@@ -430,6 +430,13 @@ public abstract class AbstractBaseTheme implements Theme {
     return 8;
   }
 
+  // Line, Scatter, Area Charts ///////////////////////////////
+
+  public int getCursorSize() {
+
+    return 2;
+  }
+
   // Error Bars ///////////////////////////////
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -1,9 +1,7 @@
 package org.knowm.xchart.style;
 
+import java.util.*;
 import java.awt.*;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.TimeZone;
 
 /** @author timmolter */
 public abstract class AxesChartStyler extends Styler {
@@ -47,6 +45,9 @@ public abstract class AxesChartStyler extends Styler {
 
   // Line, Scatter, Area Charts ///////////////////////////////
   private int markerSize;
+
+  // Line, Scatter, Area Charts ///////////////////////////////
+  private int cursorSize;
 
   // Error Bars ///////////////////////////////
   private Color errorBarsColor;
@@ -100,6 +101,9 @@ public abstract class AxesChartStyler extends Styler {
 
     // Line, Scatter, Area Charts ///////////////////////////////
     this.markerSize = theme.getMarkerSize();
+
+    // Line, Scatter, Area Charts ///////////////////////////////
+    this.cursorSize = theme.getCursorSize();
 
     // Error Bars ///////////////////////////////
     this.errorBarsColor = theme.getErrorBarsColor();
@@ -661,6 +665,24 @@ public abstract class AxesChartStyler extends Styler {
   public AxesChartStyler setMarkerSize(int markerSize) {
 
     this.markerSize = markerSize;
+    return this;
+  }
+
+  // Line, Scatter, Area Charts ///////////////////////////////
+
+  public int getCursorSize() {
+
+    return cursorSize;
+  }
+
+  /**
+   * Sets the size of the cursor (in pixels)
+   *
+   * @param cursorSize
+   */
+  public AxesChartStyler setCursorSize(int cursorSize) {
+
+    this.cursorSize = cursorSize;
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/style/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Theme.java
@@ -153,6 +153,10 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
 
   int getMarkerSize();
 
+  // Line, Scatter, Area Charts ///////////////////////////////
+
+  int getCursorSize();
+
   // Error Bars ///////////////////////////////
 
   Color getErrorBarsColor();


### PR DESCRIPTION
This patch introduces cursor support for XYChart. A cursor gets displayed while moving over the charts and adds the possibility to fire click events on the selected data point.
Please check and review and let me know if you have specific concerns.
A cursor can be activated like this: XYSeries.setCursor(new Cross())
Listener can be activated like this: Cursor.addCursorListener(new CursorListener()...)