### PR TITLE
Allow having stacked and overlapped category series

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart12.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart12.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 Energía Plus. All rights reserved.
+ */
+
+package org.knowm.xchart.demo.charts.bar;
+
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.demo.charts.ExampleChart;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Stacked Bars with Overlapped Line Chart
+ *
+ * <p>Demonstrates the following:
+ *
+ * <ul>
+ *   <li>bar series are stacked
+ *   <li>line series is overlapped
+ */
+public class BarChart12 implements ExampleChart<CategoryChart> {
+
+  public static void main(String[] args) {
+
+    ExampleChart<CategoryChart> exampleChart = new BarChart12();
+    CategoryChart chart = exampleChart.getChart();
+    new SwingWrapper<>(chart).displayChart();
+  }
+
+  private static List<Double> getRandomValues(int count) {
+
+    List<Double> values = new ArrayList<>(count);
+    Random rand = new Random();
+    for (int i = 0; i < count; i++) {
+      values.add(rand.nextDouble() * 1000);
+    }
+    return values;
+  }
+
+  @Override
+  public CategoryChart getChart() {
+
+    // Create Chart
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(800)
+            .height(600)
+            .title(getClass().getSimpleName())
+            .xAxisTitle("Quarter")
+            .yAxisTitle("Sales")
+            .build();
+
+    // Customize Chart
+    chart.getStyler().setPlotGridVerticalLinesVisible(false);
+    chart.getStyler().setLegendVisible(true);
+    chart.getStyler().setStacked(true);
+    chart
+        .getStyler()
+        .setSeriesColors(new Color[] {Color.RED, Color.ORANGE, Color.YELLOW, Color.DARK_GRAY});
+
+    List<Double> applesValues = getRandomValues(4);
+    List<Double> orangesValues = getRandomValues(4);
+    List<Double> lemonsValues = getRandomValues(4);
+    List<Double> averageValues = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      averageValues.add((applesValues.get(i) + orangesValues.get(i) + lemonsValues.get(i)) / 3);
+    }
+
+    // Series
+    CategorySeries staked1 =
+        chart.addSeries(
+            "Apples", Arrays.asList("1Q", "2Q", "3Q", "4Q"), applesValues);
+    CategorySeries staked2 =
+        chart.addSeries(
+            "Oranges", Arrays.asList("1Q", "2Q", "3Q", "4Q"), orangesValues);
+    CategorySeries staked3 =
+        chart.addSeries(
+            "Lemons", Arrays.asList("1Q", "2Q", "3Q", "4Q"), lemonsValues);
+    CategorySeries overlappedLine =
+        chart.addSeries(
+            "Average", Arrays.asList("1Q", "2Q", "3Q", "4Q"), averageValues);
+    overlappedLine.setOverlapped(true);
+    overlappedLine.setChartCategorySeriesRenderStyle(CategorySeries.CategorySeriesRenderStyle.Line);
+
+    return chart;
+  }
+
+  @Override
+  public String getExampleChartName() {
+
+    return getClass().getSimpleName() + " - Stacked Bars with Overlapped Line Chart";
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart12.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart12.java
@@ -34,6 +34,11 @@ public class BarChart12 implements ExampleChart<CategoryChart> {
     new SwingWrapper<>(chart).displayChart();
   }
 
+  private static List<String> getMonths() {
+    return Arrays.asList(
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec");
+  }
+
   private static List<Double> getRandomValues(int count) {
 
     List<Double> values = new ArrayList<>(count);
@@ -53,8 +58,8 @@ public class BarChart12 implements ExampleChart<CategoryChart> {
             .width(800)
             .height(600)
             .title(getClass().getSimpleName())
-            .xAxisTitle("Quarter")
-            .yAxisTitle("Sales")
+            .xAxisTitle("Month")
+            .yAxisTitle("Consumption")
             .build();
 
     // Customize Chart
@@ -63,29 +68,28 @@ public class BarChart12 implements ExampleChart<CategoryChart> {
     chart.getStyler().setStacked(true);
     chart
         .getStyler()
-        .setSeriesColors(new Color[] {Color.RED, Color.ORANGE, Color.YELLOW, Color.DARK_GRAY});
+        .setSeriesColors(
+            new Color[] {
+              Color.decode("#2133D0"),
+              Color.decode("#FF3B47"),
+              Color.decode("#FFBD00"),
+              Color.DARK_GRAY
+            });
 
-    List<Double> applesValues = getRandomValues(4);
-    List<Double> orangesValues = getRandomValues(4);
-    List<Double> lemonsValues = getRandomValues(4);
+    List<String> months = getMonths();
+    List<Double> period1Values = getRandomValues(12);
+    List<Double> period2Values = getRandomValues(12);
+    List<Double> period3Values = getRandomValues(12);
     List<Double> averageValues = new ArrayList<>();
-    for (int i = 0; i < 4; i++) {
-      averageValues.add((applesValues.get(i) + orangesValues.get(i) + lemonsValues.get(i)) / 3);
+    for (int i = 0; i < 12; i++) {
+      averageValues.add((period1Values.get(i) + period2Values.get(i) + period3Values.get(i)) / 3);
     }
 
     // Series
-    CategorySeries staked1 =
-        chart.addSeries(
-            "Apples", Arrays.asList("1Q", "2Q", "3Q", "4Q"), applesValues);
-    CategorySeries staked2 =
-        chart.addSeries(
-            "Oranges", Arrays.asList("1Q", "2Q", "3Q", "4Q"), orangesValues);
-    CategorySeries staked3 =
-        chart.addSeries(
-            "Lemons", Arrays.asList("1Q", "2Q", "3Q", "4Q"), lemonsValues);
-    CategorySeries overlappedLine =
-        chart.addSeries(
-            "Average", Arrays.asList("1Q", "2Q", "3Q", "4Q"), averageValues);
+    CategorySeries staked1 = chart.addSeries("Period 1", months, period1Values);
+    CategorySeries staked2 = chart.addSeries("Period 2", months, period2Values);
+    CategorySeries staked3 = chart.addSeries("Period 3", months, period3Values);
+    CategorySeries overlappedLine = chart.addSeries("Average", months, averageValues);
     overlappedLine.setOverlapped(true);
     overlappedLine.setChartCategorySeriesRenderStyle(CategorySeries.CategorySeriesRenderStyle.Line);
 

--- a/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
@@ -9,6 +9,8 @@ import org.knowm.xchart.internal.series.Series;
 /** A Series containing category data to be plotted on a Chart */
 public class CategorySeries extends AxesChartSeriesCategory {
 
+  private boolean isOverlapped = false;
+
   private CategorySeriesRenderStyle chartCategorySeriesRenderStyle = null;
 
   /**
@@ -39,6 +41,15 @@ public class CategorySeries extends AxesChartSeriesCategory {
       CategorySeriesRenderStyle categorySeriesRenderStyle) {
 
     this.chartCategorySeriesRenderStyle = categorySeriesRenderStyle;
+    return this;
+  }
+
+  public boolean isOverlapped() {
+    return isOverlapped;
+  }
+
+  public CategorySeries setOverlapped(boolean overlapped) {
+    isOverlapped = overlapped;
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -174,7 +174,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
               } else {
                 yBottom = y;
               }
-              if (stylerCategory.isStacked()) {
+              if (stylerCategory.isStacked() && !series.isOverlapped()) {
                 yTop += accumulatedStackOffsetPos[categoryCounter];
                 yBottom += accumulatedStackOffsetPos[categoryCounter];
                 accumulatedStackOffsetPos[categoryCounter] += (yTop - yBottom);
@@ -190,7 +190,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
                 // yBottom.
               }
               yBottom = y;
-              if (stylerCategory.isStacked()) {
+              if (stylerCategory.isStacked() && !series.isOverlapped()) {
                 yTop -= accumulatedStackOffsetNeg[categoryCounter];
                 yBottom -= accumulatedStackOffsetNeg[categoryCounter];
                 accumulatedStackOffsetNeg[categoryCounter] += (yTop - yBottom);


### PR DESCRIPTION
This simple change allows having overlapped series combined with stacked series on a CategoryChart to allow charts like the example below:

![example](https://github.com/knowm/XChart/assets/5601167/061f9772-6df0-4a83-bc17-a77db984dbb1)
