### PR TITLE
Give the possibility to supply a custom label generator for pie charts

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.demo.charts.pie;
 import java.awt.Color;
 import java.util.Collection;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.knowm.xchart.PieChart;
 import org.knowm.xchart.PieChartBuilder;
@@ -39,11 +40,13 @@ public class PieChart02 implements ExampleChart<PieChart> {
         new PieChartBuilder().width(800).height(600).title(getClass().getSimpleName()).build();
 
     // Series
-    chart.addSeries("Gold", 24);
-    chart.addSeries("Silver", 21);
-    chart.addSeries("Platinum", 39);
-    chart.addSeries("Copper", 17);
-    chart.addSeries("Zinc", 40);
+    int total = Stream.of(
+            chart.addSeries("Gold", 24),
+            chart.addSeries("Silver", 21),
+            chart.addSeries("Platinum", 39),
+            chart.addSeries("Copper", 17),
+            chart.addSeries("Zinc", 40)
+    ).map(PieSeries::getValue).mapToInt(Number::intValue).sum();
 
     // Customize Chart
     Color[] sliceColors =
@@ -55,7 +58,7 @@ public class PieChart02 implements ExampleChart<PieChart> {
           new Color(246, 199, 182)
         };
     chart.getStyler().setSeriesColors(sliceColors);
-    chart.getStyler().setCustomSeriesLabelFunction(generateSeriesLabel(chart.getSeriesMap().values()));
+    chart.getStyler().setCustomSeriesLabelFunction(generateSeriesLabel(total));
     // chart.getStyler().setDecimalPattern("#0.000");
     chart.getStyler().setToolTipsEnabled(true);
     //    chart.getStyler().setToolTipsAlwaysVisible(true);
@@ -69,8 +72,7 @@ public class PieChart02 implements ExampleChart<PieChart> {
     return getClass().getSimpleName() + " - Pie Chart Custom Color Palette";
   }
 
-    private Function<PieSeries, String> generateSeriesLabel(Collection<PieSeries> values) {
-      double total = values.stream().map(PieSeries::getValue).mapToDouble(Number::doubleValue).sum();
+    private Function<PieSeries, String> generateSeriesLabel(int total) {
       return pieSeries -> {
         double percent = (pieSeries.getValue().doubleValue() / total) * 100;
         return String.format("%s (%.2f%%)", pieSeries.getValue(), percent);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
@@ -1,11 +1,14 @@
 package org.knowm.xchart.demo.charts.pie;
 
 import java.awt.Color;
+import java.util.Collection;
+import java.util.function.Function;
+
 import org.knowm.xchart.PieChart;
 import org.knowm.xchart.PieChartBuilder;
+import org.knowm.xchart.PieSeries;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.demo.charts.ExampleChart;
-import org.knowm.xchart.style.PieStyler.LabelType;
 
 /**
  * Pie Chart Custom Color Palette
@@ -35,6 +38,13 @@ public class PieChart02 implements ExampleChart<PieChart> {
     PieChart chart =
         new PieChartBuilder().width(800).height(600).title(getClass().getSimpleName()).build();
 
+    // Series
+    chart.addSeries("Gold", 24);
+    chart.addSeries("Silver", 21);
+    chart.addSeries("Platinum", 39);
+    chart.addSeries("Copper", 17);
+    chart.addSeries("Zinc", 40);
+
     // Customize Chart
     Color[] sliceColors =
         new Color[] {
@@ -45,17 +55,10 @@ public class PieChart02 implements ExampleChart<PieChart> {
           new Color(246, 199, 182)
         };
     chart.getStyler().setSeriesColors(sliceColors);
-    chart.getStyler().setLabelType(LabelType.Value);
+    chart.getStyler().setCustomSeriesLabelFunction(generateSeriesLabel(chart.getSeriesMap().values()));
     // chart.getStyler().setDecimalPattern("#0.000");
     chart.getStyler().setToolTipsEnabled(true);
     //    chart.getStyler().setToolTipsAlwaysVisible(true);
-
-    // Series
-    chart.addSeries("Gold", 24);
-    chart.addSeries("Silver", 21);
-    chart.addSeries("Platinum", 39);
-    chart.addSeries("Copper", 17);
-    chart.addSeries("Zinc", 40);
 
     return chart;
   }
@@ -65,4 +68,12 @@ public class PieChart02 implements ExampleChart<PieChart> {
 
     return getClass().getSimpleName() + " - Pie Chart Custom Color Palette";
   }
+
+    private Function<PieSeries, String> generateSeriesLabel(Collection<PieSeries> values) {
+      double total = values.stream().map(PieSeries::getValue).mapToDouble(Number::doubleValue).sum();
+      return pieSeries -> {
+        double percent = (pieSeries.getValue().doubleValue() / total) * 100;
+        return String.format("%s (%.2f%%)", pieSeries.getValue(), percent);
+      };
+    }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -290,6 +290,8 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
           } else {
             label = series.getName() + " (" + y.toString() + ")";
           }
+        } else if (pieStyler.getCustomSeriesLabelFunction() != null) {
+          label = pieStyler.getCustomSeriesLabelFunction().apply(series);
         }
 
         TextLayout textLayout =

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -2,6 +2,9 @@ package org.knowm.xchart.style;
 
 import java.awt.Color;
 import java.awt.Font;
+import java.util.function.Function;
+
+import org.knowm.xchart.PieSeries;
 import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
 import org.knowm.xchart.style.colors.FontColorDetector;
 import org.knowm.xchart.style.theme.Theme;
@@ -25,6 +28,7 @@ public class PieStyler extends Styler {
   private Color labelsFontColor;
   private double labelsDistance;
   private LabelType labelType;
+  private Function<PieSeries, String> customSeriesLabelFunction;
   private boolean isForceAllLabelsVisible;
   private boolean isLabelsFontColorAutomaticEnabled;
   private Color labelsFontColorAutomaticLight;
@@ -140,6 +144,21 @@ public class PieStyler extends Styler {
   public PieStyler setLabelType(LabelType labelType) {
 
     this.labelType = labelType;
+    return this;
+  }
+
+  public Function<PieSeries, String> getCustomSeriesLabelFunction() {
+    return this.customSeriesLabelFunction;
+  }
+
+  /**
+   * Sets the Pie custom label generator
+   *
+   * @param customSeriesLabelFunction
+   */
+  public PieStyler setCustomSeriesLabelFunction(Function<PieSeries, String> customSeriesLabelFunction) {
+    this.customSeriesLabelFunction = customSeriesLabelFunction;
+    this.setLabelType(null);
     return this;
   }
 


### PR DESCRIPTION
See #698.

Demo of `PieChart02` with labels showing percentage:

**Before**
![immagine](https://github.com/knowm/XChart/assets/9415956/87182db6-4e18-4f5a-8397-0970f00b7c0c)


**After**
![immagine](https://github.com/knowm/XChart/assets/9415956/11110569-87e1-4460-96d8-d99444e0e131)

