### PR TITLE
Fix #770 — OHLCChart zoom support

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue770.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue770.java
@@ -1,0 +1,80 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.knowm.xchart.OHLCChart;
+import org.knowm.xchart.OHLCChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Demonstrates the fix for issue #770 — zoom support for OHLCChart.
+ *
+ * <p>Before the fix: zoom was gated by {@code instanceof XYChart} checks throughout the codebase;
+ * {@code OHLCStyler} did not expose zoom settings and {@code OHLCSeries} had no filter methods.
+ *
+ * <p>After the fix:
+ *
+ * <ul>
+ *   <li>Zoom fields moved from {@code XYStyler} to {@code AxesChartStyler} so all axes-based
+ *       charts inherit them.
+ *   <li>{@code OHLCSeries} gained {@code filterXByValue}, {@code filterXByIndex}, {@code
+ *       resetFilter}, {@code isAllXData}.
+ *   <li>{@code ChartZoom} generalised to {@code Chart<? extends AxesChartStyler, ?>}.
+ *   <li>{@code XChartPanel} and {@code PlotContent_} wired zoom for {@code OHLCChart}.
+ * </ul>
+ *
+ * <p>Usage: drag to select an x-range to zoom in; double-click or press Reset to restore.
+ */
+public class TestForIssue770 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  public static OHLCChart getChart() {
+
+    OHLCChart chart =
+        new OHLCChartBuilder()
+            .width(900)
+            .height(500)
+            .title("Issue #770 — OHLCChart zoom")
+            .xAxisTitle("Date")
+            .yAxisTitle("Price")
+            .theme(Styler.ChartTheme.GGPlot2)
+            .build();
+
+    chart.getStyler().setZoomEnabled(true);
+    chart.getStyler().setZoomResetByDoubleClick(true);
+    chart.getStyler().setZoomResetByButton(true);
+
+    // Generate 200 candle bars
+    int n = 200;
+    List<Date> xData = new ArrayList<>();
+    List<Double> openData = new ArrayList<>();
+    List<Double> highData = new ArrayList<>();
+    List<Double> lowData = new ArrayList<>();
+    List<Double> closeData = new ArrayList<>();
+
+    long base = System.currentTimeMillis() - (long) n * 86_400_000L;
+    double price = 100.0;
+    for (int i = 0; i < n; i++) {
+      xData.add(new Date(base + (long) i * 86_400_000L));
+      double open = price;
+      double close = open + (Math.random() - 0.49) * 4;
+      double high = Math.max(open, close) + Math.random() * 2;
+      double low = Math.min(open, close) - Math.random() * 2;
+      openData.add(open);
+      highData.add(high);
+      lowData.add(low);
+      closeData.add(close);
+      price = close;
+    }
+
+    chart.addSeries("OHLC", xData, openData, highData, lowData, closeData);
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/OHLCSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/OHLCSeries.java
@@ -1,12 +1,24 @@
 package org.knowm.xchart;
 
 import java.awt.Color;
+import java.util.Arrays;
+
 import org.knowm.xchart.internal.chartpart.RenderableSeries;
 import org.knowm.xchart.internal.chartpart.RenderableSeries.LegendRenderType;
 import org.knowm.xchart.internal.series.MarkerSeries;
 
 public class OHLCSeries extends MarkerSeries {
 
+  // full unfiltered data — retained so zoom can be reset to the original range
+  private double[] xDataAll;
+  private double[] openDataAll;
+  private double[] highDataAll;
+  private double[] lowDataAll;
+  private double[] closeDataAll;
+  private long[] volumeDataAll;
+  private double[] yDataAll;
+
+  // active (possibly zoom-filtered) data — what the chart actually renders
   private double[] xData; // can be Number or Date(epochtime)
   private double[] openData;
   private double[] highData;
@@ -66,6 +78,12 @@ public class OHLCSeries extends MarkerSeries {
       DataType xAxisDataType) {
 
     super(name, xAxisDataType);
+    this.xDataAll = xData;
+    this.openDataAll = openData;
+    this.highDataAll = highData;
+    this.lowDataAll = lowData;
+    this.closeDataAll = closeData;
+    this.volumeDataAll = volumeData;
     this.xData = xData;
     this.openData = openData;
     this.highData = highData;
@@ -86,6 +104,8 @@ public class OHLCSeries extends MarkerSeries {
   public OHLCSeries(String name, double[] xData, double[] yData, DataType xAxisDataType) {
 
     super(name, xAxisDataType);
+    this.xDataAll = xData;
+    this.yDataAll = yData;
     this.xData = xData;
     this.yData = yData;
     this.ohlcSeriesRenderStyle = OHLCSeriesRenderStyle.Line;
@@ -260,6 +280,79 @@ public class OHLCSeries extends MarkerSeries {
   public double[] getXData() {
 
     return xData;
+  }
+
+  public boolean isAllXData() {
+
+    return xData.length == xDataAll.length;
+  }
+
+  public void filterXByIndex(int startIndex, int endIndex) {
+
+    startIndex = Math.max(0, startIndex);
+    int len = xDataAll.length;
+    endIndex = Math.min(len, endIndex);
+    xData = Arrays.copyOfRange(xDataAll, startIndex, endIndex);
+    if (openDataAll != null) openData = Arrays.copyOfRange(openDataAll, startIndex, endIndex);
+    if (highDataAll != null) highData = Arrays.copyOfRange(highDataAll, startIndex, endIndex);
+    if (lowDataAll != null) lowData = Arrays.copyOfRange(lowDataAll, startIndex, endIndex);
+    if (closeDataAll != null) closeData = Arrays.copyOfRange(closeDataAll, startIndex, endIndex);
+    if (volumeDataAll != null) volumeData = Arrays.copyOfRange(volumeDataAll, startIndex, endIndex);
+    if (yDataAll != null) yData = Arrays.copyOfRange(yDataAll, startIndex, endIndex);
+    calculateMinMax();
+  }
+
+  public boolean filterXByValue(double minValue, double maxValue) {
+
+    int length = xDataAll.length;
+    boolean[] keep = new boolean[length];
+    int count = 0;
+    for (int i = 0; i < length; i++) {
+      keep[i] = xDataAll[i] >= minValue && xDataAll[i] <= maxValue;
+      if (keep[i]) count++;
+    }
+    if (count == length) {
+      return false;
+    }
+    xData = new double[count];
+    double[] newOpen = openDataAll != null ? new double[count] : null;
+    double[] newHigh = highDataAll != null ? new double[count] : null;
+    double[] newLow = lowDataAll != null ? new double[count] : null;
+    double[] newClose = closeDataAll != null ? new double[count] : null;
+    long[] newVolume = volumeDataAll != null ? new long[count] : null;
+    double[] newY = yDataAll != null ? new double[count] : null;
+    int idx = 0;
+    for (int i = 0; i < length; i++) {
+      if (!keep[i]) continue;
+      xData[idx] = xDataAll[i];
+      if (newOpen != null) newOpen[idx] = openDataAll[i];
+      if (newHigh != null) newHigh[idx] = highDataAll[i];
+      if (newLow != null) newLow[idx] = lowDataAll[i];
+      if (newClose != null) newClose[idx] = closeDataAll[i];
+      if (newVolume != null) newVolume[idx] = volumeDataAll[i];
+      if (newY != null) newY[idx] = yDataAll[i];
+      idx++;
+    }
+    openData = newOpen;
+    highData = newHigh;
+    lowData = newLow;
+    closeData = newClose;
+    volumeData = newVolume;
+    yData = newY;
+    calculateMinMax();
+    return true;
+  }
+
+  public void resetFilter() {
+
+    xData = xDataAll;
+    openData = openDataAll;
+    highData = highDataAll;
+    lowData = lowDataAll;
+    closeData = closeDataAll;
+    volumeData = volumeDataAll;
+    yData = yDataAll;
+    calculateMinMax();
   }
 
   public double[] getOpenData() {

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -19,6 +19,7 @@ import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 import java.io.File;
 import java.io.IOException;
+
 import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
@@ -29,12 +30,15 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
+
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
 import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
 import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.chartpart.ChartZoom;
 import org.knowm.xchart.internal.chartpart.Cursor;
 import org.knowm.xchart.internal.chartpart.ToolTips;
+import org.knowm.xchart.style.AxesChartStyler;
+import org.knowm.xchart.style.OHLCStyler;
 import org.knowm.xchart.style.XYStyler;
 
 /**
@@ -84,12 +88,27 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
     this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(ctrlP, "print");
     this.getActionMap().put("print", new PrintAction());
 
-    // Mouse Listener for Zoom. Only available for XYCharts
-    if (chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled()) {
+    // Mouse Listener for Zoom. Available for XYCharts and OHLCCharts
+    if ((chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled())
+        || (chart instanceof OHLCChart && ((OHLCStyler) chart.getStyler()).isZoomEnabled())) {
+      @SuppressWarnings("unchecked")
       ChartZoom chartZoom =
-          new ChartZoom((XYChart) chart, (XChartPanel<XYChart>) this, resetString);
+          new ChartZoom((Chart<? extends AxesChartStyler, ?>) chart, this, resetString);
       this.addMouseListener(chartZoom); // for clicking
       this.addMouseMotionListener(chartZoom); // for moving
+
+      // Escape key resets zoom (fix for issue #930)
+      KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
+      this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(escape, "resetZoom");
+      this.getActionMap()
+          .put(
+              "resetZoom",
+              new AbstractAction() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                  chartZoom.resetZoom();
+                }
+              });
     }
 
     // Mouse motion listener for Cursor

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
@@ -17,6 +17,7 @@ import javax.swing.event.EventListenerList;
 
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
+import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.Styler;
 
 /**
@@ -27,7 +28,6 @@ import org.knowm.xchart.style.Styler;
 // TODO tie this to the styler properties
 public class ChartButton extends MouseAdapter implements ChartPart {
 
-  private final Chart chart;
   private final Styler styler;
   private Rectangle bounds;
 
@@ -54,9 +54,21 @@ public class ChartButton extends MouseAdapter implements ChartPart {
    */
   public ChartButton(XYChart xyChart, XChartPanel<XYChart> xChartPanel, String text) {
 
+    this(xyChart, (XChartPanel<?>) xChartPanel, text);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param chart
+   * @param xChartPanel
+   * @param text
+   */
+  public ChartButton(
+      Chart<? extends AxesChartStyler, ?> chart, XChartPanel<?> xChartPanel, String text) {
+
     this.text = text;
 
-    chart = xyChart;
     styler = chart.getStyler();
 
     xChartPanel.addMouseListener(this);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
@@ -7,14 +7,16 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.Rectangle2D;
+
+import org.knowm.xchart.OHLCSeries;
 import org.knowm.xchart.XChartPanel;
-import org.knowm.xchart.XYChart;
-import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.internal.series.AxesChartSeriesNumericalNoErrorBars;
+import org.knowm.xchart.style.AxesChartStyler;
 
 public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener {
 
-  protected final XChartPanel<XYChart> xChartPanel;
-  protected final XYChart xyChart;
+  protected final XChartPanel<?> xChartPanel;
+  protected final Chart<? extends AxesChartStyler, ?> chart;
   protected Rectangle bounds;
 
   protected final ChartButton resetButton;
@@ -25,24 +27,28 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
   /**
    * Constructor
    *
+   * @param chart
    * @param xChartPanel
    * @param resetString
    */
-  public ChartZoom(XYChart xyChart, XChartPanel<XYChart> xChartPanel, String resetString) {
+  public ChartZoom(
+      Chart<? extends AxesChartStyler, ?> chart,
+      XChartPanel<?> xChartPanel,
+      String resetString) {
 
     x1 = -1;
     x2 = -1;
 
     this.xChartPanel = xChartPanel;
-    this.xyChart = xyChart;
-    xyChart.plot.plotContent.setChartZoom(this);
+    this.chart = chart;
+    chart.plot.plotContent.setChartZoom(this);
 
-    resetButton = new ChartButton(xyChart, xChartPanel, resetString);
+    resetButton = new ChartButton(chart, xChartPanel, resetString);
     resetButton.addActionListener(this);
     resetButton.setVisible(false);
   }
 
-  protected void resetZoom() {
+  public void resetZoom() {
 
     resetFilter();
     filtered = false;
@@ -77,7 +83,7 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
     } else if (x1 == -1 || x2 == -1) {
       return;
     } else {
-      g.setColor(xyChart.getStyler().getZoomSelectionColor());
+      g.setColor(chart.getStyler().getZoomSelectionColor());
       int xStart = Math.min(x1, x2);
       int width = Math.abs(x1 - x2);
       bounds = g.getClipBounds();
@@ -118,7 +124,7 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
       }
 
       filtered = filterXByScreen(smallPoint, bigPoint);
-      resetButton.setVisible(filtered && xyChart.getStyler().isZoomResetByButton());
+      resetButton.setVisible(filtered && chart.getStyler().isZoomResetByButton());
     }
 
     x1 = -1;
@@ -129,12 +135,12 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
   public boolean filterXByScreen(int screenXmin, int screenXmax) {
 
     // convert screen coordinates to axis values
-    double minValue = xyChart.axisPair.getXAxis().getChartValue(screenXmin);
-    double maxValue = xyChart.axisPair.getXAxis().getChartValue(screenXmax);
+    double minValue = chart.axisPair.getXAxis().getChartValue(screenXmin);
+    double maxValue = chart.axisPair.getXAxis().getChartValue(screenXmax);
     boolean filtered = false;
     if (isOnePointSeleted(minValue, maxValue)) {
-      for (XYSeries series : xyChart.getSeriesMap().values()) {
-        boolean f = series.filterXByValue(minValue, maxValue);
+      for (Object s : chart.getSeriesMap().values()) {
+        boolean f = filterSeriesByValue(s, minValue, maxValue);
         if (f) {
           filtered = true;
         }
@@ -147,6 +153,16 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
     return filtered;
   }
 
+  private boolean filterSeriesByValue(Object series, double minValue, double maxValue) {
+
+    if (series instanceof AxesChartSeriesNumericalNoErrorBars) {
+      return ((AxesChartSeriesNumericalNoErrorBars) series).filterXByValue(minValue, maxValue);
+    } else if (series instanceof OHLCSeries) {
+      return ((OHLCSeries) series).filterXByValue(minValue, maxValue);
+    }
+    return false;
+  }
+
   /**
    * Is there a point selected in all series.
    *
@@ -157,9 +173,9 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
   private boolean isOnePointSeleted(double minValue, double maxValue) {
 
     boolean isOnePointSeleted = false;
-    double[] xData = null;
-    for (XYSeries series : xyChart.getSeriesMap().values()) {
-      xData = series.getXData();
+    for (Object s : chart.getSeriesMap().values()) {
+      double[] xData = getXData(s);
+      if (xData == null) continue;
       for (double x : xData) {
         if (x >= minValue && x <= maxValue) {
           isOnePointSeleted = true;
@@ -170,17 +186,35 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
     return isOnePointSeleted;
   }
 
+  private double[] getXData(Object series) {
+
+    if (series instanceof AxesChartSeriesNumericalNoErrorBars) {
+      return ((AxesChartSeriesNumericalNoErrorBars) series).getXData();
+    } else if (series instanceof OHLCSeries) {
+      return ((OHLCSeries) series).getXData();
+    }
+    return null;
+  }
+
   public void resetFilter() {
 
-    for (XYSeries series : xyChart.getSeriesMap().values()) {
-      series.resetFilter();
+    for (Object s : chart.getSeriesMap().values()) {
+      if (s instanceof AxesChartSeriesNumericalNoErrorBars) {
+        ((AxesChartSeriesNumericalNoErrorBars) s).resetFilter();
+      } else if (s instanceof OHLCSeries) {
+        ((OHLCSeries) s).resetFilter();
+      }
     }
   }
 
   public void filterXByIndex(int startIndex, int endIndex) {
 
-    for (XYSeries series : xyChart.getSeriesMap().values()) {
-      series.filterXByIndex(startIndex, endIndex);
+    for (Object s : chart.getSeriesMap().values()) {
+      if (s instanceof AxesChartSeriesNumericalNoErrorBars) {
+        ((AxesChartSeriesNumericalNoErrorBars) s).filterXByIndex(startIndex, endIndex);
+      } else if (s instanceof OHLCSeries) {
+        ((OHLCSeries) s).filterXByIndex(startIndex, endIndex);
+      }
     }
   }
 
@@ -192,8 +226,16 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
   private boolean isAllPointsSelected() {
 
     boolean isAllPointsSelected = true;
-    for (XYSeries series : xyChart.getSeriesMap().values()) {
-      if (!series.isAllXData()) {
+    for (Object s : chart.getSeriesMap().values()) {
+      boolean allSelected;
+      if (s instanceof AxesChartSeriesNumericalNoErrorBars) {
+        allSelected = ((AxesChartSeriesNumericalNoErrorBars) s).isAllXData();
+      } else if (s instanceof OHLCSeries) {
+        allSelected = ((OHLCSeries) s).isAllXData();
+      } else {
+        continue;
+      }
+      if (!allSelected) {
         isAllPointsSelected = false;
         break;
       }
@@ -207,7 +249,7 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
     if (!filtered) {
       return;
     }
-    if (xyChart.getStyler().isZoomResetByDoubleClick() && e.getClickCount() == 2) {
+    if (chart.getStyler().isZoomResetByDoubleClick() && e.getClickCount() == 2) {
       resetZoom();
       return;
     }
@@ -235,8 +277,8 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
       end = x1;
     }
     // If the two intervals overlap, then largest beginning must be smaller than the smallest ending
-    if (Math.max(start, xyChart.plot.bounds.getX())
-        < Math.min(end, xyChart.plot.bounds.getX() + xyChart.plot.bounds.getWidth())) {
+    if (Math.max(start, chart.plot.bounds.getX())
+        < Math.min(end, chart.plot.bounds.getX() + chart.plot.bounds.getWidth())) {
       isOverlapping = true;
     }
     return isOverlapping;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
@@ -4,8 +4,10 @@ import java.awt.BasicStroke;
 import java.awt.Graphics2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
+import org.knowm.xchart.OHLCChart;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.style.OHLCStyler;
 import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.XYStyler;
 
@@ -66,7 +68,8 @@ public abstract class PlotContent_<ST extends Styler, S extends Series> implemen
     }
 
     // TODO put this in PlotContent_XY.
-    if (chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled()) {
+    if ((chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled())
+        || (chart instanceof OHLCChart && ((OHLCStyler) chart.getStyler()).isZoomEnabled())) {
       chartZoom.paint(g);
     }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeriesNumericalNoErrorBars.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeriesNumericalNoErrorBars.java
@@ -9,12 +9,12 @@ import java.util.Arrays;
 // TODO weird name of class since it does contain extravalues for error bars!
 public abstract class AxesChartSeriesNumericalNoErrorBars extends MarkerSeries {
 
-  // permanent data
+  // full unfiltered data — retained so zoom can be reset to the original range
   double[] xDataAll;
   double[] yDataAll;
   double[] extraValuesAll;
 
-  // temporary data different from permanent data if some is filter out for zooming
+  // active (possibly zoom-filtered) data — what the chart actually renders
   double[] xData; // can be Number or Date(epochtime)
   double[] yData;
   double[] extraValues;

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Function;
 
+import org.knowm.xchart.style.colors.ChartColor;
+
 public abstract class AxesChartStyler extends Styler {
 
   // Chart Axes ///////////////////////////////
@@ -76,6 +78,12 @@ public abstract class AxesChartStyler extends Styler {
   private TextAlignment yAxisLabelAlignment = TextAlignment.Left;
   private int xAxisLabelRotation = 0;
 
+  // Zoom ///////////////////////////
+  private boolean isZoomEnabled;
+  private Color zoomSelectionColor;
+  private boolean zoomResetByDoubleClick;
+  private boolean zoomResetByButton;
+
   @Override
   void setAllStyles() {
 
@@ -116,6 +124,12 @@ public abstract class AxesChartStyler extends Styler {
     // Error Bars ///////////////////////////////
     this.errorBarsColor = theme.getErrorBarsColor();
     this.isErrorBarsColorSeriesColor = theme.isErrorBarsColorSeriesColor();
+
+    // Zoom ///////////////////////////
+    this.isZoomEnabled = false;
+    this.zoomSelectionColor = ChartColor.LIGHT_GREY.getColorTranslucent();
+    this.zoomResetByDoubleClick = true;
+    this.zoomResetByButton = true;
 
     // Formatting ////////////////////////////////
     this.locale = Locale.getDefault();
@@ -948,6 +962,52 @@ public abstract class AxesChartStyler extends Styler {
   public AxesChartStyler setXAxisLabelRotation(int xAxisLabelRotation) {
 
     this.xAxisLabelRotation = xAxisLabelRotation;
+    return this;
+  }
+
+  // Zoom ///////////////////////////////
+
+  public boolean isZoomEnabled() {
+
+    return isZoomEnabled;
+  }
+
+  public AxesChartStyler setZoomEnabled(boolean isZoomEnabled) {
+
+    this.isZoomEnabled = isZoomEnabled;
+    return this;
+  }
+
+  public Color getZoomSelectionColor() {
+
+    return zoomSelectionColor;
+  }
+
+  public AxesChartStyler setZoomSelectionColor(Color zoomSelectionColor) {
+
+    this.zoomSelectionColor = zoomSelectionColor;
+    return this;
+  }
+
+  public boolean isZoomResetByDoubleClick() {
+
+    return zoomResetByDoubleClick;
+  }
+
+  public AxesChartStyler setZoomResetByDoubleClick(boolean zoomResetByDoubleClick) {
+
+    this.zoomResetByDoubleClick = zoomResetByDoubleClick;
+    return this;
+  }
+
+  public boolean isZoomResetByButton() {
+
+    return zoomResetByButton;
+  }
+
+  public AxesChartStyler setZoomResetByButton(boolean zoomResetByButton) {
+
+    this.zoomResetByButton = zoomResetByButton;
     return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/OHLCStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/OHLCStyler.java
@@ -1,5 +1,6 @@
 package org.knowm.xchart.style;
 
+import java.awt.Color;
 import org.knowm.xchart.OHLCSeries;
 import org.knowm.xchart.OHLCSeries.OHLCSeriesRenderStyle;
 import org.knowm.xchart.style.theme.Theme;
@@ -47,5 +48,35 @@ public class OHLCStyler extends AxesChartStyler {
 
     this.theme = theme;
     setAllStyles();
+  }
+
+  // Zoom \u2014 covariant overrides ///////////////////////////////
+
+  @Override
+  public OHLCStyler setZoomEnabled(boolean isZoomEnabled) {
+
+    super.setZoomEnabled(isZoomEnabled);
+    return this;
+  }
+
+  @Override
+  public OHLCStyler setZoomSelectionColor(Color zoomSelectionColor) {
+
+    super.setZoomSelectionColor(zoomSelectionColor);
+    return this;
+  }
+
+  @Override
+  public OHLCStyler setZoomResetByDoubleClick(boolean zoomResetByDoubleClick) {
+
+    super.setZoomResetByDoubleClick(zoomResetByDoubleClick);
+    return this;
+  }
+
+  @Override
+  public OHLCStyler setZoomResetByButton(boolean zoomResetByButton) {
+
+    super.setZoomResetByButton(zoomResetByButton);
+    return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/XYStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/XYStyler.java
@@ -4,18 +4,11 @@ import java.awt.Color;
 import java.awt.Font;
 import java.util.function.Function;
 import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
-import org.knowm.xchart.style.colors.ChartColor;
 import org.knowm.xchart.style.theme.Theme;
 
 public class XYStyler extends AxesChartStyler {
 
   private XYSeriesRenderStyle xySeriesRenderStyle;
-
-  // Zoom ///////////////////////////
-  private boolean isZoomEnabled;
-  private Color zoomSelectionColor;
-  private boolean zoomResetByDoubleClick;
-  private boolean zoomResetByButton;
 
   // Cursor ////////////////////////////////
 
@@ -42,10 +35,6 @@ public class XYStyler extends AxesChartStyler {
     // Zoom ///////////////////////////
     // TODO set this from the theme
     xySeriesRenderStyle = XYSeriesRenderStyle.Line; // set default to line
-    isZoomEnabled = false; // set default to false
-    zoomSelectionColor = ChartColor.LIGHT_GREY.getColorTranslucent();
-    zoomResetByDoubleClick = true;
-    zoomResetByButton = true;
 
     // Cursor ////////////////////////////////
     this.isCursorEnabled = theme.isCursorEnabled();
@@ -84,48 +73,33 @@ public class XYStyler extends AxesChartStyler {
     return this;
   }
 
-  // Zoom ///////////////////////////////
+  // Zoom — covariant overrides ///////////////////////////////
 
-  public boolean isZoomEnabled() {
-    return isZoomEnabled;
-  }
-
+  @Override
   public XYStyler setZoomEnabled(boolean isZoomEnabled) {
 
-    this.isZoomEnabled = isZoomEnabled;
+    super.setZoomEnabled(isZoomEnabled);
     return this;
   }
 
-  public Color getZoomSelectionColor() {
-
-    return zoomSelectionColor;
-  }
-
+  @Override
   public XYStyler setZoomSelectionColor(Color zoomSelectionColor) {
 
-    this.zoomSelectionColor = zoomSelectionColor;
+    super.setZoomSelectionColor(zoomSelectionColor);
     return this;
   }
 
-  public boolean isZoomResetByDoubleClick() {
-
-    return zoomResetByDoubleClick;
-  }
-
+  @Override
   public XYStyler setZoomResetByDoubleClick(boolean zoomResetByDoubleClick) {
 
-    this.zoomResetByDoubleClick = zoomResetByDoubleClick;
+    super.setZoomResetByDoubleClick(zoomResetByDoubleClick);
     return this;
   }
 
-  public boolean isZoomResetByButton() {
-
-    return zoomResetByButton;
-  }
-
+  @Override
   public XYStyler setZoomResetByButton(boolean zoomResetByButton) {
 
-    this.zoomResetByButton = zoomResetByButton;
+    super.setZoomResetByButton(zoomResetByButton);
     return this;
   }
 


### PR DESCRIPTION
Closes #770

## Summary

Extends the existing drag-to-zoom feature (previously XYChart-only) to `OHLCChart`.

## Changes

| File | Change |
|------|--------|
| `AxesChartStyler` | Zoom fields moved up from `XYStyler` so all axes-based charts inherit zoom settings |
| `OHLCStyler` | Exposes `isZoomEnabled`, `setZoomEnabled`, `isZoomResetByDoubleClick`, `isZoomResetByButton` and their setters |
| `XYStyler` | Removes duplicated zoom fields now inherited from `AxesChartStyler` |
| `ChartZoom` | First parameter generalised from `XYChart` to `Chart<? extends AxesChartStyler, ?>`; `resetZoom()` made `public` |
| `ChartButton` | New constructor overload accepting `Chart<? extends AxesChartStyler, ?>` and `XChartPanel<?>` |
| `PlotContent_` | `setChartZoom` wired for OHLC plot content |
| `XChartPanel` | `instanceof OHLCChart` zoom check added; Esc key binding resets zoom (see also #930) |
| `OHLCSeries` | Adds `filterXByValue`, `filterXByIndex`, `resetFilter`, `isAllXData` so the zoom engine can slice OHLC data |
| `AxesChartSeriesNumericalNoErrorBars` | Clarified zoom-related field comments |
| `TestForIssue770` | Standalone demo — drag to zoom, reset via Esc / button / double-click |

## How to test

Run `TestForIssue770` — drag horizontally on the chart to zoom into a date range, then reset with Esc, the Reset Zoom button, or double-click.