### PR TITLE
Improve SRP by decomposing Utils.java and CSVImporter.java

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/CSVImporter.java
+++ b/xchart/src/main/java/org/knowm/xchart/CSVImporter.java
@@ -6,6 +6,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.knowm.xchart.internal.FileUtils;
 import org.knowm.xchart.style.Styler.ChartTheme;
 
 /**
@@ -39,7 +41,7 @@ public class CSVImporter {
     }
 
     // 2. get all the csv files in the dir
-    File[] csvFiles = getAllFiles(path2Directory, ".*.csv");
+    File[] csvFiles = FileUtils.getAllFiles(path2Directory, ".*.csv");
 
     // 3. create a series for each file, naming the series the file name
     for (File csvFile : csvFiles) {
@@ -53,14 +55,14 @@ public class CSVImporter {
       if (xAndYData[2] == null || xAndYData[2].trim().equalsIgnoreCase("")) {
         chart.addSeries(
             csvFile.getName().substring(0, csvFile.getName().indexOf(".csv")),
-            getAxisData(xAndYData[0]),
-            getAxisData(xAndYData[1]));
+            DataConverter.getAxisData(xAndYData[0]),
+            DataConverter.getAxisData(xAndYData[1]));
       } else {
         chart.addSeries(
             csvFile.getName().substring(0, csvFile.getName().indexOf(".csv")),
-            getAxisData(xAndYData[0]),
-            getAxisData(xAndYData[1]),
-            getAxisData(xAndYData[2]));
+            DataConverter.getAxisData(xAndYData[0]),
+            DataConverter.getAxisData(xAndYData[1]),
+            DataConverter.getAxisData(xAndYData[2]));
       }
     }
 
@@ -81,8 +83,8 @@ public class CSVImporter {
       xAndYData = getSeriesDataFromCSVColumns(csvFile);
     }
     return new SeriesData(
-        getAxisData(xAndYData[0]),
-        getAxisData(xAndYData[1]),
+        DataConverter.getAxisData(xAndYData[0]),
+        DataConverter.getAxisData(xAndYData[1]),
         csvFile.getName().substring(0, csvFile.getName().indexOf(".csv")));
   }
 
@@ -168,76 +170,7 @@ public class CSVImporter {
     return xAndYData;
   }
 
-  /**
-   * @param stringData
-   * @return
-   */
-  private static List<Number> getAxisData(String stringData) {
 
-    List<Number> axisData = new ArrayList<Number>();
-    String[] stringDataArray = stringData.split(",");
-    for (String dataPoint : stringDataArray) {
-      try {
-        Double value = Double.parseDouble(dataPoint);
-        axisData.add(value);
-      } catch (NumberFormatException e) {
-        System.out.println("Error parsing >" + dataPoint + "< !");
-        throw (e);
-      }
-    }
-    return axisData;
-  }
-
-  /**
-   * This method returns the files found in the given directory matching the given regular
-   * expression.
-   *
-   * @param dirName - ex. "./path/to/directory/" *make sure you have the '/' on the end
-   * @param regex - ex. ".*.csv"
-   * @return File[] - an array of files
-   */
-  private static File[] getAllFiles(String dirName, String regex) {
-
-    File[] allFiles = getAllFiles(dirName);
-
-    List<File> matchingFiles = new ArrayList<File>();
-
-    for (File allFile : allFiles) {
-
-      if (allFile.getName().matches(regex)) {
-        matchingFiles.add(allFile);
-      }
-    }
-
-    return matchingFiles.toArray(new File[matchingFiles.size()]);
-  }
-
-  /**
-   * This method returns the Files found in the given directory
-   *
-   * @param dirName - ex. "./path/to/directory/" *make sure you have the '/' on the end
-   * @return File[] - an array of files
-   */
-  private static File[] getAllFiles(String dirName) {
-
-    File dir = new File(dirName);
-
-    File[] files = dir.listFiles(); // returns files and folders
-
-    if (files != null) {
-      List<File> filteredFiles = new ArrayList<File>();
-      for (File file : files) {
-
-        if (file.isFile()) {
-          filteredFiles.add(file);
-        }
-      }
-      return filteredFiles.toArray(new File[filteredFiles.size()]);
-    } else {
-      System.out.println(dirName + " does not denote a valid directory!");
-      return new File[0];
-    }
-  }
 
   public enum DataOrientation {
     Rows,

--- a/xchart/src/main/java/org/knowm/xchart/DataConverter.java
+++ b/xchart/src/main/java/org/knowm/xchart/DataConverter.java
@@ -1,0 +1,27 @@
+package org.knowm.xchart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DataConverter {
+    /**
+     * @param stringData
+     * @return
+     */
+    public static List<Number> getAxisData(String stringData) {
+
+        List<Number> axisData = new ArrayList<Number>();
+        String[] stringDataArray = stringData.split(",");
+        for (String dataPoint : stringDataArray) {
+            try {
+                Double value = Double.parseDouble(dataPoint);
+                axisData.add(value);
+            } catch (NumberFormatException e) {
+                System.out.println("Error parsing >" + dataPoint + "< !");
+                throw (e);
+            }
+        }
+        return axisData;
+    }
+
+}

--- a/xchart/src/main/java/org/knowm/xchart/GifEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/GifEncoder.java
@@ -3,7 +3,7 @@ package org.knowm.xchart;
 import com.madgag.gif.fmsware.AnimatedGifEncoder;
 import java.awt.image.BufferedImage;
 import java.util.List;
-import org.knowm.xchart.internal.Utils;
+import org.knowm.xchart.internal.FileUtils;
 
 /** A helper class with static methods for saving Charts as a GIF file */
 public class GifEncoder {
@@ -31,7 +31,7 @@ public class GifEncoder {
   public static void saveGif(String filePath, List<BufferedImage> images, int repeat, int delay) {
     AnimatedGifEncoder gif = new AnimatedGifEncoder();
     gif.setRepeat(repeat);
-    gif.start(Utils.addFileExtension(filePath, GIF_FILE_EXTENSION));
+    gif.start(FileUtils.addFileExtension(filePath, GIF_FILE_EXTENSION));
     gif.setDelay(delay);
     for (BufferedImage image : images) {
       gif.addFrame(image);

--- a/xchart/src/main/java/org/knowm/xchart/internal/FileUtils.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/FileUtils.java
@@ -1,0 +1,78 @@
+package org.knowm.xchart.internal;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileUtils {
+    /**
+     * Only adds the extension of the fileExtension to the filename if the filename doesn't already
+     * have it.
+     *
+     * @param fileName File name
+     * @param fileExtension File extension
+     * @return filename (if extension already exists), otherwise;: filename + fileExtension
+     */
+    public static String addFileExtension(String fileName, String fileExtension) {
+        String fileNameWithFileExtension = fileName;
+        if (fileName.length() <= fileExtension.length()
+                || !fileName
+                .substring(fileName.length() - fileExtension.length())
+                .equalsIgnoreCase(fileExtension)) {
+            fileNameWithFileExtension = fileName + fileExtension;
+        }
+        return fileNameWithFileExtension;
+    }
+
+    /**
+     * This method returns the files found in the given directory matching the given regular
+     * expression.
+     *
+     * @param dirName - ex. "./path/to/directory/" *make sure you have the '/' on the end
+     * @param regex - ex. ".*.csv"
+     * @return File[] - an array of files
+     */
+    public static File[] getAllFiles(String dirName, String regex) {
+
+        File[] allFiles = getAllFiles(dirName);
+
+        List<File> matchingFiles = new ArrayList<File>();
+
+        for (File allFile : allFiles) {
+
+            if (allFile.getName().matches(regex)) {
+                matchingFiles.add(allFile);
+            }
+        }
+
+        return matchingFiles.toArray(new File[matchingFiles.size()]);
+    }
+
+    /**
+     * This method returns the Files found in the given directory
+     *
+     * @param dirName - ex. "./path/to/directory/" *make sure you have the '/' on the end
+     * @return File[] - an array of files
+     */
+    public static File[] getAllFiles(String dirName) {
+
+        File dir = new File(dirName);
+
+        File[] files = dir.listFiles(); // returns files and folders
+
+        if (files != null) {
+            List<File> filteredFiles = new ArrayList<File>();
+            for (File file : files) {
+
+                if (file.isFile()) {
+                    filteredFiles.add(file);
+                }
+            }
+            return filteredFiles.toArray(new File[filteredFiles.size()]);
+        } else {
+            System.out.println(dirName + " does not denote a valid directory!");
+            return new File[0];
+        }
+    }
+
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/Utils.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/Utils.java
@@ -179,22 +179,4 @@ public class Utils {
     return longs;
   }
 
-  /**
-   * Only adds the extension of the fileExtension to the filename if the filename doesn't already
-   * have it.
-   *
-   * @param fileName File name
-   * @param fileExtension File extension
-   * @return filename (if extension already exists), otherwise;: filename + fileExtension
-   */
-  public static String addFileExtension(String fileName, String fileExtension) {
-    String fileNameWithFileExtension = fileName;
-    if (fileName.length() <= fileExtension.length()
-        || !fileName
-            .substring(fileName.length() - fileExtension.length())
-            .equalsIgnoreCase(fileExtension)) {
-      fileNameWithFileExtension = fileName + fileExtension;
-    }
-    return fileNameWithFileExtension;
   }
-}

--- a/xchart/src/test/java/org/knowm/xchart/internal/UtilsTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/UtilsTest.java
@@ -8,9 +8,9 @@ public class UtilsTest {
 
   @Test
   void addFileExtension() {
-    assertEquals(Utils.addFileExtension("yourchart.png", ".png"), "yourchart.png");
-    assertEquals(Utils.addFileExtension("yourchart.png", ".pn"), "yourchart.png.pn");
-    assertEquals(Utils.addFileExtension("a", ".png"), "a.png");
-    assertEquals(Utils.addFileExtension("a.PNG", ".png"), "a.PNG");
+    assertEquals(FileUtils.addFileExtension("yourchart.png", ".png"), "yourchart.png");
+    assertEquals(FileUtils.addFileExtension("yourchart.png", ".pn"), "yourchart.png.pn");
+    assertEquals(FileUtils.addFileExtension("a", ".png"), "a.png");
+    assertEquals(FileUtils.addFileExtension("a.PNG", ".png"), "a.PNG");
   }
 }


### PR DESCRIPTION
Hi!

I performed this refactoring as part of a small university homework assignment (HW) focusing on software design principles. The goal was to improve the code's cohesion and maintainability.

The changes address clear violations of the Single Responsibility Principle (SRP) in two utility classes:

1. Decomposed Utils.java
The original Utils.java was acting as a general catch-all for math, file, and data conversion logic. I split it into specialized classes:

FileUtils.java (New):

Moved addFileExtension here.

ChartMathUtil.java (New):

Moved getTickStartOffset, pow, getGeneratedDataAsList, and getGeneratedDataAsArray here.

Utils.java (Cleaned):

This class is now focused primarily on data conversion (Array/List conversion).

2. Refactored CSVImporter.java
This class was mixing three different responsibilities (chart assembly, file I/O, and string parsing).

FileUtils.java (Used):

Moved both getAllFiles methods here, as they are pure file system utilities.

DataConverter.java (New):

Moved the getAxisData (String to Number parsing) method here.

CSVImporter.java (Cleaned):

This class is now more focused on its main job: CSV reading and chart assembly.

I updated all the method calls in the project to point to the new utility classes and ran the Main demo in the xchart-demo module. All charts continue to work correctly.