### PR TITLE
Fix #792: custom axis tick label formatter drops ticks with duplicate labels

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue792.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue792.java
@@ -1,0 +1,43 @@
+package org.knowm.xchart.standalone.issues;
+
+import org.knowm.xchart.QuickChart;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+
+/**
+ * Demonstrates the fix for issue #792 — {@code setxAxisTickLabelsFormattingFunction} dropping
+ * tick labels when the formatting function intentionally returns duplicate strings.
+ *
+ * <p>Before the fix: the internal {@code do-while} loop in {@code AxisTickCalculator_} kept
+ * widening the grid step until all tick labels were unique. When the custom formatter returned
+ * {@code " "} for odd x-values, this uniqueness check collapsed most ticks and only two remained.
+ *
+ * <p>After the fix: {@code AxisTickCalculator_Callback} overrides {@code areAllTickLabelsUnique}
+ * to always return {@code true}, so the grid step is never widened and every tick position
+ * produced by the calculator is preserved.
+ *
+ * <p>Expected result: x-axis shows labels 0, 2, 4, 6 with tick marks also present at 1, 3, 5, 7
+ * (those positions show a blank label rather than being removed).
+ */
+public class TestForIssue792 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  public static XYChart getChart() {
+
+    double[] yData = new double[] {100, 90, 90, 89, 80, 101, 102, 99};
+
+    XYChart chart = QuickChart.getChart("Issue #792 — custom tick label formatter", "X", "Y", "y(x)", null, yData);
+
+    // Hide every odd x tick label — previously this caused all but two ticks to disappear.
+    chart
+        .getStyler()
+        .setxAxisTickLabelsFormattingFunction(
+            x -> x.intValue() % 2 == 0 ? String.valueOf(x.intValue()) : " ");
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Callback.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Callback.java
@@ -2,6 +2,7 @@ package org.knowm.xchart.internal.chartpart;
 
 import java.util.List;
 import java.util.function.Function;
+
 import org.knowm.xchart.internal.chartpart.Axis.Direction;
 import org.knowm.xchart.style.AxesChartStyler;
 
@@ -44,5 +45,13 @@ class AxisTickCalculator_Callback extends AxisTickCalculator_ {
     super(axisDirection, workingSpace, minValue, maxValue, axisValues, styler);
     axisFormat = new Formatter_Custom(formattingCallback);
     calculate();
+  }
+
+  @Override
+  boolean areAllTickLabelsUnique(List<?> tickLabels) {
+    // When a custom formatting function is in use, the caller controls the output intentionally
+    // (e.g. returning " " to hide a tick). Skip the uniqueness guard so the do-while loop in
+    // calculate() does not widen the grid step to eliminate those duplicates.
+    return true;
   }
 }

--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue792Test.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue792Test.java
@@ -1,0 +1,36 @@
+package org.knowm.xchart.internal.chartpart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.QuickChart;
+import org.knowm.xchart.XYChart;
+
+/** Regression test for <a href="https://github.com/knowm/XChart/issues/792">issue 792</a>. */
+public class RegressionIssue792Test {
+
+  @Test
+  public void customFormattingFunctionWithDuplicateLabelsShouldPreserveAllTicks() throws Exception {
+
+    // given - 8 data points; formatter intentionally returns " " for odd x values
+    double[] yData = new double[] {100, 90, 90, 89, 80, 101, 102, 99};
+    XYChart chart = QuickChart.getChart("Sample Chart", "X", "Y", "y(x)", null, yData);
+    chart
+        .getStyler()
+        .setxAxisTickLabelsFormattingFunction(
+            x -> x.intValue() % 2 == 0 ? String.valueOf(x.intValue()) : " ");
+
+    // when
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+
+    // then - all tick positions must be present; duplicate " " labels must not be collapsed
+    List<String> tickLabels = chart.axisPair.getXAxis().getAxisTickCalculator().getTickLabels();
+    long blankCount = tickLabels.stream().filter(" "::equals).count();
+    assertThat(blankCount)
+        .as("odd-x tick labels should all be preserved as \" \", not collapsed by uniqueness check")
+        .isGreaterThan(1);
+  }
+}


### PR DESCRIPTION
## Problem

When `setxAxisTickLabelsFormattingFunction` is used with a function that intentionally returns the same string for multiple ticks (e.g. returning `" "` to hide odd x labels), the `do-while` loop in `AxisTickCalculator_` kept widening the grid step until `areAllTickLabelsUnique()` passed. This eliminated most tick positions instead of preserving them with blank labels.

Fixes #792.

## Root Cause

`AxisTickCalculator_Callback` (used whenever a custom formatting function is set) inherits the uniqueness guard from `AxisTickCalculator_`. The guard exists to prevent the formatter from rounding adjacent numeric values to the same display string — a valid concern for the built-in formatters, but wrong for custom ones where duplicate output is intentional.

## Fix

Override `areAllTickLabelsUnique()` in `AxisTickCalculator_Callback` to always return `true`. The custom formatter is in full control of its output, so the uniqueness loop must not interfere.

## Testing

- Added `RegressionIssue792Test` — asserts that multiple `" "` labels are preserved after rendering.
- Added `TestForIssue792` demo — visually confirms even-indexed labels appear and odd positions retain their tick marks with blank labels.