### PR TITLE
fix AxisTickCalculator_Number infinite loop

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -415,6 +415,9 @@ public abstract class AxesChartStyler extends Styler {
    */
   public AxesChartStyler setYAxisTickMarkSpacingHint(int yAxisTickMarkSpacingHint) {
 
+    if (yAxisTickMarkSpacingHint < 0) {
+      throw new IllegalArgumentException("yAxisTickMarkSpacingHint cannot be less than 0 !!!");
+    }
     this.yAxisTickMarkSpacingHint = yAxisTickMarkSpacingHint;
     return this;
   }


### PR DESCRIPTION
fix #334 
When ` chart.getStyler().setYAxisTickMarkSpacingHint(-1); `  , it will be infinite loop
https://github.com/knowm/XChart/blob/445897049f5f7fb46251b6c121877c8c41d74b9f/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Number.java#L103-L107
