### PR TITLE
[resolves #456] OHLC improvements

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
@@ -7,6 +7,8 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import org.knowm.xchart.OHLCSeries.OHLCSeriesRenderStyle;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
 import org.knowm.xchart.internal.chartpart.Chart;
@@ -846,7 +848,8 @@ public class OHLCChart extends Chart<OHLCStyler, OHLCSeries> {
       if (series.getLineStyle() == null) { // wasn't set manually
         series.setLineStyle(seriesColorMarkerLineStyle.getStroke());
       }
-      if (series.getLineColor() == null) { // wasn't set manually
+      if (series.getOhlcSeriesRenderStyle() == OHLCSeriesRenderStyle.Line
+          && series.getLineColor() == null) { // wasn't set manually
         series.setLineColor(seriesColorMarkerLineStyle.getColor());
       }
       if (series.getFillColor() == null) { // wasn't set manually

--- a/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
@@ -1,6 +1,7 @@
 package org.knowm.xchart;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics2D;
 import java.util.Date;
 import java.util.Iterator;
@@ -49,6 +50,8 @@ public class OHLCChart extends Chart<OHLCStyler, OHLCSeries> {
 
     this(width, height);
     styler.setTheme(theme);
+    styler.setToolTipBackgroundColor(new Color(210, 210, 210));
+    styler.setToolTipFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
   }
 
   /**
@@ -856,10 +859,10 @@ public class OHLCChart extends Chart<OHLCStyler, OHLCSeries> {
         series.setMarkerColor(seriesColorMarkerLineStyle.getColor());
       }
       if (series.getUpColor() == null) { // wasn't set manually
-        series.setUpColor(Color.GREEN);
+        series.setUpColor(new Color(242, 39, 42));
       }
       if (series.getDownColor() == null) { // wasn't set manually
-        series.setDownColor(Color.RED);
+        series.setDownColor(new Color(19, 179, 70));
       }
     }
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_OHLC.java
@@ -59,7 +59,11 @@ public class Legend_OHLC<ST extends OHLCStyler, S extends OHLCSeries> extends Le
                 starty + legendEntryHeight / 2.0 - BOX_SIZE / 2,
                 chart.getStyler().getLegendSeriesLineLength(),
                 BOX_SIZE);
-        g.setColor(series.getUpColor());
+        if (series.getLineColor() == null) {
+          g.setColor(series.getUpColor());
+        } else {
+          g.setColor(series.getLineColor());
+        }
         g.fill(rectSmall);
       }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_OHLC.java
@@ -59,7 +59,7 @@ public class Legend_OHLC<ST extends OHLCStyler, S extends OHLCSeries> extends Le
                 starty + legendEntryHeight / 2.0 - BOX_SIZE / 2,
                 chart.getStyler().getLegendSeriesLineLength(),
                 BOX_SIZE);
-        g.setColor(Color.RED);
+        g.setColor(series.getUpColor());
         g.fill(rectSmall);
       }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -162,7 +162,11 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
               && highOffset != -Double.MAX_VALUE
               && lowOffset != -Double.MAX_VALUE
               && closeOffset != -Double.MAX_VALUE) {
-            g.setColor(series.getLineColor());
+            if (closeOrig > openOrig) {
+              g.setColor(series.getUpColor());
+            } else {
+              g.setColor(series.getDownColor());
+            }
             g.setStroke(series.getLineStyle());
             // high to low line
             line.setLine(xOffset, highOffset, xOffset, lowOffset);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -162,10 +162,16 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
               && highOffset != -Double.MAX_VALUE
               && lowOffset != -Double.MAX_VALUE
               && closeOffset != -Double.MAX_VALUE) {
-            if (closeOrig > openOrig) {
-              g.setColor(series.getUpColor());
+
+            if (series.getLineColor() != null) {
+              g.setColor(series.getLineColor());
             } else {
-              g.setColor(series.getDownColor());
+
+              if (closeOrig > openOrig) {
+                g.setColor(series.getUpColor());
+              } else {
+                g.setColor(series.getDownColor());
+              }
             }
             g.setStroke(series.getLineStyle());
             // high to low line


### PR DESCRIPTION
- The legend render color is the matching of the series upColor, representing the color of stock rising;

- The default for upColor is new Color (242,39,42), and the default for downColor is new Color (19,179,70);

- Candle line color should be consistent with upColor or downColor;

- Modify OHLCStyler default settings, styler.setToolTipBackgroundColor (new Color (210,210,210)), styler.setToolTipFont (new Font (Font.SANS_SERIF, Font.PLAIN, 12)).
