### PR TITLE
Adding back Maven options for install

### DIFF
--- a/.github/workflows/maven_on_push.yml
+++ b/.github/workflows/maven_on_push.yml
@@ -20,7 +20,7 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
     - name: Build with Maven
-      run: mvn clean install --settings etc/settings.xml -Dfmt.skip=true
+      run: mvn clean install --no-transfer-progress --batch-mode --settings etc/settings.xml -Dfmt.skip=true
     - name: Deploy with Maven
       run: mvn clean deploy --no-transfer-progress --batch-mode --settings etc/settings.xml -Dfmt.skip=true;
       if: github.repository_owner == 'knowm'


### PR DESCRIPTION
After #637 the test output of Github action for `develop` branch is extremely verbose and thus it makes analyzing failing builds harder.
Adding the options back which I skipped when calling `mvn install` (because I thought pertained to the deploy, not downloading artifacts).