### PR TITLE
Add xchart-site Maven module and GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -9,10 +9,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,9 +35,22 @@ jobs:
       - name: Build xchart + xchart-demo + xchart-site
         run: mvn package -pl xchart,xchart-demo,xchart-site --also-make --no-transfer-progress --batch-mode -Dfmt.skip=true
 
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: xchart-site/target/site-output
-          branch: gh-pages
-          clean: true
+          path: xchart-site/target/site-output
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -1,0 +1,37 @@
+# Builds the XChart static site and deploys it to GitHub Pages.
+# Runs automatically when a GitHub Release is published, or manually via workflow_dispatch.
+
+name: Deploy XChart Site to GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build xchart + xchart-demo + xchart-site
+        run: mvn package -pl xchart,xchart-demo,xchart-site --also-make --no-transfer-progress --batch-mode -Dfmt.skip=true
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: xchart-site/target/site-output
+          branch: gh-pages
+          clean: true

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <modules>
         <module>xchart</module>
         <module>xchart-demo</module>
+        <module>xchart-site</module>
     </modules>
 
     <repositories>

--- a/xchart-site/pom.xml
+++ b/xchart-site/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.knowm.xchart</groupId>
+    <artifactId>xchart-parent</artifactId>
+    <version>4.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>xchart-site</artifactId>
+
+  <name>XChart Site</name>
+  <description>Generates the static GitHub Pages website for XChart, with rendered chart images and navigation.</description>
+
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+    <site.output.dir>${project.build.directory}/site-output</site.output.dir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.knowm.xchart</groupId>
+      <artifactId>xchart-demo</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>generate-site</id>
+            <phase>package</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>org.knowm.xchart.site.GenerateSite</mainClass>
+              <arguments>
+                <argument>${site.output.dir}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/xchart-site/src/main/java/org/knowm/xchart/site/GenerateSite.java
+++ b/xchart-site/src/main/java/org/knowm/xchart/site/GenerateSite.java
@@ -1,0 +1,231 @@
+package org.knowm.xchart.site;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.BitmapEncoder.BitmapFormat;
+import org.knowm.xchart.demo.DemoChartsUtil;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Generates the static XChart GitHub Pages website.
+ *
+ * <p>Run via Maven exec plugin during the package phase. Outputs to target/site-output/.
+ */
+public class GenerateSite {
+
+  public static void main(String[] args) throws Exception {
+    String outputDir = args.length > 0 ? args[0] : "target/site-output";
+    new GenerateSite().generate(outputDir);
+  }
+
+  public void generate(String outputDirPath) throws Exception {
+    Path outputDir = Paths.get(outputDirPath);
+    Path chartsDir = outputDir.resolve("charts");
+    Path cssDir = outputDir.resolve("css");
+    Path jsDir = outputDir.resolve("js");
+
+    Files.createDirectories(chartsDir);
+    Files.createDirectories(cssDir);
+    Files.createDirectories(jsDir);
+
+    System.out.println("Collecting demo charts...");
+    List<ExampleChart<Chart<Styler, Series>>> allCharts = DemoChartsUtil.getAllDemoCharts();
+    if (allCharts == null || allCharts.isEmpty()) {
+      throw new IllegalStateException("No demo charts found — check classpath.");
+    }
+
+    // Group by category (derived from the simple class name prefix, e.g. "LineChart01" → "Line")
+    Map<String, List<ChartEntry>> byCategory = new LinkedHashMap<>();
+    for (ExampleChart<Chart<Styler, Series>> example : allCharts) {
+      String className = example.getClass().getSimpleName();
+      String category = extractCategory(className);
+      byCategory.computeIfAbsent(category, k -> new ArrayList<>()).add(new ChartEntry(className, example));
+    }
+
+    // Sort categories alphabetically
+    List<String> sortedCategories = new ArrayList<>(byCategory.keySet());
+    sortedCategories.sort(Comparator.naturalOrder());
+    Map<String, List<ChartEntry>> sorted = new LinkedHashMap<>();
+    for (String cat : sortedCategories) {
+      sorted.put(cat, byCategory.get(cat));
+    }
+
+    System.out.println("Rendering " + allCharts.size() + " charts across " + sorted.size() + " categories...");
+    renderChartImages(sorted, chartsDir);
+
+    System.out.println("Copying static assets...");
+    copyResource("site/css/style.css", cssDir.resolve("style.css"));
+    copyResource("site/js/main.js", jsDir.resolve("main.js"));
+
+    System.out.println("Generating HTML...");
+    String indexHtml = buildIndexHtml(sorted);
+    Files.write(outputDir.resolve("index.html"), indexHtml.getBytes(StandardCharsets.UTF_8));
+
+    System.out.println("Site generated at: " + outputDir.toAbsolutePath());
+  }
+
+  private void renderChartImages(Map<String, List<ChartEntry>> byCategory, Path chartsDir)
+      throws IOException {
+    for (Map.Entry<String, List<ChartEntry>> entry : byCategory.entrySet()) {
+      Path catDir = chartsDir.resolve(entry.getKey().toLowerCase());
+      Files.createDirectories(catDir);
+      for (ChartEntry ce : entry.getValue()) {
+        try {
+          Chart<?, ?> chart = ce.example.getChart();
+          String pngPath = catDir.resolve(ce.className + ".png").toString();
+          BitmapEncoder.saveBitmap(chart, pngPath, BitmapFormat.PNG);
+        } catch (Exception e) {
+          System.err.println("WARNING: Failed to render " + ce.className + ": " + e.getMessage());
+        }
+      }
+    }
+  }
+
+  private String buildIndexHtml(Map<String, List<ChartEntry>> byCategory) {
+    int totalCharts = byCategory.values().stream().mapToInt(List::size).sum();
+    StringBuilder sb = new StringBuilder();
+    sb.append("<!DOCTYPE html>\n")
+        .append("<html lang=\"en\">\n")
+        .append("<head>\n")
+        .append("  <meta charset=\"UTF-8\">\n")
+        .append("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n")
+        .append("  <title>XChart \u2014 Java Chart Library</title>\n")
+        .append("  <link rel=\"stylesheet\" href=\"css/style.css\">\n")
+        .append("</head>\n")
+        .append("<body>\n")
+        .append("  <header class=\"site-header\">\n")
+        .append("    <div class=\"header-inner\">\n")
+        .append("      <div class=\"header-title\">\n")
+        .append("        <span class=\"logo\">\uD83D\uDCCA</span>\n")
+        .append("        <h1>XChart</h1>\n")
+        .append("        <p class=\"tagline\">A lightweight Java charting library</p>\n")
+        .append("      </div>\n")
+        .append("      <nav class=\"header-links\">\n")
+        .append("        <a href=\"https://github.com/knowm/XChart\" target=\"_blank\">GitHub</a>\n")
+        .append("        <a href=\"https://search.maven.org/search?q=g:org.knowm.xchart\" target=\"_blank\">Maven Central</a>\n")
+        .append("      </nav>\n")
+        .append("    </div>\n")
+        .append("  </header>\n\n")
+        .append("  <div class=\"layout\">\n")
+        .append("    <aside class=\"sidebar\">\n")
+        .append("      <div class=\"sidebar-header\">\n")
+        .append("        <input type=\"text\" id=\"search\" placeholder=\"Search charts\u2026\" autocomplete=\"off\">\n")
+        .append("      </div>\n")
+        .append("      <nav class=\"category-nav\">\n")
+        .append("        <a href=\"#all\" class=\"cat-link active\" data-category=\"all\">\n")
+        .append("          All <span class=\"badge\">")
+        .append(totalCharts)
+        .append("</span>\n")
+        .append("        </a>\n");
+
+    for (Map.Entry<String, List<ChartEntry>> entry : byCategory.entrySet()) {
+      String cat = entry.getKey();
+      int count = entry.getValue().size();
+      sb.append("        <a href=\"#")
+          .append(cat.toLowerCase())
+          .append("\" class=\"cat-link\" data-category=\"")
+          .append(cat.toLowerCase())
+          .append("\">")
+          .append(cat)
+          .append(" <span class=\"badge\">")
+          .append(count)
+          .append("</span></a>\n");
+    }
+
+    sb.append("      </nav>\n")
+        .append("    </aside>\n\n")
+        .append("    <main class=\"content\">\n")
+        .append("      <div class=\"charts-grid\" id=\"charts-grid\">\n");
+
+    for (Map.Entry<String, List<ChartEntry>> entry : byCategory.entrySet()) {
+      String cat = entry.getKey();
+      for (ChartEntry ce : entry.getValue()) {
+        String chartName = ce.example.getExampleChartName();
+        String imgPath = "charts/" + cat.toLowerCase() + "/" + ce.className + ".png";
+        sb.append("        <div class=\"chart-card\" data-category=\"")
+            .append(cat.toLowerCase())
+            .append("\">\n")
+            .append("          <div class=\"chart-img-wrap\">\n")
+            .append("            <img src=\"")
+            .append(imgPath)
+            .append("\" alt=\"")
+            .append(escapeHtml(chartName))
+            .append("\" loading=\"lazy\">\n")
+            .append("          </div>\n")
+            .append("          <div class=\"chart-info\">\n")
+            .append("            <span class=\"chart-category\">")
+            .append(cat)
+            .append("</span>\n")
+            .append("            <p class=\"chart-name\">")
+            .append(escapeHtml(chartName))
+            .append("</p>\n")
+            .append("          </div>\n")
+            .append("        </div>\n");
+      }
+    }
+
+    sb.append("        <div class=\"no-results\" id=\"no-results\" style=\"display:none;\">\n")
+        .append("          No charts match your search.\n")
+        .append("        </div>\n")
+        .append("      </div>\n")
+        .append("    </main>\n")
+        .append("  </div>\n\n")
+        .append("  <footer class=\"site-footer\">\n")
+        .append("    <p>XChart is open source under the <a href=\"https://github.com/knowm/XChart/blob/develop/LICENSE\" target=\"_blank\">Apache 2.0 License</a></p>\n")
+        .append("  </footer>\n\n")
+        .append("  <script src=\"js/main.js\"></script>\n")
+        .append("</body>\n")
+        .append("</html>\n");
+
+    return sb.toString();
+  }
+
+  /** Derives a display category name from a class name like "LineChart01" → "Line". */
+  private String extractCategory(String className) {
+    // Strip trailing digits
+    String noDigits = className.replaceAll("\\d+$", "");
+    // Remove "Chart" suffix if present
+    if (noDigits.endsWith("Chart")) {
+      noDigits = noDigits.substring(0, noDigits.length() - 5);
+    }
+    return noDigits.isEmpty() ? "Other" : noDigits;
+  }
+
+  private String escapeHtml(String s) {
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+  }
+
+  private void copyResource(String resourcePath, Path destination) throws IOException {
+    try (InputStream in = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+      if (in == null) {
+        throw new IllegalStateException("Resource not found: " + resourcePath);
+      }
+      Files.copy(in, destination, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  private static class ChartEntry {
+    final String className;
+    final ExampleChart<Chart<Styler, Series>> example;
+
+    ChartEntry(String className, ExampleChart<Chart<Styler, Series>> example) {
+      this.className = className;
+      this.example = example;
+    }
+  }
+}

--- a/xchart-site/src/main/resources/site/css/style.css
+++ b/xchart-site/src/main/resources/site/css/style.css
@@ -1,0 +1,276 @@
+/* XChart Site — style.css */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg: #f8f9fb;
+  --surface: #ffffff;
+  --surface-alt: #f0f2f5;
+  --border: #e2e5ea;
+  --accent: #2563eb;
+  --accent-hover: #1d4ed8;
+  --text: #111827;
+  --text-muted: #6b7280;
+  --radius: 10px;
+  --sidebar-width: 210px;
+  --header-height: 64px;
+  --shadow: 0 2px 8px rgba(0,0,0,.08);
+  --shadow-hover: 0 6px 20px rgba(0,0,0,.14);
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+/* ── Header ── */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  height: var(--header-height);
+}
+
+.header-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+}
+
+.logo {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.header-title h1 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -.3px;
+}
+
+.tagline {
+  font-size: .8rem;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+.header-links {
+  display: flex;
+  gap: 1rem;
+}
+
+.header-links a {
+  font-size: .875rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color .15s;
+}
+
+.header-links a:hover {
+  color: var(--accent);
+}
+
+/* ── Layout ── */
+.layout {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  min-height: calc(100vh - var(--header-height) - 56px);
+}
+
+/* ── Sidebar ── */
+.sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  position: sticky;
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
+  overflow-y: auto;
+  padding: 1.25rem 1rem;
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.sidebar-header {
+  margin-bottom: 1rem;
+}
+
+#search {
+  width: 100%;
+  padding: .5rem .75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: .875rem;
+  background: var(--surface-alt);
+  color: var(--text);
+  outline: none;
+  transition: border-color .15s, box-shadow .15s;
+}
+
+#search:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37,99,235,.15);
+}
+
+.category-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cat-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .45rem .75rem;
+  border-radius: 7px;
+  font-size: .875rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: background .12s, color .12s;
+}
+
+.cat-link:hover {
+  background: var(--surface-alt);
+  color: var(--text);
+}
+
+.cat-link.active {
+  background: #eff6ff;
+  color: var(--accent);
+}
+
+.badge {
+  font-size: .72rem;
+  font-weight: 600;
+  background: var(--surface-alt);
+  color: var(--text-muted);
+  padding: .1rem .45rem;
+  border-radius: 999px;
+}
+
+.cat-link.active .badge {
+  background: #dbeafe;
+  color: var(--accent);
+}
+
+/* ── Content ── */
+.content {
+  flex: 1;
+  padding: 1.5rem;
+  min-width: 0;
+}
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.25rem;
+}
+
+/* ── Chart Card ── */
+.chart-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  transition: box-shadow .2s, transform .2s;
+}
+
+.chart-card:hover {
+  box-shadow: var(--shadow-hover);
+  transform: translateY(-2px);
+}
+
+.chart-card.hidden {
+  display: none;
+}
+
+.chart-img-wrap {
+  background: var(--surface-alt);
+  aspect-ratio: 4/3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.chart-img-wrap img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.chart-info {
+  padding: .75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+
+.chart-category {
+  font-size: .72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--accent);
+}
+
+.chart-name {
+  font-size: .875rem;
+  font-weight: 500;
+  color: var(--text);
+}
+
+/* ── No results ── */
+.no-results {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 4rem 1rem;
+  color: var(--text-muted);
+  font-size: .95rem;
+}
+
+/* ── Footer ── */
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 1rem 1.5rem;
+  text-align: center;
+  font-size: .8rem;
+  color: var(--text-muted);
+  background: var(--surface);
+}
+
+.site-footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+/* ── Scrollbar ── */
+.sidebar::-webkit-scrollbar {
+  width: 4px;
+}
+.sidebar::-webkit-scrollbar-track { background: transparent; }
+.sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }

