### PR TITLE
fix bug NullPointerException

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
@@ -42,7 +42,11 @@ public abstract class PlotContent_<ST extends Styler, S extends Series> implemen
     java.awt.Shape saveClip = g.getClip();
     // this is for preventing the series to be drawn outside the plot area if min and max is
     // overridden to fall inside the data range
-    g.setClip(bounds.createIntersection(saveClip.getBounds2D()));
+    if (saveClip != null) {
+      g.setClip(bounds.createIntersection(saveClip.getBounds2D()));
+    } else {
+      g.setClip(bounds);
+    }
 
     chart.toolTips.prepare(g);
 


### PR DESCRIPTION
Report NullPointerException, When XChart is saved as another file.
```java
java.awt.Shape saveClip = g.getClip();
g.setClip(bounds.createIntersection(saveClip.getBounds2D()));
```
saveClip is null.