### PR TITLE
Remove raw types from some parts of the public API

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/Example2.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/Example2.java
@@ -18,7 +18,7 @@ public class Example2 {
 
     int numCharts = 4;
 
-    List<Chart> charts = new ArrayList<Chart>();
+    List<XYChart> charts = new ArrayList<XYChart>();
 
     for (int i = 0; i < numCharts; i++) {
       XYChart chart =
@@ -29,7 +29,7 @@ public class Example2 {
       series.setMarker(SeriesMarkers.NONE);
       charts.add(chart);
     }
-    new SwingWrapper<Chart>(charts).displayChartMatrix();
+    new SwingWrapper<XYChart>(charts).displayChartMatrix();
 
     BitmapEncoder.saveBitmap(charts, 2, 2, "./Sample_Chart_Matrix", BitmapEncoder.BitmapFormat.PNG);
   }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue244.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue244.java
@@ -107,7 +107,7 @@ public class TestForIssue244 {
       charts.add(chart);
     }
 
-    new SwingWrapper<Chart>(charts).displayChartMatrix();
+    new SwingWrapper(charts).displayChartMatrix();
   }
 
   static Chart getLineChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue291.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue291.java
@@ -28,7 +28,7 @@ public class TestForIssue291 {
     chart.getStyler().setYAxisGroupPosition(0, YAxisPosition.Right);
     chart.setYAxisGroupTitle(1, "sin(x)");
 
-    final SwingWrapper<Chart> sw = new SwingWrapper<Chart>(chart);
+    final SwingWrapper<XYChart> sw = new SwingWrapper<XYChart>(chart);
 
     sw.displayChart();
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_1.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_1.java
@@ -124,7 +124,7 @@ public class TestForIssue54_1 {
       charts.add(chart);
     }
 
-    new SwingWrapper<Chart>(charts).displayChartMatrix();
+    new SwingWrapper(charts).displayChartMatrix();
   }
 
   static Chart getLineChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_2.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_2.java
@@ -30,7 +30,7 @@ public class TestForIssue54_2 {
     chart.getStyler().setYAxisGroupPosition(0, YAxisPosition.Right);
     chart.setYAxisGroupTitle(1, "sin(x)");
 
-    new SwingWrapper<Chart>(chart).displayChart();
+    new SwingWrapper(chart).displayChart();
   }
 
   static Chart getLineChart() {

--- a/xchart/src/main/java/org/knowm/xchart/BitmapEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/BitmapEncoder.java
@@ -62,7 +62,7 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @throws IOException
    */
-  public static void saveBitmap(Chart chart, String fileName, BitmapFormat bitmapFormat)
+  public static <T extends Chart<?, ?>> void saveBitmap(T chart, String fileName, BitmapFormat bitmapFormat)
       throws IOException {
 
     try (OutputStream out = new FileOutputStream(addFileExtension(fileName, bitmapFormat)); ) {
@@ -79,7 +79,7 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @throws IOException
    */
-  public static void saveBitmap(Chart chart, OutputStream targetStream, BitmapFormat bitmapFormat)
+  public static <T extends Chart<?, ?>> void saveBitmap(T chart, OutputStream targetStream, BitmapFormat bitmapFormat)
       throws IOException {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
@@ -97,8 +97,8 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @throws IOException
    */
-  public static void saveBitmap(
-      List<Chart> charts,
+  public static <T extends Chart<?, ?>> void saveBitmap(
+      List<T> charts,
       Integer rows,
       Integer cols,
       String fileName,
@@ -122,8 +122,8 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @throws IOException
    */
-  public static void saveBitmap(
-      List<Chart> charts,
+  public static <T extends Chart<?, ?>> void saveBitmap(
+      List<T> charts,
       Integer rows,
       Integer cols,
       OutputStream targetStream,
@@ -131,7 +131,7 @@ public final class BitmapEncoder {
       throws IOException {
 
     List<BufferedImage> chartImages = new LinkedList<>();
-    for (Chart c : charts) chartImages.add(getBufferedImage(c));
+    for (T c : charts) chartImages.add(getBufferedImage(c));
 
     BufferedImage bufferedImage = mergeImages(chartImages, rows, cols);
     ImageIO.write(bufferedImage, bitmapFormat.toString().toLowerCase(), targetStream);
@@ -146,8 +146,8 @@ public final class BitmapEncoder {
    * @param DPI
    * @throws IOException
    */
-  public static void saveBitmapWithDPI(
-      Chart chart, String fileName, BitmapFormat bitmapFormat, int DPI) throws IOException {
+  public static <T extends Chart<?, ?>> void saveBitmapWithDPI(
+      T chart, String fileName, BitmapFormat bitmapFormat, int DPI) throws IOException {
 
     double scaleFactor = DPI / 72.0;
 
@@ -197,6 +197,7 @@ public final class BitmapEncoder {
   /**
    * Sets the metadata correctly
    *
+   *
    * @param metadata
    * @param DPI
    * @throws IIOInvalidTreeException
@@ -230,7 +231,7 @@ public final class BitmapEncoder {
    * @param quality - a float between 0 and 1 (1 = maximum quality)
    * @throws IOException
    */
-  public static void saveJPGWithQuality(Chart chart, String fileName, float quality)
+  public static <T extends Chart<?, ?>> void saveJPGWithQuality(T chart, String fileName, float quality)
       throws IOException {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
@@ -258,7 +259,8 @@ public final class BitmapEncoder {
    * @return a byte[] for a given chart
    * @throws IOException
    */
-  public static byte[] getBitmapBytes(Chart chart, BitmapFormat bitmapFormat) throws IOException {
+  public static <T extends Chart<?, ?>> byte[] getBitmapBytes(T chart, BitmapFormat bitmapFormat)
+      throws IOException {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
 
@@ -272,7 +274,7 @@ public final class BitmapEncoder {
     return imageInBytes;
   }
 
-  public static BufferedImage getBufferedImage(Chart chart) {
+  public static <T extends Chart<?, ?>> BufferedImage getBufferedImage(T chart) {
 
     BufferedImage bufferedImage =
         new BufferedImage(chart.getWidth(), chart.getHeight(), BufferedImage.TYPE_INT_RGB);

--- a/xchart/src/main/java/org/knowm/xchart/SwingWrapper.java
+++ b/xchart/src/main/java/org/knowm/xchart/SwingWrapper.java
@@ -14,7 +14,7 @@ import org.knowm.xchart.internal.chartpart.Chart;
  *
  * @author timmolter
  */
-public class SwingWrapper<T extends Chart> {
+public class SwingWrapper<T extends Chart<?, ?>> {
 
   private final List<XChartPanel<T>> chartPanels = new ArrayList<XChartPanel<T>>();
   private String windowTitle = "XChart";

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -41,7 +41,7 @@ import org.knowm.xchart.internal.chartpart.ToolTips;
  *
  * @author timmolter
  */
-public class XChartPanel<T extends Chart> extends JPanel {
+public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
 
   private final T chart;
   private final Dimension preferredSize;


### PR DESCRIPTION
Raw types cause problems for use of this library from more strongly typed languages like the upcoming Scala 3. And avoiding raw types also improves type checking in Java.