--- a/xchart-site/src/main/resources/site/js/main.js
+++ b/xchart-site/src/main/resources/site/js/main.js
@@ -1,0 +1,47 @@
+// XChart Site — main.js
+// Category filtering and search
+
+(function () {
+  const cards = Array.from(document.querySelectorAll('.chart-card'));
+  const catLinks = Array.from(document.querySelectorAll('.cat-link'));
+  const searchInput = document.getElementById('search');
+  const noResults = document.getElementById('no-results');
+
+  let activeCategory = 'all';
+  let searchQuery = '';
+
+  function applyFilters() {
+    let visible = 0;
+    cards.forEach(function (card) {
+      const cat = card.dataset.category;
+      const name = card.querySelector('.chart-name').textContent.toLowerCase();
+      const catLabel = card.querySelector('.chart-category').textContent.toLowerCase();
+      const matchesCat = activeCategory === 'all' || cat === activeCategory;
+      const matchesSearch =
+        searchQuery === '' || name.includes(searchQuery) || catLabel.includes(searchQuery);
+
+      if (matchesCat && matchesSearch) {
+        card.classList.remove('hidden');
+        visible++;
+      } else {
+        card.classList.add('hidden');
+      }
+    });
+    noResults.style.display = visible === 0 ? 'block' : 'none';
+  }
+
+  catLinks.forEach(function (link) {
+    link.addEventListener('click', function (e) {
+      e.preventDefault();
+      catLinks.forEach(function (l) { l.classList.remove('active'); });
+      link.classList.add('active');
+      activeCategory = link.dataset.category;
+      applyFilters();
+    });
+  });
+
+  searchInput.addEventListener('input', function () {
+    searchQuery = searchInput.value.trim().toLowerCase();
+    applyFilters();
+  });
+})();


