### PR TITLE
[resolves #308] Error bars in category chart not rendered correctly on negative values

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue308.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue308.java
@@ -1,0 +1,65 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.style.Styler.ChartTheme;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+public class TestForIssue308 implements ExampleChart<CategoryChart> {
+
+  public static void main(String[] args) {
+
+    ExampleChart<CategoryChart> exampleChart = new TestForIssue308();
+    CategoryChart chart = exampleChart.getChart();
+    new SwingWrapper<CategoryChart>(chart).displayChart();
+  }
+
+  @Override
+  public CategoryChart getChart() {
+
+    // Create Chart
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Value vs. Letter")
+            .xAxisTitle("Letter")
+            .yAxisTitle("Value")
+            .theme(ChartTheme.GGPlot2)
+            .build();
+
+    // Customize Chart
+    chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
+    chart.getStyler().setAvailableSpaceFill(.55);
+    chart.getStyler().setOverlapped(true);
+
+    // Series
+    chart.addSeries(
+        "China",
+        new ArrayList<String>(Arrays.asList(new String[] {"A", "B", "C", "D", "E"})),
+        new ArrayList<Number>(Arrays.asList(new Number[] {-11, -23, 20, 36, 20})),
+        new ArrayList<Number>(Arrays.asList(new Number[] {3, 3, 2, 1, 2})));
+    CategorySeries series2 =
+        chart.addSeries(
+            "Korea",
+            new ArrayList<String>(Arrays.asList(new String[] {"A", "B", "C", "D", "E"})),
+            new ArrayList<Number>(Arrays.asList(new Number[] {13, 15, -22, -28, 7})),
+            new ArrayList<Number>(Arrays.asList(new Number[] {3, 3, 2, 1, 2})));
+    series2.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
+    CategorySeries series3 =
+        chart.addSeries(
+            "World Ave.",
+            new ArrayList<String>(Arrays.asList(new String[] {"A", "B", "C", "D", "E"})),
+            new ArrayList<Number>(Arrays.asList(new Number[] {30, 22, 18, -36, -32})),
+            new ArrayList<Number>(Arrays.asList(new Number[] {3, 3, 2, 1, 2})));
+    series3.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Scatter);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -460,9 +460,15 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
           // Top value
           double errorBarLength = ((eb) / (yMax - yMin) * yTickSpace);
           double topEBOffset = yOffset - errorBarLength;
+          if (y < 0) {
+            topEBOffset = zeroOffset - errorBarLength;
+          }
 
           // Bottom value
           double bottomEBOffset = yOffset + errorBarLength;
+          if (y < 0) {
+            bottomEBOffset = zeroOffset + errorBarLength;
+          }
 
           // Draw it
           double errorBarOffset = xOffset + barWidth / 2;


### PR DESCRIPTION
 resolves https://github.com/knowm/XChart/issues/308 
in category charts with negative values, the error bars get centered around 0 instead of around the negative value. 
here is a category charts with negative values before modification
![Screenshot_2019-11-13_16-11-00](https://user-images.githubusercontent.com/57353473/68744738-3ffd8e80-0630-11ea-8dc7-7f2a34a5eeb3.png)
here is a category charts with negative values after modification
![Screenshot_2019-11-13_15-55-19](https://user-images.githubusercontent.com/57353473/68743729-0d529680-062e-11ea-8390-7c68380dcb2a.png)
