### PR TITLE
Make all the setters in Styler classes return 'this' to easier chain calls together

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart05.java
@@ -29,7 +29,7 @@ public class HeatMapChart05 implements ExampleChart<HeatMapChart> {
 
     ExampleChart<HeatMapChart> exampleChart = new HeatMapChart05();
     HeatMapChart chart = exampleChart.getChart();
-    new SwingWrapper<HeatMapChart>(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 
   @Override
@@ -45,18 +45,21 @@ public class HeatMapChart05 implements ExampleChart<HeatMapChart> {
             .yAxisTitle("Working day")
             .build();
 
-    chart.getStyler().setPlotContentSize(0.999);
-    chart.getStyler().setLegendFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
-    chart.getStyler().setToolTipsEnabled(true);
-    chart.getStyler().setPiecewise(true);
-    chart.getStyler().setPiecewiseRanged(false);
-    chart.getStyler().setShowValue(true);
-    chart.getStyler().setHeatMapDecimalValueFormatter(x -> "\u2265 " + x);
+    chart.getStyler()
+            .setPlotContentSize(0.999)
+            .setLegendFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12))
+            .setToolTipsEnabled(true);
+    chart
+        .getStyler()
+        .setPiecewise(true)
+        .setPiecewiseRanged(false)
+        .setShowValue(true)
+        .setHeatMapDecimalValueFormatter(x -> "\u2265 " + x);
 
     Color[] rangeColors = {Color.YELLOW, Color.CYAN, Color.GREEN, Color.BLUE, Color.RED};
     chart.getStyler().setRangeColors(rangeColors);
 
-    List<String> xData = new ArrayList<String>();
+    List<String> xData = new ArrayList<>();
     xData.add("Tim");
     xData.add("Tom");
     xData.add("Lida");
@@ -65,10 +68,10 @@ public class HeatMapChart05 implements ExampleChart<HeatMapChart> {
     xData.add("Lukas");
     xData.add("Marie");
 
-    List<String> yData = new ArrayList<String>();
+    List<String> yData = new ArrayList<>();
     yData.add("Monday");
     yData.add("Tuesday");
-    yData.add("Wedesday");
+    yData.add("Wednesday");
     yData.add("Thursday");
     yData.add("Friday");
 

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -532,9 +532,10 @@ public abstract class AxesChartStyler extends Styler {
     return xAxisMaxLabelCount;
   }
 
-  public void setXAxisMaxLabelCount(int xAxisMaxLabelCount) {
+  public AxesChartStyler setXAxisMaxLabelCount(int xAxisMaxLabelCount) {
 
     this.xAxisMaxLabelCount = xAxisMaxLabelCount;
+    return this;
   }
 
   // Chart Plot Area ///////////////////////////////
@@ -795,18 +796,20 @@ public abstract class AxesChartStyler extends Styler {
     return xAxisTickLabelsFormattingFunction;
   }
 
-  public void setxAxisTickLabelsFormattingFunction(
+  public AxesChartStyler setxAxisTickLabelsFormattingFunction(
       Function<Double, String> xAxisTickLabelsFormattingFunction) {
     this.xAxisTickLabelsFormattingFunction = xAxisTickLabelsFormattingFunction;
+    return this;
   }
 
   public Function<Double, String> getyAxisTickLabelsFormattingFunction() {
     return yAxisTickLabelsFormattingFunction;
   }
 
-  public void setyAxisTickLabelsFormattingFunction(
+  public AxesChartStyler setyAxisTickLabelsFormattingFunction(
       Function<Double, String> yAxisTickLabelsFormattingFunction) {
     this.yAxisTickLabelsFormattingFunction = yAxisTickLabelsFormattingFunction;
+    return this;
   }
 
   // TickLabels and MarksColor colors for xAxis, yAxis, yAxisGroup ////////////////////////////////
@@ -903,9 +906,10 @@ public abstract class AxesChartStyler extends Styler {
     return xAxisLabelAlignment;
   }
 
-  public void setXAxisLabelAlignment(TextAlignment xAxisLabelAlignment) {
+  public AxesChartStyler setXAxisLabelAlignment(TextAlignment xAxisLabelAlignment) {
 
     this.xAxisLabelAlignment = xAxisLabelAlignment;
+    return this;
   }
 
   public TextAlignment getXAxisLabelAlignmentVertical() {
@@ -913,9 +917,10 @@ public abstract class AxesChartStyler extends Styler {
     return xAxisLabelAlignmentVertical;
   }
 
-  public void setXAxisLabelAlignmentVertical(TextAlignment xAxisLabelAlignmentVertical) {
+  public AxesChartStyler setXAxisLabelAlignmentVertical(TextAlignment xAxisLabelAlignmentVertical) {
 
     this.xAxisLabelAlignmentVertical = xAxisLabelAlignmentVertical;
+    return this;
   }
 
   public TextAlignment getYAxisLabelAlignment() {

--- a/xchart/src/main/java/org/knowm/xchart/style/BoxStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/BoxStyler.java
@@ -24,9 +24,10 @@ public class BoxStyler extends AxesChartStyler {
     return boxplotCalCulationMethod;
   }
 
-  public void setBoxplotCalCulationMethod(BoxplotCalCulationMethod boxplotCalCulationMethod) {
+  public BoxStyler setBoxplotCalCulationMethod(BoxplotCalCulationMethod boxplotCalCulationMethod) {
 
     this.boxplotCalCulationMethod = boxplotCalCulationMethod;
+    return this;
   }
 
   /** Box plot calculation method, method for determining the position of the quartile */

--- a/xchart/src/main/java/org/knowm/xchart/style/HeatMapStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/HeatMapStyler.java
@@ -74,14 +74,15 @@ public class HeatMapStyler extends AxesChartStyler {
   }
 
   @Override
-  public Styler setLegendPosition(LegendPosition legendPosition) {
+  public HeatMapStyler setLegendPosition(LegendPosition legendPosition) {
 
     if (!LegendPosition.OutsideE.equals(legendPosition)
         && !LegendPosition.OutsideS.equals(legendPosition)) {
       throw new IllegalArgumentException(
           "HeatMapStyler LegendPosition must be OutsideE or OutsideS!!!");
     }
-    return super.setLegendPosition(legendPosition);
+    super.setLegendPosition(legendPosition);
+    return this;
   }
 
   public boolean isPiecewise() {
@@ -233,19 +234,21 @@ public class HeatMapStyler extends AxesChartStyler {
     return heatMapDecimalValueFormatter;
   }
 
-  public void setHeatMapDecimalValueFormatter(
+  public HeatMapStyler setHeatMapDecimalValueFormatter(
       Function<Double, String> heatMapDecimalValueFormatter) {
     this.heatMapDecimalValueFormatter = heatMapDecimalValueFormatter;
+    return this;
   }
 
   public boolean isPiecewiseRanged() {
     return isPiecewiseRanged;
   }
 
-  public void setPiecewiseRanged(boolean piecewiseRanged) {
+  public HeatMapStyler setPiecewiseRanged(boolean piecewiseRanged) {
     if (piecewiseRanged) {
       setPiecewise(true);
     }
     isPiecewiseRanged = piecewiseRanged;
+    return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -121,9 +121,10 @@ public class PieStyler extends Styler {
    *
    * @param labelsDistance
    */
-  public void setLabelsDistance(double labelsDistance) {
+  public PieStyler setLabelsDistance(double labelsDistance) {
 
     this.labelsDistance = labelsDistance;
+    return this;
   }
 
   public LabelType getLabelType() {

--- a/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
@@ -117,9 +117,10 @@ public class RadarStyler extends Styler {
     return radiiTicksMarksVisible;
   }
 
-  public void setRadiiTicksMarksVisible(boolean radiiTicksMarksVisible) {
+  public RadarStyler setRadiiTicksMarksVisible(boolean radiiTicksMarksVisible) {
 
     this.radiiTicksMarksVisible = radiiTicksMarksVisible;
+    return this;
   }
 
   public Color getRadiiTickMarksColor() {
@@ -127,9 +128,10 @@ public class RadarStyler extends Styler {
     return radiiTickMarksColor;
   }
 
-  public void setRadiiTickMarksColor(Color radiiTickMarksColor) {
+  public RadarStyler setRadiiTickMarksColor(Color radiiTickMarksColor) {
 
     this.radiiTickMarksColor = radiiTickMarksColor;
+    return this;
   }
 
   public BasicStroke getRadiiTickMarksStroke() {
@@ -137,9 +139,10 @@ public class RadarStyler extends Styler {
     return radiiTickMarksStroke;
   }
 
-  public void setRadiiTickMarksStroke(BasicStroke radiiTickMarksStroke) {
+  public RadarStyler setRadiiTickMarksStroke(BasicStroke radiiTickMarksStroke) {
 
     this.radiiTickMarksStroke = radiiTickMarksStroke;
+    return this;
   }
 
   public boolean isRadiiTitleVisible() {
@@ -147,9 +150,10 @@ public class RadarStyler extends Styler {
     return isRadiiTitleVisible;
   }
 
-  public void setRadiiTitleVisible(boolean radiiTitleVisible) {
+  public RadarStyler setRadiiTitleVisible(boolean radiiTitleVisible) {
 
     this.isRadiiTitleVisible = radiiTitleVisible;
+    return this;
   }
 
   public Font getRadiiTitleFont() {
@@ -157,9 +161,10 @@ public class RadarStyler extends Styler {
     return radiiTitleFont;
   }
 
-  public void setRadiiTitleFont(Font radiiTitleFont) {
+  public RadarStyler setRadiiTitleFont(Font radiiTitleFont) {
 
     this.radiiTitleFont = radiiTitleFont;
+    return this;
   }
 
   public int getRadiiTitlePadding() {
@@ -167,9 +172,10 @@ public class RadarStyler extends Styler {
     return radiiTitlePadding;
   }
 
-  public void setRadiiTitlePadding(int radiiTitlePadding) {
+  public RadarStyler setRadiiTitlePadding(int radiiTitlePadding) {
 
     this.radiiTitlePadding = radiiTitlePadding;
+    return this;
   }
 
   public int getRadiiTickMarksCount() {
@@ -177,9 +183,10 @@ public class RadarStyler extends Styler {
     return radiiTickMarksCount;
   }
 
-  public void setRadiiTickMarksCount(int radiiTickMarksCount) {
+  public RadarStyler setRadiiTickMarksCount(int radiiTickMarksCount) {
 
     this.radiiTickMarksCount = radiiTickMarksCount;
+    return this;
   }
 
   public boolean isSeriesFilled() {
@@ -187,9 +194,10 @@ public class RadarStyler extends Styler {
     return isSeriesFilled;
   }
 
-  public void setSeriesFilled(boolean seriesFilled) {
+  public RadarStyler setSeriesFilled(boolean seriesFilled) {
 
     this.isSeriesFilled = seriesFilled;
+    return this;
   }
 
   public RadarRenderStyle getRadarRenderStyle() {
@@ -197,9 +205,10 @@ public class RadarStyler extends Styler {
     return radarRenderStyle;
   }
 
-  public void setRadarRenderStyle(RadarRenderStyle radarRenderStyle) {
+  public RadarStyler setRadarRenderStyle(RadarRenderStyle radarRenderStyle) {
 
     this.radarRenderStyle = radarRenderStyle;
+    return this;
   }
 
   public enum RadarRenderStyle {

--- a/xchart/src/main/java/org/knowm/xchart/style/XYStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/XYStyler.java
@@ -90,7 +90,7 @@ public class XYStyler extends AxesChartStyler {
     return isZoomEnabled;
   }
 
-  public Styler setZoomEnabled(boolean isZoomEnabled) {
+  public XYStyler setZoomEnabled(boolean isZoomEnabled) {
 
     this.isZoomEnabled = isZoomEnabled;
     return this;
@@ -101,9 +101,10 @@ public class XYStyler extends AxesChartStyler {
     return zoomSelectionColor;
   }
 
-  public void setZoomSelectionColor(Color zoomSelectionColor) {
+  public XYStyler setZoomSelectionColor(Color zoomSelectionColor) {
 
     this.zoomSelectionColor = zoomSelectionColor;
+    return this;
   }
 
   public boolean isZoomResetByDoubleClick() {
@@ -111,9 +112,10 @@ public class XYStyler extends AxesChartStyler {
     return zoomResetByDoubleClick;
   }
 
-  public void setZoomResetByDoubleClick(boolean zoomResetByDoubleClick) {
+  public XYStyler setZoomResetByDoubleClick(boolean zoomResetByDoubleClick) {
 
     this.zoomResetByDoubleClick = zoomResetByDoubleClick;
+    return this;
   }
 
   public boolean isZoomResetByButton() {
@@ -121,9 +123,10 @@ public class XYStyler extends AxesChartStyler {
     return zoomResetByButton;
   }
 
-  public void setZoomResetByButton(boolean zoomResetByButton) {
+  public XYStyler setZoomResetByButton(boolean zoomResetByButton) {
 
     this.zoomResetByButton = zoomResetByButton;
+    return this;
   }
 
   // Cursor ///////////////////////////////
@@ -132,7 +135,7 @@ public class XYStyler extends AxesChartStyler {
     return isCursorEnabled;
   }
 
-  public Styler setCursorEnabled(boolean isCursorEnabled) {
+  public XYStyler setCursorEnabled(boolean isCursorEnabled) {
 
     this.isCursorEnabled = isCursorEnabled;
     return this;
@@ -142,7 +145,7 @@ public class XYStyler extends AxesChartStyler {
     return cursorColor;
   }
 
-  public Styler setCursorColor(Color cursorColor) {
+  public XYStyler setCursorColor(Color cursorColor) {
 
     this.cursorColor = cursorColor;
     return this;
@@ -153,7 +156,7 @@ public class XYStyler extends AxesChartStyler {
     return cursorLineWidth;
   }
 
-  public Styler setCursorLineWidth(float cursorLineWidth) {
+  public XYStyler setCursorLineWidth(float cursorLineWidth) {
 
     this.cursorLineWidth = cursorLineWidth;
     return this;
@@ -164,7 +167,7 @@ public class XYStyler extends AxesChartStyler {
     return cursorFont;
   }
 
-  public Styler setCursorFont(Font cursorFont) {
+  public XYStyler setCursorFont(Font cursorFont) {
 
     this.cursorFont = cursorFont;
     return this;
@@ -175,7 +178,7 @@ public class XYStyler extends AxesChartStyler {
     return cursorFontColor;
   }
 
-  public Styler setCursorFontColor(Color cursorFontColor) {
+  public XYStyler setCursorFontColor(Color cursorFontColor) {
 
     this.cursorFontColor = cursorFontColor;
     return this;
@@ -186,7 +189,7 @@ public class XYStyler extends AxesChartStyler {
     return cursorBackgroundColor;
   }
 
-  public Styler setCursorBackgroundColor(Color cursorBackgroundColor) {
+  public XYStyler setCursorBackgroundColor(Color cursorBackgroundColor) {
 
     this.cursorBackgroundColor = cursorBackgroundColor;
     return this;
@@ -201,9 +204,10 @@ public class XYStyler extends AxesChartStyler {
    *
    * @param customCursorXDataFormattingFunction
    */
-  public void setCustomCursorXDataFormattingFunction(
+  public XYStyler setCustomCursorXDataFormattingFunction(
       Function<Double, String> customCursorXDataFormattingFunction) {
     this.customCursorXDataFormattingFunction = customCursorXDataFormattingFunction;
+    return this;
   }
 
   public Function<Double, String> getCustomCursorYDataFormattingFunction() {
@@ -215,8 +219,9 @@ public class XYStyler extends AxesChartStyler {
    *
    * @param customCursorYDataFormattingFunction
    */
-  public void setCustomCursorYDataFormattingFunction(
+  public XYStyler setCustomCursorYDataFormattingFunction(
       Function<Double, String> customCursorYDataFormattingFunction) {
     this.customCursorYDataFormattingFunction = customCursorYDataFormattingFunction;
+    return this;
   }
 }


### PR DESCRIPTION
While working with the stylers, noticed only some of the setters returned 'this' so could chain the calls together. Updated all of them to do so, and changed some to return more specific class type.