### PR TITLE
Fix missing x-Axis on 1D Timeframe

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Date.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Date.java
@@ -190,7 +190,8 @@ class AxisTickCalculator_Date extends AxisTickCalculator_ {
     // now increase the timespan until one is found where all the labels fit nicely. It will often
     // be the first one.
     index--;
-    boolean skip;
+    int fallbackindex = index;
+    boolean skip, force = false;
     do {
       skip = false;
 
@@ -242,9 +243,14 @@ class AxisTickCalculator_Date extends AxisTickCalculator_ {
         // }
       }
       //      System.out.println("************");
-      if (index >= timeSpans.size() - 1)
-        break; // We reached the end, even though we might not yet have the result we want,
-      // continuing will lead to an Exception!
+      if (index >= timeSpans.size() - 1) {
+        // Nothing matches, as mentioned above, first one is usually the best fit, force it!
+        force = true;
+        index = fallbackindex;
+        continue; // We can't exit just yet, we need to do the calculations above again
+      }
+      if (force)
+        break; // We don't care anymore if it's a match or not, just use it
     } while (skip
         || !areAllTickLabelsUnique(tickLabels)
         || !willLabelsFitInTickSpaceHint(tickLabels, gridStepInChartSpace));


### PR DESCRIPTION
Unfortunately the fix from #717 caused the Axis to disappear in certain cases (for example when a Timeframe of 1d was used). This fix is better as it goes back to the first attempt and then ignores if the labels are not unique. It is mentioned in the code that usually the first one works alright, so in case we didn't find anything better we should use the first one as a fallback and not the last one as in my original fix.