### PR TITLE
Fix window issue when parent is modal

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -241,7 +241,7 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
 
     fileChooser.setFileFilter(pngFileFilter);
 
-    if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
+    if (fileChooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {
 
       if (fileChooser.getSelectedFile() != null) {
         File theFileToSave = fileChooser.getSelectedFile();
@@ -304,7 +304,7 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
     fileChooser.setAcceptAllFileFilterUsed(false);
     fileChooser.setDialogTitle("Export");
 
-    if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
+    if (fileChooser.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {
 
       File theFileToSave = null;
       if (fileChooser.getSelectedFile() != null) {


### PR DESCRIPTION
This happens when XChartPanel is displayed in a modal window. The JFileChooser window remains hidden when you click next to it.

The JFileChooser also becomes modal when it is initialized with XChartPanel as a parent.