### PR TITLE
[resolves #432] The plot data beyond the XChartpanel

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
@@ -42,7 +42,7 @@ public abstract class PlotContent_<ST extends Styler, S extends Series> implemen
     java.awt.Shape saveClip = g.getClip();
     // this is for preventing the series to be drawn outside the plot area if min and max is
     // overridden to fall inside the data range
-    g.setClip(bounds.createIntersection(bounds));
+    g.setClip(bounds.createIntersection(saveClip.getBounds2D()));
 
     chart.toolTips.prepare(g);
 


### PR DESCRIPTION
When drawing PlotContent, drawing bounds will be hidden.

Graphics.setClip(Shape clip), clip is the intersection of the current window display bounds and PlotContent_.getBounds().

```java
g.setClip(bounds.createIntersection(saveClip.getBounds2D()));
```
![432](https://user-images.githubusercontent.com/57353473/77044901-34b1d980-69fb-11ea-99de-7971f1c2b0d5.gif)
