### PR TITLE
Fix #781: render OHLC doji candle as horizontal cross

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue781.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue781.java
@@ -1,0 +1,39 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Arrays;
+import java.util.List;
+import org.knowm.xchart.OHLCChart;
+import org.knowm.xchart.OHLCChartBuilder;
+import org.knowm.xchart.OHLCSeries;
+import org.knowm.xchart.SwingWrapper;
+
+/**
+ * Demonstrates that a doji candle (open == close) renders as a horizontal cross rather than just a
+ * vertical line.
+ *
+ * @see <a href="https://github.com/knowm/XChart/issues/781">Issue #781</a>
+ */
+public class TestForIssue781 {
+
+  public static void main(String[] args) {
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  public static OHLCChart getChart() {
+
+    OHLCChart chart =
+        new OHLCChartBuilder().width(800).height(600).title("Issue 781 - Doji Candle").build();
+
+    // Three candles: normal up, doji (open == close), normal down
+    List<Double> xData = Arrays.asList(1.0, 2.0, 3.0);
+    List<Double> openData = Arrays.asList(100.0, 110.0, 115.0);
+    List<Double> highData = Arrays.asList(108.0, 118.0, 120.0);
+    List<Double> lowData = Arrays.asList(95.0, 102.0, 105.0);
+    List<Double> closeData = Arrays.asList(106.0, 110.0, 107.0); // middle candle: open == close
+
+    OHLCSeries series = chart.addSeries("Candles", xData, openData, highData, lowData, closeData);
+    series.setOhlcSeriesRenderStyle(OHLCSeries.OHLCSeriesRenderStyle.Candle);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -262,15 +262,25 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                 } else {
                   g.setPaint(series.getDownColor());
                 }
-                rect.setRect(
-                    xStart,
-                    Math.min(openOffset, closeOffset),
-                    xEnd - xStart,
-                    Math.abs(closeOffset - openOffset));
-                g.fill(rect);
-                // add data labels
-                if (chart.getStyler().isToolTipsEnabled()) {
-                  toolTipArea.add(new Area(rect));
+                if (openOffset == closeOffset) {
+                  // Doji: open == close, draw a horizontal line across the candle width
+                  line.setLine(xStart, openOffset, xEnd, openOffset);
+                  g.draw(line);
+                  if (chart.getStyler().isToolTipsEnabled()) {
+                    rect.setRect(xStart, openOffset - lineWidth / 2, xEnd - xStart, lineWidth);
+                    toolTipArea.add(new Area(rect));
+                  }
+                } else {
+                  rect.setRect(
+                      xStart,
+                      Math.min(openOffset, closeOffset),
+                      xEnd - xStart,
+                      Math.abs(closeOffset - openOffset));
+                  g.fill(rect);
+                  // add data labels
+                  if (chart.getStyler().isToolTipsEnabled()) {
+                    toolTipArea.add(new Area(rect));
+                  }
                 }
 
               } else { // HiLo style


### PR DESCRIPTION
## Problem
A doji candlestick (where `open == close`) was rendered as a plain vertical line because the candle body rectangle had zero height, leaving only the high–low wick visible.

## Fix
In `PlotContent_OHLC.java`, detect when `openOffset == closeOffset` and draw a horizontal line across the full candle width instead of filling a zero-height rectangle. All non-doji candles are unaffected.

## Demo
`xchart-demo/.../standalone/issues/TestForIssue781.java` — contains a 3-candle series where the middle candle is a doji.

Fixes #781