### PR TITLE
Add XYSeriesRenderStyle.PolygonArea to draw arbitrary polygons

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/area/AreaChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/area/AreaChart05.java
@@ -1,0 +1,56 @@
+package org.knowm.xchart.demo.charts.area;
+
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+/**
+ * Area Chart with 1 series
+ *
+ * <p>Demonstrates the following:
+ *
+ * <ul>
+ *   <li>Polygon Area Chart
+ *   <li>Place legend at Inside-NE position
+ *   <li>ChartBuilder
+ */
+public class AreaChart05 implements ExampleChart<XYChart> {
+
+  public static void main(String[] args) {
+
+    ExampleChart<XYChart> exampleChart = new AreaChart05();
+    XYChart chart = exampleChart.getChart();
+    new SwingWrapper<XYChart>(chart).displayChart();
+  }
+
+  @Override
+  public XYChart getChart() {
+
+    // Create Chart
+    XYChart chart =
+        new XYChartBuilder()
+            .width(800)
+            .height(600)
+            .title(getClass().getSimpleName())
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .build();
+
+    // Customize Chart
+    chart.getStyler().setLegendPosition(LegendPosition.InsideNE);
+    chart.getStyler().setAxisTitlesVisible(false);
+    chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.PolygonArea);
+
+    // Series
+    chart.addSeries("a",
+            new double[] {0, 3, 5, 7, 9,    // x coordinates ascending
+                          9, 7, 5, 3, 0},   // x coordinates descending
+            new double[] {-1, 6, 9, 6, 5,   // upper y
+                          4, 0, 4, 5, -3}); // lower y
+
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/area/AreaChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/area/AreaChart05.java
@@ -45,11 +45,16 @@ public class AreaChart05 implements ExampleChart<XYChart> {
     chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.PolygonArea);
 
     // Series
-    chart.addSeries("a",
-            new double[] {0, 3, 5, 7, 9,    // x coordinates ascending
-                          9, 7, 5, 3, 0},   // x coordinates descending
-            new double[] {-1, 6, 9, 6, 5,   // upper y
-                          4, 0, 4, 5, -3}); // lower y
+    chart.addSeries(
+        "a",
+        new double[] {
+          0, 3, 5, 7, 9, // x coordinates ascending
+          9, 7, 5, 3, 0
+        }, // x coordinates descending
+        new double[] {
+          -1, 6, 9, 6, 5, // upper y
+          4, 0, 4, 5, -3
+        }); // lower y
 
     return chart;
   }

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/area/AreaChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/area/AreaChart05.java
@@ -59,3 +59,4 @@ public class AreaChart05 implements ExampleChart<XYChart> {
     return chart;
   }
 }
+

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue433.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue433.java
@@ -6,7 +6,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;

--- a/xchart/src/main/java/org/knowm/xchart/XYSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYSeries.java
@@ -63,7 +63,11 @@ public class XYSeries extends AxesChartSeriesNumericalNoErrorBars {
 
     StepArea(LegendRenderType.Line),
 
+    PolygonArea(LegendRenderType.Line),
+
     Scatter(LegendRenderType.Scatter);
+
+
 
     private final LegendRenderType legendRenderType;
 

--- a/xchart/src/main/java/org/knowm/xchart/XYSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYSeries.java
@@ -63,11 +63,9 @@ public class XYSeries extends AxesChartSeriesNumericalNoErrorBars {
 
     StepArea(LegendRenderType.Line),
 
-    PolygonArea(LegendRenderType.Line),
+    PolygonArea(LegendRenderType.Box),
 
     Scatter(LegendRenderType.Scatter);
-
-
 
     private final LegendRenderType legendRenderType;
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -155,7 +155,7 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
         boolean isSeriesLineOrArea =
             XYSeriesRenderStyle.Line == series.getXYSeriesRenderStyle()
                 || XYSeriesRenderStyle.Area == series.getXYSeriesRenderStyle()
-                    || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle();
+                || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle();
         boolean isSeriesStepLineOrStepArea =
             XYSeriesRenderStyle.Step == series.getXYSeriesRenderStyle()
                 || XYSeriesRenderStyle.StepArea == series.getXYSeriesRenderStyle();
@@ -200,7 +200,7 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
         // paint area
         if (XYSeriesRenderStyle.Area == series.getXYSeriesRenderStyle()
             || XYSeriesRenderStyle.StepArea == series.getXYSeriesRenderStyle()
-                || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle()) {
+            || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle()) {
 
           if (previousX != -Double.MAX_VALUE && previousY != -Double.MAX_VALUE) {
             if (path == null) {
@@ -215,7 +215,7 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
               }
             }
             if (XYSeriesRenderStyle.Area == series.getXYSeriesRenderStyle()
-                    || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle()) {
+                || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle()) {
               if (series.isSmooth()) {
                 path.curveTo(
                     (previousX + xOffset) / 2,
@@ -236,7 +236,8 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
               }
             }
           }
-          if (xOffset < previousX &&  XYSeriesRenderStyle.PolygonArea != series.getXYSeriesRenderStyle()) {
+          if (xOffset < previousX
+              && XYSeriesRenderStyle.PolygonArea != series.getXYSeriesRenderStyle()) {
             throw new RuntimeException("X-Data must be in ascending order for Area Charts!!!");
           }
         }
@@ -338,9 +339,15 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends XYSeries>
     }
   }
 
-  void closePathXY(Graphics2D g, Path2D.Double path, double previousX, double yZeroOffset, double polygonStartX, double polygonStartY) {
+  void closePathXY(
+      Graphics2D g,
+      Path2D.Double path,
+      double previousX,
+      double yZeroOffset,
+      double polygonStartX,
+      double polygonStartY) {
     if (path != null) {
-      if (polygonStartX != - Double.MAX_VALUE){
+      if (polygonStartX != -Double.MAX_VALUE) {
         path.lineTo(polygonStartX, polygonStartY);
       } else {
         path.lineTo(previousX, yZeroOffset);


### PR DESCRIPTION
Dear Maintainers

This PR adds a new XY series type that allows for drawing filled polygons.
With this, it is possible do for example what is requested here https://github.com/knowm/XChart/issues/247

The new series assumes that the x,y coordinates defines the entire boundary of the area, not just the upper limit as with `Area`.

To fill in between 2 lines, one would append the coordinates of the lower line, in reversed order. Thus the upper line is given as left->right, immediately followed by the lower line from right->left.

Please tell me if any tests or additional docs are necessary.
