### PR TITLE
Fixed histogram charts showing wrong total number when stacked

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -391,6 +391,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
           }
           if (stylerCategory.hasAnnotations()
               && stylerCategory.isShowTotalAnnotations()
+              && stylerCategory.isStacked()
               && seriesCounter == (seriesMap.size() - 1)) {
             Number totalNext =
                 accumulatedStackOffsetPos[categoryCounter - 1]


### PR DESCRIPTION
Before fix:
```java
// Customize Chart
chart.getStyler().setHasAnnotations(true);
chart.getStyler().setShowTotalAnnotations(true);
```
![bug](https://user-images.githubusercontent.com/57353473/75856463-5d4ca780-5e2f-11ea-8572-490db1fc69fc.png)

After fix:
```java
// Customize Chart
chart.getStyler().setHasAnnotations(true);
chart.getStyler().setShowTotalAnnotations(true);
```
![image](https://user-images.githubusercontent.com/57353473/75857029-7bff6e00-5e30-11ea-9575-3c74092bd100.png)


```java
// Customize Chart
chart.getStyler().setHasAnnotations(true);
chart.getStyler().setStacked(true);
chart.getStyler().setShowTotalAnnotations(true);
```
![image](https://user-images.githubusercontent.com/57353473/75857094-92a5c500-5e30-11ea-8b43-061505ba8fe9.png)


`stacked` is true, `showTotalAnnotations` takes effect
