### PR TITLE
Fix #862: add null guards so BitmapEncoder works with tooltips/cursor enabled

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue862.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue862.java
@@ -1,0 +1,70 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.BitmapEncoder.BitmapFormat;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Demonstrates the fix for issue #862 — {@link BitmapEncoder#saveBitmap} throws NPE when tooltips
+ * are enabled.
+ *
+ * <p>Root cause: {@code ToolTips} and {@code Cursor} are only injected into the chart's
+ * {@code PlotContent_} from {@code XChartPanel}. When rendering headlessly via {@link
+ * BitmapEncoder}, no panel is created, so the fields remain {@code null}. Every {@code doPaint()}
+ * override that called {@code toolTips.addData()} guarded only on {@code isToolTipsEnabled()},
+ * causing an NPE at runtime.
+ *
+ * <p>Fix: all {@code isToolTipsEnabled()} / {@code isCursorEnabled()} guards in every {@code
+ * PlotContent_*} subclass now also check {@code toolTips != null} / {@code cursor != null}.
+ *
+ * <p>To verify the fix: calling {@link #getChart()} must not throw. Previously it threw:
+ *
+ * <pre>
+ *   java.lang.NullPointerException
+ *     at PlotContent_XY.doPaint(PlotContent_XY.java:304)
+ *     at BitmapEncoder.getBufferedImage(BitmapEncoder.java:277)
+ * </pre>
+ */
+public class TestForIssue862 {
+
+  public static void main(String[] args) throws IOException {
+
+    XYChart chart = getChart();
+
+    // Write to /tmp — confirms no NPE during headless rendering with tooltips enabled.
+    BitmapEncoder.saveBitmap(chart, "/tmp/issue862", BitmapFormat.PNG);
+    System.out.println("Saved /tmp/issue862.png — no NPE.");
+
+    // Also show the interactive chart to confirm tooltips still work with a panel.
+    new SwingWrapper<>(chart).displayChart();
+  }
+
+  /**
+   * Returns an XYChart with tooltips enabled. Calling this method previously triggered an NPE
+   * inside {@code BitmapEncoder.saveBitmap()} before the fix.
+   */
+  public static XYChart getChart() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Issue #862 – BitmapEncoder + tooltips (was: NPE)")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .build();
+
+    chart.getStyler().setToolTipsEnabled(true);
+    chart.getStyler().setToolTipsAlwaysVisible(true);
+    chart.getStyler().setToolTipType(Styler.ToolTipType.yLabels);
+
+    chart.addSeries("series", Arrays.asList(1, 2, 3, 4, 5), Arrays.asList(2.0, 4.0, 3.0, 7.0, 5.0));
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
@@ -68,8 +68,10 @@ public abstract class PlotContent_<ST extends Styler, S extends Series> implemen
     }
 
     // TODO put this in PlotContent_XY.
-    if ((chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled())
-        || (chart instanceof OHLCChart && ((OHLCStyler) chart.getStyler()).isZoomEnabled())) {
+    if (chartZoom != null
+        && ((chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled())
+            || (chart instanceof OHLCChart
+                && ((OHLCStyler) chart.getStyler()).isZoomEnabled()))) {
       chartZoom.paint(g);
     }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
@@ -41,7 +41,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
     // Y-Axis
     yTickSpace = boxPlotStyler.getPlotContentSize() * getBounds().getHeight();
     yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
-    boolean toolTipsEnabled = chart.getStyler().isToolTipsEnabled();
+    boolean toolTipsEnabled = toolTips != null && chart.getStyler().isToolTipsEnabled();
     double gridStep = xTickSpace / chart.getSeriesMap().size();
 
     BoxPlotDataCalculator<ST, S> boxPlotDataCalculator = new BoxPlotDataCalculator<>();
@@ -234,7 +234,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
     area.add(new Area(lowLine.getBounds()));
     area.add(new Area(rect.getBounds()));
 
-    if (boxPlotStyler.isToolTipsEnabled()) {
+    if (toolTips != null && boxPlotStyler.isToolTipsEnabled()) {
       toolTips.addData(
           area,
           xOffset,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
@@ -131,7 +131,7 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
           g.draw(bubble);
 
           // add tooltips
-          if (chart.getStyler().isToolTipsEnabled()) {
+          if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
             toolTips.addData(
                 bubble,
                 xOffset,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -484,7 +484,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
           g.draw(line);
         }
         // add data labels
-        if (chart.getStyler().isToolTipsEnabled()) {
+        if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
           Rectangle2D.Double rect =
               new Rectangle2D.Double(xOffset, yOffset, barWidth, Math.abs(yOffset - zeroOffset));
           double yPoint;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Dial.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Dial.java
@@ -223,7 +223,7 @@ public class PlotContent_Dial<ST extends DialStyler, S extends DialSeries>
       double yOffset = yCenter - Math.sin(radians) * (yDiameter * arrowLengthPercentage);
 
       Path2D.Double path = new Path2D.Double();
-      if (styler.isToolTipsEnabled()) {
+      if (toolTips != null && styler.isToolTipsEnabled()) {
         String label = series.getLabel();
         if (label == null) {
           if (styler.getDecimalPattern() != null) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
@@ -95,7 +95,7 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
         showValue(g, rect, df.format(numbers[2]));
       }
 
-      if (heatMapStyler.isToolTipsEnabled()) {
+      if (toolTips != null && heatMapStyler.isToolTipsEnabled()) {
         toolTips.addData(
             rect,
             rect.getCenterX(),

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HorizontalBar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HorizontalBar.java
@@ -171,7 +171,7 @@ public class PlotContent_HorizontalBar<
         }
 
         // add data labels
-        if (chart.getStyler().isToolTipsEnabled()) {
+        if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
           Rectangle2D.Double rect =
               new Rectangle2D.Double(
                   zeroOffset, yOffset, Math.abs(xOffset - zeroOffset), barHeight);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -139,7 +139,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
           }
 
           // add tooltips
-          if (chart.getStyler().isToolTipsEnabled()) {
+          if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
             toolTips.addData(
                 xOffset,
                 yOffset,
@@ -250,7 +250,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
               g.draw(line);
               final double xStart = xOffset - candleHalfWidth;
               final double xEnd = xOffset + candleHalfWidth;
-              if (chart.getStyler().isToolTipsEnabled()) {
+              if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
                 rect.setRect(
                     xOffset - lineWidth / 2, highOffset, lineWidth, lowOffset - highOffset);
                 toolTipArea = new Area(rect);
@@ -266,7 +266,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                   // Doji: open == close, draw a horizontal line across the candle width
                   line.setLine(xStart, openOffset, xEnd, openOffset);
                   g.draw(line);
-                  if (chart.getStyler().isToolTipsEnabled()) {
+                  if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
                     rect.setRect(xStart, openOffset - lineWidth / 2, xEnd - xStart, lineWidth);
                     toolTipArea.add(new Area(rect));
                   }
@@ -278,7 +278,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                       Math.abs(closeOffset - openOffset));
                   g.fill(rect);
                   // add data labels
-                  if (chart.getStyler().isToolTipsEnabled()) {
+                  if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
                     toolTipArea.add(new Area(rect));
                   }
                 }
@@ -289,7 +289,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                 g.draw(line);
                 line.setLine(xOffset, closeOffset, xEnd, closeOffset);
                 g.draw(line);
-                if (chart.getStyler().isToolTipsEnabled()) {
+                if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
                   rect.setRect(xStart, openOffset - lineWidth / 2, xOffset - xStart, lineWidth);
                   toolTipArea.add(new Area(rect));
                   rect.setRect(xOffset, closeOffset - lineWidth / 2, xEnd - xOffset, lineWidth);
@@ -300,7 +300,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
           }
 
           // add tooltips
-          if (chart.getStyler().isToolTipsEnabled()) {
+          if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
 
             StringBuilder sb = new StringBuilder();
             if (series.getVolumeData() != null) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -193,7 +193,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
       // TOOLTIPS ////////////////////////////////////////////////////
       // TOOLTIPS ////////////////////////////////////////////////////
 
-      if (pieStyler.isToolTipsEnabled()) {
+      if (toolTips != null && pieStyler.isToolTipsEnabled()) {
         // add data labels
         // maybe another option to construct this label
         // TODO use tool tip label type enum and customize this label

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
@@ -233,7 +233,7 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
         }
 
         // add data labels
-        if (chart.getStyler().isToolTipsEnabled()) {
+        if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
           String label = null;
           if (tooltipOverrides != null) {
             label = tooltipOverrides[i];

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -312,7 +312,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
               chart.getYAxisFormat(series.getYAxisDecimalPattern()).format(yOrig));
         }
 
-        if (xyStyler.isCursorEnabled()) {
+        if (cursor != null && xyStyler.isCursorEnabled()) {
           Format xFormat;
           Format yFormat;
           if (xyStyler.getCustomCursorXDataFormattingFunction() == null) {
@@ -339,7 +339,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
       g.setColor(series.getFillColor());
       closePathXY(g, path, previousX, yZeroOffset, polygonStartX, polygonStartY);
     }
-    if (chart.getStyler().isCursorEnabled()) {
+    if (cursor != null && chart.getStyler().isCursorEnabled()) {
       cursor.paint(g);
     }
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -304,7 +304,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
         }
 
         // add tooltips
-        if (chart.getStyler().isToolTipsEnabled()) {
+        if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
           toolTips.addData(
               xOffset,
               yOffset,

--- a/xchart/src/test/java/org/knowm/xchart/BitmapEncoderTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/BitmapEncoderTest.java
@@ -1,9 +1,11 @@
 package org.knowm.xchart;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import org.knowm.xchart.style.Styler;
 
 public class BitmapEncoderTest {
 
@@ -21,5 +23,27 @@ public class BitmapEncoderTest {
         "asdf.bmp", BitmapEncoder.addFileExtension("asdf", BitmapEncoder.BitmapFormat.BMP));
     assertEquals(".bmp", BitmapEncoder.addFileExtension(".bmp", BitmapEncoder.BitmapFormat.BMP));
     assertEquals(".bmp", BitmapEncoder.addFileExtension(".BmP", BitmapEncoder.BitmapFormat.BMP));
+  }
+
+  /** Regression test for issue #862: BitmapEncoder must not NPE when tooltips are enabled. */
+  @Test
+  public void getBufferedImageDoesNotNPEWithToolTipsEnabled() {
+    XYChart chart = new XYChartBuilder().width(400).height(300).build();
+    chart.getStyler().setToolTipsEnabled(true);
+    chart.getStyler().setToolTipsAlwaysVisible(true);
+    chart.getStyler().setToolTipType(Styler.ToolTipType.yLabels);
+    chart.addSeries("series", new double[] {1, 2, 3}, new double[] {4, 5, 6});
+
+    assertDoesNotThrow(() -> BitmapEncoder.getBufferedImage(chart));
+  }
+
+  /** Regression test for issue #862: zoom-enabled charts must not NPE with BitmapEncoder. */
+  @Test
+  public void getBufferedImageDoesNotNPEWithZoomEnabled() {
+    XYChart chart = new XYChartBuilder().width(400).height(300).build();
+    chart.getStyler().setZoomEnabled(true);
+    chart.addSeries("series", new double[] {1, 2, 3}, new double[] {4, 5, 6});
+
+    assertDoesNotThrow(() -> BitmapEncoder.getBufferedImage(chart));
   }
 }


### PR DESCRIPTION
## Why

`BitmapEncoder.saveBitmap()` throws a `NullPointerException` when the chart has tooltips enabled. This regression was introduced in 3.7.0 (commit `0de2c997`) and is still present through 3.8.8 and beyond.

The root cause: `ToolTips` and `Cursor` are interactive Swing features that are **only injected into `PlotContent_` from `XChartPanel`**. When rendering headlessly via `BitmapEncoder` (no panel, no mouse listeners), those fields stay `null`. Every `doPaint()` override called `toolTips.addData()` guarded only on `isToolTipsEnabled()` -- no null check -- causing the NPE.

The base class `PlotContent_.paint()` already had the correct pattern (`&& toolTips != null`). The subclasses' `doPaint()` methods were just never updated to match.

## What changed

- Added `toolTips != null &&` to every `isToolTipsEnabled()` check inside `doPaint()` across all 10 `PlotContent_*` subclasses.
- Added `cursor != null &&` to the `isCursorEnabled()` guards in `PlotContent_XY` (`cursor.addData()` and `cursor.paint()`).
- Added a `chartZoom != null` guard in `PlotContent_.paint()` for the zoom paint call.
- Added regression tests in `BitmapEncoderTest` covering both tooltips and zoom.
- Added `TestForIssue862.java` demo in `xchart-demo/.../standalone/issues/`.

Fixes: #862