### PR TITLE
Renaming the test class to fit the *Test.java pattern

### DIFF
--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue536Test.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue536Test.java
@@ -16,10 +16,10 @@ import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.markers.SeriesMarkers;
 
 /** Regression test for <a href="https://github.com/knowm/XChart/issues/536">issue 536</a>. */
-public class RegressionTestIssue527 {
+public class RegressionIssue536Test {
 
   @Test
-  public void issue546RegressionTest() throws Exception {
+  public void issue536RegressionTest() throws Exception {
 
     String series = "ABC";
 


### PR DESCRIPTION
Renaming the test class without changing its logic.
Without it, the test is not executed with `mvn test` as it doesn't follow the `*Test.java` naming pattern.

Also fixing the issue reference. I think #536 was meant.