### PR TITLE
Modify PR #407, Support setting XY axis or multiple Y axis title font color

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue405.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue405.java
@@ -1,0 +1,33 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.demo.charts.date.DateChart03;
+import org.knowm.xchart.demo.charts.line.LineChart03;
+
+public class TestForIssue405 {
+
+  public static void main(String[] args) {
+
+    List<XYChart> charts = new ArrayList<>();
+
+    XYChart chart1 = new LineChart03().getChart();
+    chart1.setTitle("Set XY axis title font color");
+    chart1.getStyler().setXAxisTitleColor(Color.RED);
+    chart1.getStyler().setYAxisTitleColor(Color.GREEN);
+    charts.add(chart1);
+
+    XYChart chart2 = new DateChart03().getChart();
+    chart2.setTitle("Set multiple Y-axis title font colors");
+    chart2.setYAxisGroupTitle(1, "Y1");
+    chart2.setYAxisGroupTitle(0, "Y2");
+    chart2.getStyler().setYAxisGroupTitleColor(1, chart2.getStyler().getSeriesColors()[0]);
+    chart2.getStyler().setYAxisGroupTitleColor(0, chart2.getStyler().getSeriesColors()[1]);
+    charts.add(chart2);
+    new SwingWrapper<XYChart>(charts).displayChartMatrix();
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTitle.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTitle.java
@@ -48,6 +48,9 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
           && !yAxisTitle.trim().equalsIgnoreCase("")
           && chart.getStyler().isYAxisTitleVisible()) {
 
+        if (chart.getStyler().getYAxisGroupTitleColor(yIndex) != null) {
+          g.setColor(chart.getStyler().getYAxisGroupTitleColor(yIndex));
+        }
         FontRenderContext frc = g.getFontRenderContext();
         TextLayout nonRotatedTextLayout =
             new TextLayout(yAxisTitle, chart.getStyler().getAxisTitleFont(), frc);
@@ -110,6 +113,9 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
           && !chart.getXAxisTitle().trim().equalsIgnoreCase("")
           && chart.getStyler().isXAxisTitleVisible()) {
 
+        if (chart.getStyler().getXAxisTitleColor() != null) {
+          g.setColor(chart.getStyler().getXAxisTitleColor());
+        }
         FontRenderContext frc = g.getFontRenderContext();
         TextLayout textLayout =
             new TextLayout(chart.getXAxisTitle(), chart.getStyler().getAxisTitleFont(), frc);

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -2,6 +2,8 @@ package org.knowm.xchart.style;
 
 import java.awt.*;
 import java.util.HashMap;
+import java.util.Map;
+
 import org.knowm.xchart.style.markers.Marker;
 
 /**
@@ -79,6 +81,10 @@ public abstract class Styler {
   private int yAxisLeftWidthHint;
   // Box plot data ///////////////////////////////
   private boolean showWithinAreaPoint = false;
+  // Axis Title Font Color
+  private Color xAxisTitleColor;
+  private Color yAxisTitleColor;
+  private Map<Integer, Color> yAxisGroupTitleColorMap = new HashMap<Integer, Color>();
 
   void setAllStyles() {
 
@@ -909,12 +915,52 @@ public abstract class Styler {
     this.yAxisLeftWidthHint = yAxisLeftWidthHint;
   }
 
-  public void setShowWithinAreaPoint(boolean showWithinAreaPoint) {
+  public Styler setShowWithinAreaPoint(boolean showWithinAreaPoint) {
+
     this.showWithinAreaPoint = showWithinAreaPoint;
+    return this;
   }
 
   public boolean getShowWithinAreaPoint() {
+
     return this.showWithinAreaPoint;
+  }
+
+  public Color getXAxisTitleColor() {
+
+    return xAxisTitleColor;
+  }
+
+  public Styler setXAxisTitleColor(Color xAxisTitleColor) {
+
+    this.xAxisTitleColor = xAxisTitleColor;
+    return this;
+  }
+
+  public Color getYAxisTitleColor() {
+
+    return yAxisTitleColor;
+  }
+
+  public Styler setYAxisTitleColor(Color yAxisColor) {
+
+    this.yAxisTitleColor = yAxisColor;
+    return this;
+  }
+
+  public Color getYAxisGroupTitleColor(int yAxisGroup) {
+
+    Color color = yAxisGroupTitleColorMap.get(yAxisGroup);
+    if (color == null) {
+      return yAxisTitleColor;
+    }
+    return color;
+  }
+
+  public Styler setYAxisGroupTitleColor(int yAxisGroup, Color yAxisColor) {
+
+    yAxisGroupTitleColorMap.put(yAxisGroup, yAxisColor);
+    return this;
   }
 
   public enum LegendPosition {


### PR DESCRIPTION
Implemented according to PR #407, copy setting the Y-axis and multiple Y-axis title font color function codes.
Added the function of setting the X-axis title font color, and added issue testing.

Set XY axis title font color and set multiple Y-axis title font colors,like this:
![setAxisTitleColor](https://user-images.githubusercontent.com/57353473/74898446-dcc08c80-53d4-11ea-8ccf-ae456aa19087.png)

Associate issue and PR #404 #405 #406 #407 
