### PR TITLE
[resolves #402] Cannot change annotation position in category chart

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue402.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue402.java
@@ -1,0 +1,44 @@
+package org.knowm.xchart.standalone.issues;
+
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+public class TestForIssue402 implements ExampleChart<CategoryChart> {
+
+  public static void main(String[] args) {
+    ExampleChart<CategoryChart> exampleChart = new TestForIssue402();
+    CategoryChart chart = exampleChart.getChart();
+    new SwingWrapper<CategoryChart>(chart).displayChart();
+  }
+
+  @Override
+  public CategoryChart getChart() {
+
+    // Create Chart
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(800)
+            .height(600)
+            .title("TestForIssue402")
+            .xAxisTitle("x")
+            .yAxisTitle("y")
+            .build();
+
+    // Customize Chart
+    chart.getStyler().setLegendPosition(LegendPosition.OutsideE);
+    chart.getStyler().setStacked(true);
+    chart.getStyler().setHasAnnotations(true);
+    chart.getStyler().setShowTotalAnnotations(true);
+
+    // Series
+    chart.addSeries("a", new double[] {0, 1, 2, 3, 4}, new double[] {40, 35, -45, -60, -60});
+    chart.addSeries("b", new double[] {0, 1, 2, 3, 4}, new double[] {50, 65, 60, -70, 30});
+    chart.addSeries("c", new double[] {0, 1, 2, 3, 4}, new double[] {70, 45, -55, -80, 40});
+    chart.addSeries("d", new double[] {0, 1, 2, 3, 4}, new double[] {90, 80, 75, 75, 50});
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -70,6 +70,8 @@ public abstract class Styler {
   private Font annotationsFont;
   private Color annotationsFontColor;
   private int annotationsRotation = 0;
+  private float annotationsPosition = 0.5f;
+  private boolean showTotalAnnotations = false;
   // Misc. ///////////////////////////////
   private boolean antiAlias = true;
   private String decimalPattern;
@@ -820,6 +822,31 @@ public abstract class Styler {
    */
   public Styler setAnnotationsRotation(int annotationsRotation) {
     this.annotationsRotation = annotationsRotation;
+    return this;
+  }
+
+  public float getAnnotationsPosition() {
+
+    return annotationsPosition;
+  }
+
+  public Styler setAnnotationsPosition(float annotationsPosition) {
+
+    if (annotationsPosition < 0 || annotationsPosition > 1) {
+      throw new IllegalArgumentException("Annotations position must be tween 0 and 1!!!");
+    }
+    this.annotationsPosition = annotationsPosition;
+    return this;
+  }
+
+  public boolean isShowTotalAnnotations() {
+
+    return showTotalAnnotations;
+  }
+
+  public Styler setShowTotalAnnotations(boolean showTotalAnnotations) {
+
+    this.showTotalAnnotations = showTotalAnnotations;
     return this;
   }
 


### PR DESCRIPTION
resolves issue #402 , style add two properties
- annotationsPosition: set  annotations position, must be tween 0 and 1, default is 0.5
- showTotalAnnotations: show total annotations, default is false not show

The results are as follows:
defaulte style
```java
    chart.getStyler().setStacked(true);
    chart.getStyler().setHasAnnotations(true);
    chart.getStyler().setShowTotalAnnotations(true);
```
- default
![an-1](https://user-images.githubusercontent.com/57353473/72714816-5123c800-3baa-11ea-81ff-c8d2dda63989.png)

- `chart.getStyler().setAnnotationsPosition(0f)`
![an-2 0](https://user-images.githubusercontent.com/57353473/72715103-d313f100-3baa-11ea-9b18-3fb980bbdf5f.png)

- `chart.getStyler().setAnnotationsPosition(1f)`
![an-3 0](https://user-images.githubusercontent.com/57353473/72715183-fb9beb00-3baa-11ea-84dd-827e32fda6a7.png)

- `chart.getStyler().setShowTotalAnnotations(false)`
![an-4 0](https://user-images.githubusercontent.com/57353473/72715298-2e45e380-3bab-11ea-8fe7-b4d367c47a89.png)

