### PR TITLE
Reset Zoom Button bug

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue349.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue349.java
@@ -1,0 +1,77 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.JFrame;
+import javax.swing.WindowConstants;
+
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.internal.chartpart.SelectionZoom;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+public class TestForIssue349 implements ExampleChart<XYChart> {
+
+  public static void main(String[] args) {
+
+    ExampleChart<XYChart> exampleChart = new TestForIssue349();
+    XYChart chart = exampleChart.getChart();
+    XChartPanel chartPanel = new XChartPanel(chart);
+    SelectionZoom sz = new SelectionZoom();
+    sz.getResetButton().setPosition(LegendPosition.InsideNW);
+    sz.init(chartPanel);
+
+    // Create and set up the window.
+    final JFrame frame = new JFrame("TestForIssue349");
+
+    // Schedule a job for the event-dispatching thread:
+    // creating and showing this application's GUI.
+    try {
+      javax.swing.SwingUtilities.invokeAndWait(
+          new Runnable() {
+
+            @Override
+            public void run() {
+
+              frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+              frame.add(chartPanel);
+
+              // Display the window.
+              frame.pack();
+              frame.setVisible(true);
+            }
+          });
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (InvocationTargetException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public XYChart getChart() {
+
+    // Create Chart
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+
+    // Customize Chart
+    chart.getStyler().setChartTitleVisible(false);
+    chart.getStyler().setLegendVisible(false);
+
+    List<Integer> xData = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    List<Double> yData = Arrays.asList(1.1, 2.2, 7.3, 8.4, 4.5, 6.6, 2.7, 6.8, 4.9, 3.10);
+
+    List<Double> xData2 = Arrays.asList(4.5, 6.5, 7.5);
+    List<Double> yData2 = Arrays.asList(3.4, 5.6, 3.7);
+
+    // Series
+    chart.addSeries("1", xData, yData);
+    chart.addSeries("2", xData2, yData2);
+
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForSelectionZoom.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForSelectionZoom.java
@@ -9,6 +9,7 @@ import org.knowm.xchart.demo.ExampleChartTester;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.chartpart.SelectionZoom;
+import org.knowm.xchart.style.Styler.LegendPosition;
 
 public class TestForSelectionZoom {
 
@@ -33,6 +34,7 @@ public class TestForSelectionZoom {
               XChartPanel chartPanel = new XChartPanel(chart);
               if (chart instanceof XYChart) {
                 SelectionZoom sz = new SelectionZoom();
+                sz.getResetButton().setPosition(LegendPosition.InsideNW);
                 sz.init(chartPanel);
               }
               tabbedPane.addTab(e.getKey(), chartPanel);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Date.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Date.java
@@ -113,6 +113,22 @@ class AxisTickCalculator_Date extends AxisTickCalculator_ {
       // System.out.println("Returning!");
       return;
     }
+    
+    // minValue & maxValue is not set
+    if (minValue > maxValue && minValue == Double.MAX_VALUE) {
+      String datePattern = timeSpans.get(0).getDatePattern();
+      if (styler.getDatePattern() != null) {
+        datePattern = styler.getDatePattern();
+      }
+
+      SimpleDateFormat simpleDateformat = new SimpleDateFormat(datePattern, styler.getLocale());
+      simpleDateformat.setTimeZone(styler.getTimezone());
+      axisFormat = simpleDateformat;
+
+      tickLabels.add(axisFormat.format(0.0));
+      tickLocations.add(workingSpace / 2.0);
+      return;
+    }
 
     // where the tick should begin in the working space in pixels
     double margin =

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Number.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Number.java
@@ -48,6 +48,13 @@ class AxisTickCalculator_Number extends AxisTickCalculator_ {
       return;
     }
 
+    // a check for no data
+    if (minValue > maxValue && minValue == Double.MAX_VALUE) {
+      tickLabels.add(numberFormatter.format(0.0));
+      tickLocations.add(workingSpace / 2.0);
+      return;
+    }
+
     // tick space - a percentage of the working space available for ticks
     double tickSpace = styler.getPlotContentSize() * workingSpace; // in plot space
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartButton.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/components/ChartButton.java
@@ -352,4 +352,8 @@ public class ChartButton extends MouseAdapter implements ChartPart {
 
     this.yOffset = yOffset;
   }
+
+  public void setPosition(LegendPosition position) {
+    this.position = position;
+  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeriesNumericalNoErrorBars.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeriesNumericalNoErrorBars.java
@@ -109,10 +109,8 @@ public abstract class AxesChartSeriesNumericalNoErrorBars extends MarkerSeries {
       }
     }
 
+    // System.out.println("Filtering between " + String.format("%.2f %.2f", minValue, maxValue) + " all: " + length + " rem: " + remainingDataCount);
     if (remainingDataCount == length) {
-      return false;
-    }
-    if (remainingDataCount == 0) {
       return false;
     }
 


### PR DESCRIPTION
Fixes #357 

The problem was when the zoom filters all data points. When no data remains AxisTickCalculator either hangs while trying to find tick places or throws an exception. I fixed both Number and Date tick calculators for such a case.

Added a new class TestForIssue349.java to fix issue #349. But my I could not reproduce the bug.

