### PR TITLE
Refactoring: extracting AxisTickCalculator interface

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/HeatMapSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/HeatMapSeries.java
@@ -122,17 +122,17 @@ public class HeatMapSeries extends AxesChartSeries {
     return axisType;
   }
 
-  public Collection<?> getXData() {
+  public List<?> getXData() {
 
     return xData;
   }
 
-  public Collection<?> getYData() {
+  public List<?> getYData() {
 
     return yData;
   }
 
-  public Collection<? extends Number[]> getHeatData() {
+  public List<? extends Number[]> getHeatData() {
 
     return heatData;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator.java
@@ -1,0 +1,12 @@
+package org.knowm.xchart.internal.chartpart;
+
+import java.text.Format;
+import java.util.List;
+
+public interface AxisTickCalculator {
+  List<Double> getTickLocations();
+
+  List<String> getTickLabels();
+
+  Format getAxisFormat();
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_.java
@@ -23,7 +23,7 @@ import org.knowm.xchart.style.Styler;
 /**
  * @author timmolter
  */
-public abstract class AxisTickCalculator_ {
+public abstract class AxisTickCalculator_ implements AxisTickCalculator {
 
   /** the List of tick label position in pixels */
   final List<Double> tickLocations = new LinkedList<>();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
@@ -58,9 +58,9 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
     int x = 0;
     int y = 0;
     Number value = 0.0;
-    List<? extends Number[]> list = (List<? extends Number[]>) series.getHeatData();
-    List<?> xData = (List<?>) series.getXData();
-    List<?> yData = (List<?>) series.getYData();
+    List<? extends Number[]> list = series.getHeatData();
+    List<?> xData = series.getXData();
+    List<?> yData = series.getYData();
     double plotContentBoundsWidth = plotContentBounds.getWidth();
     double plotContentBoundsHeight = plotContentBounds.getHeight();
     double rectWidth = (plotContentBoundsWidth - 2 * xLeftMargin) / xData.size();

--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue536Test.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue536Test.java
@@ -80,7 +80,8 @@ public class RegressionIssue536Test {
     assertThat(tickLabels.size()).isEqualTo(13);
     assertThat(tickLabels.get(0)).isEqualTo("10-18");
     boolean areAllLabelsUnique =
-        chart.axisPair.getXAxis().getAxisTickCalculator().areAllTickLabelsUnique(tickLabels);
+        ((AxisTickCalculator_Date) chart.axisPair.getXAxis().getAxisTickCalculator())
+            .areAllTickLabelsUnique(tickLabels);
     assertThat(areAllLabelsUnique).isEqualTo(true);
   }
 }


### PR DESCRIPTION
First step towards cleaning up the code in multiple subclasses of `AxisTickCalculator_`.
Making the contract of `AxisTickCalculator` clear.
The calculations should be immutable (not yet) data structures with just the results of the calculation.
