### PR TITLE
Easier way to run the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,18 @@ Download [`google-java-format-eclipse-plugin_*.jar`](https://github.com/google/g
 
 In the plugins section in IntelliJ search for `google-java-format` and install the plugin. Restart IntelliJ.
 
-## Running Demo
+## Running Demo - option 1 - using released version
+
+- Linux: execute command `java -cp xchart-demo-3.8.0.jar:xchart-3.8.0.jar org.knowm.xchart.demo.XChartDemo`.
+
+- Windows: In the cmd command window, execute the command `java -cp xchart-demo-3.8.0.jar;xchart-3.8.0.jar org.knowm.xchart.demo.XChartDemo`; In the PowerShell command window, execute the command `java -cp "xchart-demo-3.8.0.jar;xchart-3.8.0.jar" org.knowm.xchart.demo.XChartDemo`.
+
+E.g:
+```sh
+cd /path/to/xchart-demo/jar/
+java -cp xchart-demo-3.8.0.jar:xchart-3.8.0.jar org.knowm.xchart.demo.XChartDemo
+
+## Running Demo - option 2 - building yourself
 
 ```
 mvn install

--- a/README.md
+++ b/README.md
@@ -595,14 +595,9 @@ In the plugins section in IntelliJ search for `google-java-format` and install t
 
 ## Running Demo
 
-- Linux: execute command `java -cp xchart-demo-3.8.0.jar:xchart-3.8.0.jar org.knowm.xchart.demo.XChartDemo`.
-
-- Windows: In the cmd command window, execute the command `java -cp xchart-demo-3.8.0.jar;xchart-3.8.0.jar org.knowm.xchart.demo.XChartDemo`; In the PowerShell command window, execute the command `java -cp "xchart-demo-3.8.0.jar;xchart-3.8.0.jar" org.knowm.xchart.demo.XChartDemo`.
-
-E.g:
-```sh
-cd /path/to/xchart-demo/jar/
-java -cp xchart-demo-3.8.0.jar:xchart-3.8.0.jar org.knowm.xchart.demo.XChartDemo
+```
+mvn install
+mvn exec:java -Djava.awt.headless=false -pl xchart-demo -Dexec.mainClass=org.knowm.xchart.demo.XChartDemo
 ```
 
 ![](https://raw.githubusercontent.com/knowm/XChart/develop/etc/XChart_Demo.png)


### PR DESCRIPTION
Changing the `README.md` to simplify instructions on how to run the demo. They (the same text) should work in different platforms (Windows / Linux / OSX / others).
Also they no longer hard-code the version, so people can run just the latest.