### PR TITLE
Replaced Name to Label in Legend

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_.java
@@ -291,7 +291,7 @@ public abstract class Legend_<ST extends Styler, S extends Series> implements Ch
     // FontMetrics fontMetrics = g.getFontMetrics(getChartPainter().getstyler().getLegendFont());
     // float fontDescent = fontMetrics.getDescent();
 
-    String lines[] = series.getName().split("\\n");
+    String lines[] = series.getLabel().split("\\n");
     Map<String, Rectangle2D> seriesTextBounds =
         new LinkedHashMap<String, Rectangle2D>(lines.length);
     for (String line : lines) {


### PR DESCRIPTION
Hello, `series.setLabel()` and `series.getLabel()` methods were added by #231, but `series.getLabel()` isn't used. I have replaced `series.getName()` with `series.getLabel()` in `Legend_` class.

> By default it is the same as "name" but can be changed with the method "setLabel".