### PR TITLE
[resolves #404] Set the TickLabels and MarksColor colors of xAxis, yAxis, yAxisGroup

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue404.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue404.java
@@ -1,0 +1,47 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.demo.charts.date.DateChart03;
+import org.knowm.xchart.demo.charts.line.LineChart03;
+
+public class TestForIssue404 {
+
+  public static void main(String[] args) {
+
+    List<XYChart> charts = new ArrayList<>();
+
+    XYChart chart1 = new LineChart03().getChart();
+    chart1.setTitle("Set XY axis tickLabels and tickMarks color");
+    chart1.getStyler().setXAxisTitleColor(Color.RED);
+    chart1.getStyler().setYAxisTitleColor(Color.GREEN);
+    chart1.getStyler().setAxisTickLabelsColor(Color.PINK);
+    chart1.getStyler().setXAxisTickLabelsColor(Color.BLUE);
+    chart1.getStyler().setYAxisTickLabelsColor(Color.CYAN);
+    chart1.getStyler().setAxisTickMarksColor(Color.ORANGE);
+    chart1.getStyler().setXAxisTickMarksColor(Color.RED);
+    chart1.getStyler().setYAxisTickMarksColor(Color.YELLOW);
+    charts.add(chart1);
+
+    XYChart chart2 = new DateChart03().getChart();
+    chart2.setTitle("Set multiple Y-axis tickLabels and tickMarks colors");
+    chart2.setYAxisGroupTitle(1, "Y1");
+    chart2.setYAxisGroupTitle(0, "Y2");
+    chart2.getStyler().setYAxisGroupTitleColor(1, chart2.getStyler().getSeriesColors()[0]);
+    chart2.getStyler().setYAxisGroupTitleColor(0, chart2.getStyler().getSeriesColors()[1]);
+
+    chart2.getStyler().setXAxisTickLabelsColor(Color.YELLOW);
+    chart2.getStyler().setXAxisTickMarksColor(Color.BLUE);
+
+    chart2.getStyler().setYAxisGroupTickLabelsColorMap(1, Color.CYAN);
+    chart2.getStyler().setYAxisGroupTickLabelsColorMap(0, Color.RED);
+    chart2.getStyler().setYAxisGroupTickMarksColorMap(1, Color.ORANGE);
+    chart2.getStyler().setYAxisGroupTickMarksColorMap(0, Color.PINK);
+    charts.add(chart2);
+    new SwingWrapper<XYChart>(charts).displayChartMatrix();
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
@@ -40,10 +40,9 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends AxesChartSerie
     ST styler = chart.getStyler();
     g.setFont(styler.getAxisTickLabelsFont());
 
-    g.setColor(styler.getAxisTickLabelsColor());
-
     if (direction == Axis.Direction.Y && styler.isYAxisTicksVisible()) { // Y-Axis
 
+      g.setColor(styler.getYAxisGroupTickLabelsColorMap(yAxis.getYIndex()));
       boolean onRight = styler.getYAxisGroupPosistion(yAxis.getYIndex()) == YAxisPosition.Right;
 
       double xOffset;
@@ -122,6 +121,7 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends AxesChartSerie
     // X-Axis
     else if (direction == Axis.Direction.X && styler.isXAxisTicksVisible()) {
 
+      g.setColor(styler.getXAxisTickLabelsColor());
       double xOffset = chart.getXAxis().getBounds().getX();
       double yOffset = chart.getXAxis().getAxisTitle().getBounds().getY();
       double width = chart.getXAxis().getBounds().getWidth();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickMarks.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickMarks.java
@@ -34,11 +34,11 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends AxesChartSeries
   public void paint(Graphics2D g) {
 
     ST styler = chart.getStyler();
-    g.setColor(styler.getAxisTickMarksColor());
     g.setStroke(styler.getAxisTickMarksStroke());
 
     if (direction == Axis.Direction.Y && styler.isYAxisTicksVisible()) { // Y-Axis
 
+      g.setColor(styler.getYAxisGroupTickMarksColorMap(yAxis.getYIndex()));
       int axisTickMarkLength = styler.getAxisTickMarkLength();
 
       boolean onRight = styler.getYAxisGroupPosistion(yAxis.getYIndex()) == YAxisPosition.Right;
@@ -102,6 +102,7 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends AxesChartSeries
     // X-Axis
     else if (direction == Axis.Direction.X && styler.isXAxisTicksVisible()) {
 
+      g.setColor(styler.getXAxisTickMarksColor());
       int axisTickMarkLength = styler.getAxisTickMarkLength();
       double xOffset = chart.getXAxis().getBounds().getX();
       double yOffset =

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -66,6 +66,14 @@ public abstract class AxesChartStyler extends Styler {
   private boolean xAxisLogarithmicDecadeOnly;
   private boolean yAxisLogarithmicDecadeOnly;
 
+  // TickLabels and MarksColor colors for xAxis, yAxis, yAxisGroup ////////////////////////////////
+  private Color xAxisTickLabelsColor;
+  private Color yAxisTickLabelsColor;
+  private Color xAxisTickMarksColor;
+  private Color yAxisTickMarksColor;
+  private Map<Integer, Color> yAxisGroupTickLabelsColorMap = new HashMap<Integer, Color>();
+  private Map<Integer, Color> yAxisGroupTickMarksColorMap = new HashMap<Integer, Color>();
+
   @Override
   void setAllStyles() {
 
@@ -845,5 +853,92 @@ public abstract class AxesChartStyler extends Styler {
   public void setXAxisLabelAlignmentVertical(TextAlignment xAxisLabelAlignmentVertical) {
 
     this.xAxisLabelAlignmentVertical = xAxisLabelAlignmentVertical;
+  }
+
+  public Color getXAxisTickLabelsColor() {
+
+    if (xAxisTickLabelsColor == null) {
+      return axisTickLabelsColor;
+    }
+    return xAxisTickLabelsColor;
+  }
+
+  public AxesChartStyler setXAxisTickLabelsColor(Color xAxisTickLabelsColor) {
+
+    this.xAxisTickLabelsColor = xAxisTickLabelsColor;
+    return this;
+  }
+
+  public Color getYAxisTickLabelsColor() {
+
+    if (yAxisTickLabelsColor == null) {
+      return axisTickLabelsColor;
+    }
+    return yAxisTickLabelsColor;
+  }
+
+  public AxesChartStyler setYAxisTickLabelsColor(Color yAxisTickLabelsColor) {
+
+    this.yAxisTickLabelsColor = yAxisTickLabelsColor;
+    return this;
+  }
+
+  public Color getXAxisTickMarksColor() {
+
+    if (xAxisTickMarksColor == null) {
+      return axisTickMarksColor;
+    }
+    return xAxisTickMarksColor;
+  }
+
+  public AxesChartStyler setXAxisTickMarksColor(Color xAxisTickMarksColor) {
+
+    this.xAxisTickMarksColor = xAxisTickMarksColor;
+    return this;
+  }
+
+  public Color getYAxisTickMarksColor() {
+
+    if (yAxisTickMarksColor == null) {
+      return axisTickMarksColor;
+    }
+    return yAxisTickMarksColor;
+  }
+
+  public AxesChartStyler setYAxisTickMarksColor(Color yAxisTickMarksColor) {
+
+    this.yAxisTickMarksColor = yAxisTickMarksColor;
+    return this;
+  }
+
+  public Color getYAxisGroupTickLabelsColorMap(int yAxisGroup) {
+
+    Color color = yAxisGroupTickLabelsColorMap.get(yAxisGroup);
+    if (color == null) {
+      color = getYAxisTickLabelsColor();
+    }
+    return color;
+  }
+
+  public AxesChartStyler setYAxisGroupTickLabelsColorMap(
+      int yAxisGroup, Color yAxisTickLabelsColor) {
+
+    yAxisGroupTickLabelsColorMap.put(yAxisGroup, yAxisTickLabelsColor);
+    return this;
+  }
+
+  public Color getYAxisGroupTickMarksColorMap(int yAxisGroup) {
+
+    Color color = yAxisGroupTickMarksColorMap.get(yAxisGroup);
+    if (color == null) {
+      color = getYAxisTickMarksColor();
+    }
+    return color;
+  }
+
+  public AxesChartStyler setYAxisGroupTickMarksColorMap(int yAxisGroup, Color yAxisTickMarksColor) {
+
+    yAxisGroupTickMarksColorMap.put(yAxisGroup, yAxisTickMarksColor);
+    return this;
   }
 }


### PR DESCRIPTION
AxesChartStyler class adds attribute styles:
```java
  // TickLabels and MarksColor colors for xAxis, yAxis, yAxisGroup ////////////////////////////////
  private Color xAxisTickLabelsColor;
  private Color yAxisTickLabelsColor;
  private Color xAxisTickMarksColor;
  private Color yAxisTickMarksColor;
  private Map<Integer, Color> yAxisGroupTickLabelsColorMap = new HashMap<Integer, Color>();
  private Map<Integer, Color> yAxisGroupTickMarksColorMap = new HashMap<Integer, Color>();
```
The effect is as follows:
![image](https://user-images.githubusercontent.com/57353473/76190926-1db00200-6219-11ea-992f-8c3268b028fc.png)
