### PR TITLE
Added seriesFilled option to RadarStyler.

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue315.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue315.java
@@ -1,0 +1,49 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+public class TestForIssue315 {
+
+  static final int WIDTH = 465;
+  static final int HEIGHT = 320;
+
+  static XYChart getChart(boolean group0Enabled, boolean group1Enabled) {
+
+    double[] xData = new double[] { 0.0, 1.0, 2.0 };
+    double[] yData = new double[] { 2.0, 1.0, 0.0 };
+    double[] yData2 = new double[] { 10.0, 20.0, 15.0 };
+    XYChart chart = new XYChart(500, 200);
+    XYSeries xySeries = chart.addSeries("Series 0", xData, yData);
+    xySeries.setYAxisGroup(0);
+    xySeries.setEnabled(group0Enabled);
+
+    XYSeries xySeries2 = chart.addSeries("Series 1", xData, yData2);
+    xySeries2.setYAxisGroup(1);
+    xySeries2.setEnabled(group1Enabled);
+    chart.getStyler().setLegendPosition(LegendPosition.OutsideS);
+    return chart;
+  }
+
+  public static void main(String[] args) {
+
+    List<Chart> charts = new ArrayList<Chart>();
+    boolean[] options = { true, false };
+    for (boolean g0 : options) {
+      for (boolean g1 : options) {
+        XYChart chart = getChart(g0, g1);
+        chart.setTitle("Series 0 " + (g0 ? "enabled" : "disabled") + " - Series 1 " + (g1 ? "enabled" : "disabled"));
+        charts.add(chart);
+      }
+    }
+
+    new SwingWrapper(charts).displayChartMatrix();
+  }
+
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue316.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue316.java
@@ -1,0 +1,55 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.knowm.xchart.demo.ExampleChartTester;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.radar.RadarChart01;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.style.RadarStyler;
+
+public class TestForIssue316 {
+
+  static final int WIDTH = 465;
+  static final int HEIGHT = 320;
+
+  public static void main(String[] args) {
+
+    ExampleChartTester tester =
+        new ExampleChartTester() {
+
+          @Override
+          protected Map<String, Chart> getCharts(ExampleChartInfo chartInfo) {
+
+            LinkedHashMap<String, Chart> map = new LinkedHashMap<String, Chart>();
+            ExampleChart ec = chartInfo.getExampleChart();
+
+            map.put("No fill", getChartWithoutFill(ec));
+            map.put("Default fill", getChart(ec));
+
+            return map;
+          }
+        };
+
+    ArrayList<ExampleChart> exampleList = new ArrayList<ExampleChart>(1);
+    exampleList.add(new RadarChart01());
+    tester.setExampleList(exampleList);
+    tester.createAndShowGUI();
+  }
+
+  private static Chart getChart(ExampleChart ec) {
+
+    Chart chart = ec.getChart();
+    return chart;
+  }
+  
+  private static Chart getChartWithoutFill(ExampleChart ec) {
+    
+    Chart chart = ec.getChart();
+    ((RadarStyler)chart.getStyler()).setSeriesFilled(false);
+    return chart;
+  }
+
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -209,6 +209,9 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
     boolean mainYAxisUsed = false;
     if (chart.getSeriesMap() != null) {
       for (S series : chart.getSeriesMap().values()) {
+        if (!series.isEnabled()) {
+          continue;
+        }
         int yIndex = series.getYAxisGroup();
         if (!mainYAxisUsed && yIndex == 0) {
           mainYAxisUsed = true;
@@ -227,6 +230,10 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
     }
     for (S series : chart.getSeriesMap().values()) {
       xAxis.setDataType(series.getxAxisDataType());
+      if (!series.isEnabled()) {
+        continue;
+      }
+
       getYAxis(series.getYAxisGroup()).setDataType(series.getyAxisDataType());
       if (!mainYAxisUsed) {
         yAxis.setDataType(series.getyAxisDataType());

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
@@ -322,8 +322,10 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
       path.closePath();
       g.setColor(series.getLineColor());
       g.draw(path);
-      g.setColor(series.getFillColor());
-      g.fill(path);
+      if (styler.isSeriesFilled()) {
+        g.setColor(series.getFillColor());
+        g.fill(path);
+      }
     }
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
@@ -25,6 +25,7 @@ public class RadarStyler extends Styler {
   private int axisTitlePadding;
 
   private int markerSize;
+  private boolean seriesFilled = true;
 
   public RadarStyler() {
 
@@ -216,5 +217,15 @@ public class RadarStyler extends Styler {
   public void setAxisTickMarksCount(int axisTickMarksCount) {
 
     this.axisTickMarksCount = axisTickMarksCount;
+  }
+
+  public boolean isSeriesFilled() {
+
+    return seriesFilled;
+  }
+  
+  public void setSeriesFilled(boolean seriesFilled) {
+
+    this.seriesFilled = seriesFilled;
   }
 }


### PR DESCRIPTION
Fixes #316 

Use `radarStyler.setSeriesFilled(false);` to disable radar series fill. 
Check screenshot below:
![image](https://user-images.githubusercontent.com/6737748/60587333-de353a00-9d9c-11e9-9f39-20763ec29e50.png)


Fixes #315 
When all series in a group removed, axis is not rendered. Axis with group 0 (default axis) is an exception, it is always rendered.
Check screenshot below:
![image](https://user-images.githubusercontent.com/6737748/60589933-5e5e9e00-9da3-11e9-8679-11df1181fbe6.png)