### PR DESCRIPTION
## Motivation

XChart has no public gallery of its charts -- people evaluating the library have to clone the repo and run the Swing demo app just to see what it can produce. This PR adds a static website that renders every demo chart to PNG and presents them in a searchable, navigable gallery, hosted on GitHub Pages.

## Approach

A new `xchart-site/` Maven module sits alongside `xchart/` and `xchart-demo/`. During the `package` phase, `GenerateSite.java` uses the existing `DemoChartsUtil` to instantiate every `ExampleChart` class, renders each to a PNG via `BitmapEncoder`, and emits a fully static `index.html` with the images embedded as chart cards.

The site itself is pure static HTML/CSS/JS -- no framework, no build tool, no Node dependency:

- **Sticky header** with links to GitHub and Maven Central
- **Category sidebar** (Area, Bar, Box, Bubble, Line, Pie, etc.) derived from chart class names
- **Live search** that filters cards client-side as you type
- **Lazy-loaded chart images** in a responsive card grid with hover lift effects
- Zero JavaScript dependencies

### Deployment

A new workflow (`.github/workflows/deploy_site.yml`) builds the site and deploys it to GitHub Pages using the official `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages` action chain (no `gh-pages` branch needed).

Trigger conditions:
- `on: release: types: [published]` -- auto-deploys on every GitHub Release
- `on: workflow_dispatch` -- manual trigger for preview/testing

### Enabling GitHub Pages

After merging, go to **Settings -> Pages -> Source -> GitHub Actions** to activate the site. Then trigger the workflow once manually to do the first deploy.

## Files changed

| File | Purpose |
|------|---------|
| `xchart-site/pom.xml` | New Maven module; runs `GenerateSite` via `exec-maven-plugin` at `package` phase |
| `xchart-site/.../GenerateSite.java` | Collects all demo charts, renders PNGs, generates `index.html` |
| `site/css/style.css` | Modern vanilla CSS layout and card styles |
| `site/js/main.js` | Client-side category filtering and search |
| `.github/workflows/deploy_site.yml` | GitHub Actions Pages deploy workflow |
| `pom.xml` | Adds `xchart-site` to root module list |