### PR TITLE
Introducing project.junit.jupiter.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,13 +92,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.1</version>
+            <version>${project.junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.9.1</version>
+            <version>${project.junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -259,6 +259,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.junit.jupiter.version>5.9.2</project.junit.jupiter.version>
     </properties>
 
 </project>


### PR DESCRIPTION
What: Introducing `project.junit.jupiter.version` in pom.xml

Why: That is to keep the versions of multiple artifacts in Junit project in sync. I.e. to prevent @dependabot-bot from suggesting #752, #751 separately.