### PR TITLE
Added annotationFontColor, sumFormat for Pie chart styling

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -132,20 +132,22 @@ public class XChartPanel<T extends Chart> extends JPanel {
         JFrame w = (JFrame) SwingUtilities.windowForComponent(this);
         if (w.getWidth() > w.getHeight()) {
           pageFormat.setOrientation(PageFormat.LANDSCAPE);
-          paper.setImageableArea(0,0, pageFormat.getHeight(), pageFormat.getWidth());
+          paper.setImageableArea(0, 0, pageFormat.getHeight(), pageFormat.getWidth());
         } else {
-          paper.setImageableArea(0,0, pageFormat.getWidth(), pageFormat.getHeight());
+          paper.setImageableArea(0, 0, pageFormat.getWidth(), pageFormat.getHeight());
         }
         pageFormat.setPaper(paper);
         pageFormat = printJob.validatePage(pageFormat);
 
         String jobName = "XChart " + chart.getTitle().trim();
-        if (!w.getTitle().trim().isEmpty() && !w.getTitle().trim().contentEquals(chart.getTitle().trim())) {
+        if (!w.getTitle().trim().isEmpty()
+            && !w.getTitle().trim().contentEquals(chart.getTitle().trim())) {
           jobName = jobName + " " + w.getTitle().trim();
         }
         printJob.setJobName(jobName);
 
-        printJob.setPrintable(new Printer(getParent() /*start with parent to include the caption*/), pageFormat);
+        printJob.setPrintable(
+            new Printer(getParent() /*start with parent to include the caption*/), pageFormat);
 
         Dimension windowSize = w.getSize();
         Styler styler = getChart().getStyler();
@@ -165,11 +167,11 @@ public class XChartPanel<T extends Chart> extends JPanel {
           styler.setPlotBackgroundColor(Color.white);
 
           // optional for printing: higher resolution, larger markers
-          //cs.setMarkerSize(Math.max(markerSize, 5));
-          //double widthPx = (int) Math.floor(pageFormat.getImageableWidth()/72*400);
-          //double heightPx = (int) Math.floor(pageFormat.getImageableHeight()/72*400);
-          //w.setSize((int) Math.floor(widthPx), (int) Math.floor(heightPx));
-          //w.validate();
+          // cs.setMarkerSize(Math.max(markerSize, 5));
+          // double widthPx = (int) Math.floor(pageFormat.getImageableWidth()/72*400);
+          // double heightPx = (int) Math.floor(pageFormat.getImageableHeight()/72*400);
+          // w.setSize((int) Math.floor(widthPx), (int) Math.floor(heightPx));
+          // w.validate();
 
           printJob.print();
         } finally {
@@ -433,26 +435,26 @@ public class XChartPanel<T extends Chart> extends JPanel {
 
       printMenuItem = new JMenuItem(printString);
       printMenuItem.addMouseListener(
-              new MouseListener() {
+          new MouseListener() {
 
-                @Override
-                public void mouseReleased(MouseEvent e) {
+            @Override
+            public void mouseReleased(MouseEvent e) {
 
-                  showPrintDialog();
-                }
+              showPrintDialog();
+            }
 
-                @Override
-                public void mousePressed(MouseEvent e) {}
+            @Override
+            public void mousePressed(MouseEvent e) {}
 
-                @Override
-                public void mouseExited(MouseEvent e) {}
+            @Override
+            public void mouseExited(MouseEvent e) {}
 
-                @Override
-                public void mouseEntered(MouseEvent e) {}
+            @Override
+            public void mouseEntered(MouseEvent e) {}
 
-                @Override
-                public void mouseClicked(MouseEvent e) {}
-              });
+            @Override
+            public void mouseClicked(MouseEvent e) {}
+          });
       add(printMenuItem);
 
       if (chart instanceof XYChart) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -379,7 +379,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
               annotationY = zeroOffset + 4 + annotationRectangle.getHeight();
             }
             Shape shape = textLayout.getOutline(null);
-            g.setColor(stylerCategory.getChartFontColor());
+            g.setColor(stylerCategory.getAnnotationsFontColor());
             g.setFont(stylerCategory.getAnnotationsFont());
             AffineTransform orig = g.getTransform();
             AffineTransform at = new AffineTransform();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -6,7 +6,6 @@ import java.awt.font.TextLayout;
 import java.awt.geom.*;
 import java.awt.geom.Arc2D.Double;
 import java.text.DecimalFormat;
-import java.text.MessageFormat;
 import java.util.Map;
 import org.knowm.xchart.PieSeries;
 import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
@@ -385,7 +384,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
       String annotation =
           pieStyler.getSumFormat() == null || pieStyler.getSumFormat().isEmpty()
               ? totalDf.format(total)
-              : MessageFormat.format(pieStyler.getSumFormat(), totalDf.format(total));
+              : String.format(pieStyler.getSumFormat(), total);
 
       TextLayout textLayout =
           new TextLayout(

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -320,7 +320,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
         // draw annotation
         if (pieStyler.isDrawAllAnnotations() || annotationWillFit) {
 
-          g.setColor(pieStyler.getChartFontColor());
+          g.setColor(pieStyler.getAnnotationsFontColor());
           g.setFont(pieStyler.getAnnotationsFont());
           AffineTransform orig = g.getTransform();
           AffineTransform at = new AffineTransform();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -6,6 +6,7 @@ import java.awt.font.TextLayout;
 import java.awt.geom.*;
 import java.awt.geom.Arc2D.Double;
 import java.text.DecimalFormat;
+import java.text.MessageFormat;
 import java.util.Map;
 import org.knowm.xchart.PieSeries;
 import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
@@ -381,7 +382,10 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
               ? df
               : new DecimalFormat(pieStyler.getDecimalPattern());
 
-      String annotation = totalDf.format(total);
+      String annotation =
+          pieStyler.getSumFormat() == null || pieStyler.getSumFormat().isEmpty()
+              ? totalDf.format(total)
+              : MessageFormat.format(pieStyler.getSumFormat(), totalDf.format(total));
 
       TextLayout textLayout =
           new TextLayout(

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
@@ -201,7 +201,7 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
 
       // draw variable names
       if (axisTitleVisible) {
-        g.setColor(styler.getChartFontColor());
+        g.setColor(styler.getAnnotationsFontColor());
         g.setFont(styler.getAnnotationsFont());
         AffineTransform orig = g.getTransform();
         AffineTransform at = new AffineTransform();

--- a/xchart/src/main/java/org/knowm/xchart/style/AbstractBaseTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AbstractBaseTheme.java
@@ -452,4 +452,10 @@ public abstract class AbstractBaseTheme implements Theme {
 
     return getPieFont().deriveFont(12f);
   }
+
+  /** Annotations default colour */
+  @Override
+  public Color getAnnotationsFontColor() {
+    return getChartFontColor();
+  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -15,6 +15,7 @@ public class PieStyler extends Styler {
   private double donutThickness;
   private boolean isSumVisible;
   private Font sumFont;
+  private String sumFormat;
 
   public PieStyler() {
 
@@ -162,6 +163,30 @@ public class PieStyler extends Styler {
   public boolean isSumVisible() {
 
     return isSumVisible;
+  }
+
+  /**
+   * Set the Format to be applied to the sum, the default is just to display the sum as a number
+   * using the PieStyler DecimalFormat. This allows a separate MessageFormat @see
+   * java.text.MessageFormat#format()
+   *
+   * @param sumFormat Format to use for the sum display, {0} indicates the original sum value e.g.
+   *     "Total {0}" will display "Total 100.0" (assuming a sum of 100.0)
+   * @return PieStyler so that modifiers can be chained.
+   */
+  public PieStyler setSumFormat(String sumFormat) {
+    this.sumFormat = sumFormat;
+    return this;
+  }
+
+  /**
+   * Access the current sumFormat value, a value of "" or null implies use the original sum
+   * formatted using the PieStyler DecimalFormat.
+   *
+   * @return MessageFormat string to be used when displaying the sum value or <code>null</code>
+   */
+  public String getSumFormat() {
+    return sumFormat;
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -167,11 +167,11 @@ public class PieStyler extends Styler {
 
   /**
    * Set the Format to be applied to the sum, the default is just to display the sum as a number
-   * using the PieStyler DecimalFormat. This allows a separate MessageFormat @see
-   * java.text.MessageFormat#format()
+   * using the PieStyler DecimalFormat. This allows a separate Formatter @see
+   * java.util.Formatter#format()
    *
-   * @param sumFormat Format to use for the sum display, {0} indicates the original sum value e.g.
-   *     "Total {0}" will display "Total 100.0" (assuming a sum of 100.0)
+   * @param sumFormat Format to use for the sum display, the Double sum value will be passed to this
+   *     to generate the overall sum string.
    * @return PieStyler so that modifiers can be chained.
    */
   public PieStyler setSumFormat(String sumFormat) {
@@ -183,7 +183,7 @@ public class PieStyler extends Styler {
    * Access the current sumFormat value, a value of "" or null implies use the original sum
    * formatted using the PieStyler DecimalFormat.
    *
-   * @return MessageFormat string to be used when displaying the sum value or <code>null</code>
+   * @return Formatter string to be used when displaying the sum value or <code>null</code>
    */
   public String getSumFormat() {
     return sumFormat;

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -54,6 +54,7 @@ public abstract class Styler {
   private Color toolTipHighlightColor;
   // Annotations ///////////////////////////////
   private Font annotationsFont;
+  private Color annotationsFontColor;
   // Misc. ///////////////////////////////
   private boolean antiAlias = true;
   private String decimalPattern;
@@ -106,6 +107,7 @@ public abstract class Styler {
 
     // Annotations ///////////////////////////////
     annotationsFont = theme.getAnnotationFont();
+    annotationsFontColor = theme.getAnnotationsFontColor();
 
     // Formatting
     decimalPattern = null;
@@ -623,6 +625,20 @@ public abstract class Styler {
   public Styler setAnnotationsFont(Font annotationsFont) {
 
     this.annotationsFont = annotationsFont;
+    return this;
+  }
+
+  public Color getAnnotationsFontColor() {
+    return annotationsFontColor;
+  }
+
+  /**
+   * Sets the color of the Font used for chart annotations
+   *
+   * @param annotationsFontColor
+   */
+  public Styler setAnnotationsFontColor(Color annotationsFontColor) {
+    this.annotationsFontColor = annotationsFontColor;
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/style/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Theme.java
@@ -162,4 +162,6 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
   // Annotations ///////////////////////////////
 
   Font getAnnotationFont();
+
+  Color getAnnotationsFontColor();
 }


### PR DESCRIPTION
*Added `annotationFontColor` Theme/Styler attribute*
Allow the Chart annotations to use a different Font color than the chart font color. This is particularly useful in the Pie chart case with darker colors where a lighter font color looks better but you don’t want to change the chart legend/sum font colors.

In order to avoid breaking any existing cases the `AbstractBaseTheme.getAnnotationsFontColor()` is set to use `getChartFontColor()` so this change won't have any affect unless either a custom Theme with a `getAnnotationsFontColor()` override or an explicit call is made to `Styler.setAnnotationsFontColor()`.

*Added `sumFormat` PieStyler attribute*
In order to allow custom “Sum” formats within Pie graphs added a `sumFormat` attribute to the `PieStyler` if non-null this acts as a `Formatter` to calculate the string to be displayed as the sum.
If null (default) then the current behaviour will hold and the sum will be calculated as a number using the PieStyler DecimalFormat.
Within the Formatter the sum value will be passed as a Double.

So for example if the sum for a Pie is 101 then calling.

`PieStyler.setSumFormat("Total %.1f GB")`

will cause the sum to be displayed as `Total 101.0 GB`