### PR TITLE
Decouple ToolTips/ChartZoom/Cursor from PlotContent rendering pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,12 @@ BoxChart chart =
 
 // Choose a calculation method
 chart.getStyler().setBoxplotCalCulationMethod(BoxplotCalCulationMethod.N_LESS_1_PLUS_1);
-chart.getStyler().setToolTipsEnabled(true);
 
 // Series
-chart.addSeries("boxOne",Arrays.asList(1,2,3,4));
-new SwingWrapper<BoxChart>(chart).displayChart();
+chart.addSeries("boxOne", Arrays.asList(1, 2, 3, 4));
+SwingWrapper<BoxChart> sw = new SwingWrapper<>(chart);
+sw.displayChart();
+sw.getXChartPanel().setToolTipsEnabled(true);
 ```
 
 Four calculation methods for boxplots:
@@ -474,14 +475,16 @@ double-clicking on the chart or by clicking on the "reset" button, which can be 
 
 ![](https://raw.githubusercontent.com/knowm/XChart/develop/etc/XChart_Zoom.png)
 
-The following example zoom style options show which are available:
+Zoom is a Swing-panel feature and is configured on `XChartPanel`, not on the Styler:
 
 ```java
-chart.getStyler().setZoomEnabled(true);
-chart.getStyler().setZoomResetButtomPosition(Styler.CardinalPosition.InsideS);
-chart.getStyler().setZoomResetByDoubleClick(false);
-chart.getStyler().setZoomResetByButton(true);
-chart.getStyler().setZoomSelectionColor(new Color(0,0,192,128));
+SwingWrapper<XYChart> sw = new SwingWrapper<>(chart);
+sw.displayChart();
+sw.getXChartPanel()
+    .setZoomEnabled(true)
+    .setZoomResetByDoubleClick(false)
+    .setZoomResetByButton(true)
+    .setZoomSelectionColor(new Color(0, 0, 192, 128));
 ```
 
 A working example can be found at [DateChart01](https://github.com/knowm/XChart/blob/develop/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart01.java).
@@ -532,49 +535,58 @@ A working example can be found at [ScatterChart04](https://github.com/knowm/XCha
 
 ### Tool Tips
 
-For all chart types, tool tips can be activated on an `XChartPanel` via
+Tool tips come in two flavours:
+
+**1. Hover tooltips** — interactive labels that follow the mouse, visible only in a Swing panel. Configured on `XChartPanel`:
 
 ```java
-chart.getStyler().setToolTipsEnabled(true);
+SwingWrapper<XYChart> sw = new SwingWrapper<>(chart);
+sw.displayChart();
+sw.getXChartPanel().setToolTipsEnabled(true);
 ```
 
-![](https://raw.githubusercontent.com/knowm/XChart/develop/etc/XChart_Tooltips.png)
-
-The following example tooltip options show which are available:
+**2. Always-visible labels** — data-point labels baked into the chart image itself. These appear in Swing panels *and* in headless output such as `BitmapEncoder`. Configured on the Styler:
 
 ```java
-chart.getStyler().setToolTipsEnabled(true);
 chart.getStyler().setToolTipsAlwaysVisible(true);
-chart.getStyler().setToolTipFont( new Font("Verdana", Font.BOLD, 12));
+chart.getStyler().setToolTipType(ToolTipType.yLabels); // xAndYLabels (default), xLabels, yLabels
+```
+
+Both can be active at the same time. Tooltip visual appearance (font, colors) is always on the Styler:
+
+```java
+chart.getStyler().setToolTipFont(new Font("Verdana", Font.BOLD, 12));
 chart.getStyler().setToolTipHighlightColor(Color.CYAN);
 chart.getStyler().setToolTipBorderColor(Color.BLACK);
 chart.getStyler().setToolTipBackgroundColor(Color.LIGHT_GRAY);
-chart.getStyler().setToolTipType(Styler.ToolTipType.xAndYLabels);
 ```
+
+![](https://raw.githubusercontent.com/knowm/XChart/develop/etc/XChart_Tooltips.png)
 
 A working example can be found at [LineChart05](https://github.com/knowm/XChart/blob/develop/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart05.java).
 
 ### Cursor
 
-For the `XYChart` chart type, it is possible to add an interactive cursor on an `XChartPanel` via
+For the `XYChart` chart type, it is possible to add an interactive cursor on an `XChartPanel`. Cursor is a Swing-panel feature configured on `XChartPanel`:
 
 ```java
-chart.getStyler().setCursorEnabled(true);
+SwingWrapper<XYChart> sw = new SwingWrapper<>(chart);
+sw.displayChart();
+sw.getXChartPanel().setCursorEnabled(true);
 ```
 
 ![](https://raw.githubusercontent.com/knowm/XChart/develop/etc/XChart_Cursor.png)
 
-The following example cursor options show which are available:
+Cursor visual appearance is configured on the Styler:
 
 ```java
-chart.getStyler().setCursorEnabled(true);
 chart.getStyler().setCursorColor(Color.GREEN);
 chart.getStyler().setCursorLineWidth(30f);
 chart.getStyler().setCursorFont(new Font("Verdana", Font.BOLD, 12));
 chart.getStyler().setCursorFontColor(Color.ORANGE);
 chart.getStyler().setCursorBackgroundColor(Color.BLUE);
-chart.getStyler().setCustomCursorXDataFormattingFunction(x ->"hello xvalue: "+x);
-chart.getStyler().setCustomCursorYDataFormattingFunction(y ->"hello yvalue divided by 2: "+y /2);
+chart.getStyler().setCustomCursorXDataFormattingFunction(x -> "hello xvalue: " + x);
+chart.getStyler().setCustomCursorYDataFormattingFunction(y -> "hello yvalue divided by 2: " + y / 2);
 ```
 
 A working example can be found at [LineChart09](https://github.com/knowm/XChart/blob/develop/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart09.java).

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartDemo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartDemo.java
@@ -86,7 +86,9 @@ public class XChartDemo extends JPanel implements TreeSelectionListener {
     if (node.isLeaf()) {
       ChartInfo chartInfo = (ChartInfo) nodeInfo;
       // displayURL(chartInfo.bookURL);
-      chartPanel = new XChartPanel(chartInfo.getExampleChart().getChart());
+      ExampleChart exampleChart = chartInfo.getExampleChart();
+      chartPanel = new XChartPanel(exampleChart.getChart());
+      exampleChart.customizePanel(chartPanel);
       splitPane.setBottomComponent(chartPanel);
 
       // start running a simulated data feed for the sample real-time plot

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ExampleChart.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ExampleChart.java
@@ -1,5 +1,6 @@
 package org.knowm.xchart.demo.charts;
 
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.internal.chartpart.Chart;
 
 public interface ExampleChart<C extends Chart<?, ?>> {
@@ -7,4 +8,13 @@ public interface ExampleChart<C extends Chart<?, ?>> {
   C getChart();
 
   String getExampleChartName();
+
+  /**
+   * Optional hook for configuring {@link XChartPanel} interaction features (tooltips, zoom,
+   * cursor) after the panel is created by the demo app. The default implementation does nothing.
+   * Override to enable hover tooltips, zoom, etc. for this example.
+   *
+   * @param panel the panel that was just created with {@link #getChart()}
+   */
+  default void customizePanel(XChartPanel<C> panel) {}
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart07.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart07.java
@@ -31,7 +31,7 @@ public class BarChart07 implements ExampleChart<CategoryChart> {
     CategoryChart chart = exampleChart.getChart();
     SwingWrapper<CategoryChart> wrapper = new SwingWrapper<>(chart);
     wrapper.displayChart();
-    wrapper.getXChartPanel().setToolTipsEnabled(true).setToolTipType(ToolTipType.yLabels);
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -51,6 +51,7 @@ public class BarChart07 implements ExampleChart<CategoryChart> {
     chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
     chart.getStyler().setAvailableSpaceFill(.96);
     chart.getStyler().setPlotGridVerticalLinesVisible(false);
+    chart.getStyler().setToolTipType(ToolTipType.yLabels);
     // Series
     Histogram histogram1 = new Histogram(getGaussianData(1000), 10, -30, 30);
     chart.addSeries("histogram 1", histogram1.getxAxisData(), histogram1.getyAxisData());

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart07.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart07.java
@@ -7,6 +7,7 @@ import org.knowm.xchart.CategoryChart;
 import org.knowm.xchart.CategoryChartBuilder;
 import org.knowm.xchart.Histogram;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.Styler.LegendPosition;
@@ -28,7 +29,9 @@ public class BarChart07 implements ExampleChart<CategoryChart> {
 
     ExampleChart<CategoryChart> exampleChart = new BarChart07();
     CategoryChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<CategoryChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true).setToolTipType(ToolTipType.yLabels);
   }
 
   @Override
@@ -48,9 +51,6 @@ public class BarChart07 implements ExampleChart<CategoryChart> {
     chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
     chart.getStyler().setAvailableSpaceFill(.96);
     chart.getStyler().setPlotGridVerticalLinesVisible(false);
-    chart.getStyler().setToolTipsEnabled(true);
-    chart.getStyler().setToolTipType(Styler.ToolTipType.yLabels);
-
     // Series
     Histogram histogram1 = new Histogram(getGaussianData(1000), 10, -30, 30);
     chart.addSeries("histogram 1", histogram1.getxAxisData(), histogram1.getyAxisData());

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart07.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart07.java
@@ -8,6 +8,7 @@ import org.knowm.xchart.CategoryChartBuilder;
 import org.knowm.xchart.Histogram;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.ToolTipType;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.Styler.LegendPosition;
@@ -59,6 +60,12 @@ public class BarChart07 implements ExampleChart<CategoryChart> {
     chart.addSeries("histogram 2", histogram2.getxAxisData(), histogram2.getyAxisData());
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<CategoryChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   private List<Integer> getGaussianData(int count) {

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/box/BoxChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/box/BoxChart02.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import org.knowm.xchart.BoxChart;
 import org.knowm.xchart.BoxChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.BoxStyler.BoxplotCalCulationMethod;
 import org.knowm.xchart.style.Styler.ChartTheme;
@@ -43,6 +44,12 @@ public class BoxChart02 implements ExampleChart<BoxChart> {
     chart.addSeries("ccc", Arrays.asList(-10, -8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 20, 21));
     chart.getStyler().setShowWithinAreaPoint(true);
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<BoxChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/box/BoxChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/box/BoxChart02.java
@@ -17,7 +17,9 @@ public class BoxChart02 implements ExampleChart<BoxChart> {
   public static void main(String[] args) {
     ExampleChart<BoxChart> exampleChart = new BoxChart02();
     BoxChart chart = exampleChart.getChart();
-    new SwingWrapper<BoxChart>(chart).displayChart();
+    SwingWrapper<BoxChart> wrapper = new SwingWrapper<BoxChart>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -40,7 +42,6 @@ public class BoxChart02 implements ExampleChart<BoxChart> {
     chart.addSeries("bbb", Arrays.asList(1, 2, 3, 4, 5, 6, 17));
     chart.addSeries("ccc", Arrays.asList(-10, -8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 20, 21));
     chart.getStyler().setShowWithinAreaPoint(true);
-    chart.getStyler().setToolTipsEnabled(true);
     return chart;
   }
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/box/BoxChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/box/BoxChart03.java
@@ -17,7 +17,9 @@ public class BoxChart03 implements ExampleChart<BoxChart> {
   public static void main(String[] args) {
     ExampleChart<BoxChart> exampleChart = new BoxChart03();
     BoxChart chart = exampleChart.getChart();
-    new SwingWrapper<BoxChart>(chart).displayChart();
+    SwingWrapper<BoxChart> wrapper = new SwingWrapper<BoxChart>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -35,7 +37,6 @@ public class BoxChart03 implements ExampleChart<BoxChart> {
             .build();
 
     // Customize Chart
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setYAxisLogarithmic(true);
 
     // Series

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/box/BoxChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/box/BoxChart03.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import org.knowm.xchart.BoxChart;
 import org.knowm.xchart.BoxChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler.ChartTheme;
 
@@ -42,6 +43,12 @@ public class BoxChart03 implements ExampleChart<BoxChart> {
     // Series
     chart.addSeries("aaa", Arrays.asList(10, 40, 80, 120, 350));
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<BoxChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bubble/BubbleChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bubble/BubbleChart01.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.demo.charts.bubble;
 import org.knowm.xchart.BubbleChart;
 import org.knowm.xchart.BubbleChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler;
 
@@ -56,6 +57,12 @@ public class BubbleChart01 implements ExampleChart<BubbleChart> {
     chart.addSeries("B", xData2, yData2, bubbleData2);
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<BubbleChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bubble/BubbleChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bubble/BubbleChart01.java
@@ -21,7 +21,9 @@ public class BubbleChart01 implements ExampleChart<BubbleChart> {
 
     ExampleChart<BubbleChart> exampleChart = new BubbleChart01();
     BubbleChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<BubbleChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -38,7 +40,6 @@ public class BubbleChart01 implements ExampleChart<BubbleChart> {
             .build();
     chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideN);
     chart.getStyler().setLegendLayout(Styler.LegendLayout.Horizontal);
-    chart.getStyler().setToolTipsEnabled(true);
 
     // Customize Chart
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart01.java
@@ -33,7 +33,9 @@ public class DateChart01 implements ExampleChart<XYChart> {
 
     ExampleChart<XYChart> exampleChart = new DateChart01();
     XYChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<XYChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setZoomEnabled(true);
   }
 
   @Override
@@ -46,7 +48,6 @@ public class DateChart01 implements ExampleChart<XYChart> {
     // Customize Chart
     chart.getStyler().setLegendPosition(Styler.LegendPosition.OutsideS);
     chart.getStyler().setLegendLayout(Styler.LegendLayout.Horizontal);
-    chart.getStyler().setZoomEnabled(true);
     //    chart.getStyler().setZoomResetButtomPosition(Styler.CardinalPosition.InsideS);
     //    chart.getStyler().setZoomResetByDoubleClick(false);
     //    chart.getStyler().setZoomResetByButton(true);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart01.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.TimeZone;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.XYSeries;
@@ -83,6 +84,12 @@ public class DateChart01 implements ExampleChart<XYChart> {
     chart.addSeries("series 2", xData2, yData2).setMarker(SeriesMarkers.NONE).setYAxisGroup(1);
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<XYChart> panel) {
+
+    panel.setZoomEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart09.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart09.java
@@ -8,6 +8,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.demo.charts.ExampleChart;
@@ -72,6 +73,12 @@ public class DateChart09 implements ExampleChart<XYChart> {
             x -> startTime.plusDays(x.longValue()).format(cursorXFormatter));
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<XYChart> panel) {
+
+    panel.setCursorEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart09.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart09.java
@@ -28,7 +28,9 @@ public class DateChart09 implements ExampleChart<XYChart> {
 
     ExampleChart<XYChart> exampleChart = new DateChart09();
     XYChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<XYChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setCursorEnabled(true);
   }
 
   @Override
@@ -63,7 +65,6 @@ public class DateChart09 implements ExampleChart<XYChart> {
             x -> startTime.plusDays(x.longValue()).format(xTickFormatter));
 
     // set custom cursor tool tip text
-    chart.getStyler().setCursorEnabled(true);
     DateTimeFormatter cursorXFormatter = DateTimeFormatter.ofPattern("LLL dd");
     chart
         .getStyler()

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart01.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.demo.charts.dial;
 import org.knowm.xchart.DialChart;
 import org.knowm.xchart.DialChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 
 /**
@@ -37,6 +38,12 @@ public class DialChart01 implements ExampleChart<DialChart> {
     chart.getStyler().setLabelVisible(true);
     chart.getStyler().setLegendVisible(false);
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<DialChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart01.java
@@ -20,7 +20,9 @@ public class DialChart01 implements ExampleChart<DialChart> {
 
     ExampleChart<DialChart> exampleChart = new DialChart01();
     DialChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<DialChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -32,7 +34,6 @@ public class DialChart01 implements ExampleChart<DialChart> {
 
     // Series
     chart.addSeries("Rate", 0.9381, "93.81 %");
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setLabelVisible(true);
     chart.getStyler().setLegendVisible(false);
     return chart;

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart02.java
@@ -27,7 +27,9 @@ public class DialChart02 implements ExampleChart<DialChart> {
 
     ExampleChart<DialChart> exampleChart = new DialChart02();
     DialChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<DialChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -45,7 +47,6 @@ public class DialChart02 implements ExampleChart<DialChart> {
     // Series
     DialSeries series = chart.addSeries("Rate", 0.55, "55 %");
 
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setLegendVisible(true);
     chart.getStyler().setArcAngle(330);
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart02.java
@@ -7,6 +7,7 @@ import org.knowm.xchart.DialChart;
 import org.knowm.xchart.DialChartBuilder;
 import org.knowm.xchart.DialSeries;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler;
 
@@ -83,6 +84,12 @@ public class DialChart02 implements ExampleChart<DialChart> {
     chart.getStyler().setLabelFont(new Font(Font.MONOSPACED, Font.BOLD, 8));
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<DialChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart03.java
@@ -9,6 +9,7 @@ import org.knowm.xchart.HeatMapChart;
 import org.knowm.xchart.HeatMapChartBuilder;
 import org.knowm.xchart.HeatMapSeries;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 
 /**
@@ -85,6 +86,12 @@ public class HeatMapChart03 implements ExampleChart<HeatMapChart> {
     heatMapSeries.setMin(0);
     heatMapSeries.setMax(1000);
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<HeatMapChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart03.java
@@ -30,7 +30,9 @@ public class HeatMapChart03 implements ExampleChart<HeatMapChart> {
 
     ExampleChart<HeatMapChart> exampleChart = new HeatMapChart03();
     HeatMapChart chart = exampleChart.getChart();
-    new SwingWrapper<HeatMapChart>(chart).displayChart();
+    SwingWrapper<HeatMapChart> wrapper = new SwingWrapper<HeatMapChart>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -48,7 +50,6 @@ public class HeatMapChart03 implements ExampleChart<HeatMapChart> {
 
     chart.getStyler().setPlotContentSize(0.999);
     chart.getStyler().setLegendFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setPiecewise(true);
     chart.getStyler().setShowValue(true);
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart04.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart04.java
@@ -36,7 +36,9 @@ public class HeatMapChart04 implements ExampleChart<HeatMapChart> {
 
     ExampleChart<HeatMapChart> exampleChart = new HeatMapChart04();
     HeatMapChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<HeatMapChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -52,7 +54,6 @@ public class HeatMapChart04 implements ExampleChart<HeatMapChart> {
 
     chart.getStyler().setPlotContentSize(1);
     chart.getStyler().setLegendFont(new Font(Font.SANS_SERIF, Font.PLAIN, 16));
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setDatePattern("HH");
     chart.getStyler().setShowValue(true);
     chart.getStyler().setLegendPosition(LegendPosition.OutsideS);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart04.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart04.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.knowm.xchart.HeatMapChart;
 import org.knowm.xchart.HeatMapChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler.LegendLayout;
 import org.knowm.xchart.style.Styler.LegendPosition;
@@ -192,6 +193,12 @@ public class HeatMapChart04 implements ExampleChart<HeatMapChart> {
 
     chart.addSeries("heatMap", xData, yData, Arrays.asList(data));
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<HeatMapChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart05.java
@@ -8,6 +8,7 @@ import org.knowm.xchart.HeatMapChart;
 import org.knowm.xchart.HeatMapChartBuilder;
 import org.knowm.xchart.HeatMapSeries;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 
 /**
@@ -91,6 +92,12 @@ public class HeatMapChart05 implements ExampleChart<HeatMapChart> {
     heatMapSeries.setMin(0);
     heatMapSeries.setMax(1000);
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<HeatMapChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/heatmap/HeatMapChart05.java
@@ -30,7 +30,9 @@ public class HeatMapChart05 implements ExampleChart<HeatMapChart> {
 
     ExampleChart<HeatMapChart> exampleChart = new HeatMapChart05();
     HeatMapChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<HeatMapChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -49,8 +51,7 @@ public class HeatMapChart05 implements ExampleChart<HeatMapChart> {
     chart
         .getStyler()
         .setPlotContentSize(0.999)
-        .setLegendFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12))
-        .setToolTipsEnabled(true);
+        .setLegendFont(new Font(Font.SANS_SERIF, Font.PLAIN, 12));
     chart
         .getStyler()
         .setPiecewise(true)

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/horizontalbar/HorizontalBarChart04.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/horizontalbar/HorizontalBarChart04.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.demo.charts.horizontalbar;
 import org.knowm.xchart.HorizontalBarChart;
 import org.knowm.xchart.HorizontalBarChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler;
 
@@ -57,6 +58,12 @@ public class HorizontalBarChart04 implements ExampleChart<HorizontalBarChart> {
     chart.addSeries("male", Arrays.asList(40, 30, 20, null, 60), Arrays.asList(10, 20, 30, 40, 50));
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<HorizontalBarChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/horizontalbar/HorizontalBarChart04.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/horizontalbar/HorizontalBarChart04.java
@@ -28,7 +28,9 @@ public class HorizontalBarChart04 implements ExampleChart<HorizontalBarChart> {
 
     ExampleChart<HorizontalBarChart> exampleChart = new HorizontalBarChart04();
     HorizontalBarChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<HorizontalBarChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -46,7 +48,6 @@ public class HorizontalBarChart04 implements ExampleChart<HorizontalBarChart> {
 
     // Customize Chart
     chart.getStyler().setLabelsVisible(true);
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setPlotGridVerticalLinesVisible(false);
     chart.getStyler().setLegendPosition(Styler.LegendPosition.OutsideS);
     chart.getStyler().setLegendLayout(Styler.LegendLayout.Horizontal);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart05.java
@@ -2,6 +2,7 @@ package org.knowm.xchart.demo.charts.line;
 
 import java.awt.Color;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.XYSeries;
@@ -74,6 +75,12 @@ public class LineChart05 implements ExampleChart<XYChart> {
     series2.setLineColor(Color.BLACK);
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<XYChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart05.java
@@ -27,7 +27,9 @@ public class LineChart05 implements ExampleChart<XYChart> {
 
     ExampleChart<XYChart> exampleChart = new LineChart05();
     XYChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<XYChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -50,13 +52,11 @@ public class LineChart05 implements ExampleChart<XYChart> {
     chart.getStyler().setYAxisMax(1000.0);
     chart.getStyler().setXAxisMin(2.0);
     chart.getStyler().setXAxisMax(7.0);
-    chart.getStyler().setToolTipsEnabled(true);
     //    chart.getStyler().setToolTipsAlwaysVisible(true);
     //    chart.getStyler().setToolTipFont(new Font("Verdana", Font.BOLD, 12));
     //    chart.getStyler().setToolTipHighlightColor(Color.CYAN);
     //    chart.getStyler().setToolTipBorderColor(Color.BLACK);
     //    chart.getStyler().setToolTipBackgroundColor(Color.LIGHT_GRAY);
-    //    chart.getStyler().setToolTipType(Styler.ToolTipType.xAndYLabels);
 
     // Series
     double[] xData = new double[] {0.0, 1.0, 2.0, 3.0, 4.0, 5, 6};

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart09.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart09.java
@@ -1,6 +1,7 @@
 package org.knowm.xchart.demo.charts.line;
 
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.demo.charts.ExampleChart;
@@ -63,6 +64,12 @@ public class LineChart09 implements ExampleChart<XYChart> {
     chart.addSeries("c", new double[] {0, 1.5, 5, 8, 9}, new double[] {-2, -1, 1, 0, 1});
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<XYChart> panel) {
+
+    panel.setCursorEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart09.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart09.java
@@ -23,7 +23,9 @@ public class LineChart09 implements ExampleChart<XYChart> {
 
     ExampleChart<XYChart> exampleChart = new LineChart09();
     XYChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<XYChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setCursorEnabled(true);
   }
 
   @Override
@@ -45,7 +47,6 @@ public class LineChart09 implements ExampleChart<XYChart> {
     chart.getStyler().setLegendPosition(LegendPosition.OutsideS);
     chart.getStyler().setLegendLayout(Styler.LegendLayout.Horizontal);
 
-    chart.getStyler().setCursorEnabled(true);
     //    chart.getStyler().setCursorColor(Color.GREEN);
     //    chart.getStyler().setCursorLineWidth(30f);
     //    chart.getStyler().setCursorFont(new Font("Verdana", Font.BOLD, 12));

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart01.java
@@ -25,7 +25,9 @@ public class OHLCChart01 implements ExampleChart<OHLCChart> {
 
     ExampleChart<OHLCChart> exampleChart = new OHLCChart01();
     OHLCChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<OHLCChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   public static void populateData(
@@ -110,7 +112,6 @@ public class OHLCChart01 implements ExampleChart<OHLCChart> {
 
     xData = null;
     chart.addSeries("Series", xData, openData, highData, lowData, closeData);
-    chart.getStyler().setToolTipsEnabled(true);
     return chart;
   }
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart01.java
@@ -116,6 +116,12 @@ public class OHLCChart01 implements ExampleChart<OHLCChart> {
   }
 
   @Override
+  public void customizePanel(XChartPanel<OHLCChart> panel) {
+
+    panel.setToolTipsEnabled(true);
+  }
+
+  @Override
   public String getExampleChartName() {
 
     return getClass().getSimpleName() + " - HiLo rendering";

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart02.java
@@ -26,7 +26,9 @@ public class OHLCChart02 implements ExampleChart<OHLCChart> {
 
     ExampleChart<OHLCChart> exampleChart = new OHLCChart02();
     OHLCChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<OHLCChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -39,7 +41,6 @@ public class OHLCChart02 implements ExampleChart<OHLCChart> {
     chart.getStyler().setLegendPosition(Styler.LegendPosition.OutsideS);
     chart.getStyler().setLegendLayout(Styler.LegendLayout.Horizontal);
     chart.getStyler().setDefaultSeriesRenderStyle(OHLCSeries.OHLCSeriesRenderStyle.HiLo);
-    chart.getStyler().setToolTipsEnabled(true);
 
     List<Date> xData = new ArrayList<>();
     List<Double> openData = new ArrayList<>();

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart02.java
@@ -8,6 +8,7 @@ import org.knowm.xchart.OHLCChart;
 import org.knowm.xchart.OHLCChartBuilder;
 import org.knowm.xchart.OHLCSeries;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler;
 
@@ -56,6 +57,12 @@ public class OHLCChart02 implements ExampleChart<OHLCChart> {
         .setDownColor(Color.GREEN);
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<OHLCChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart03.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import org.knowm.xchart.OHLCChart;
 import org.knowm.xchart.OHLCChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler;
 
@@ -78,6 +79,12 @@ public class OHLCChart03 implements ExampleChart<OHLCChart> {
       result.add(sum / dayCount);
     }
     return result;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<OHLCChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart03.java
@@ -25,7 +25,9 @@ public class OHLCChart03 implements ExampleChart<OHLCChart> {
 
     ExampleChart<OHLCChart> exampleChart = new OHLCChart03();
     OHLCChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<OHLCChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -37,10 +39,8 @@ public class OHLCChart03 implements ExampleChart<OHLCChart> {
     // Customize Chart
     chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideS);
     chart.getStyler().setLegendLayout(Styler.LegendLayout.Horizontal);
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setYAxisDecimalPattern("##.00");
     //    chart.getStyler().setDefaultSeriesRenderStyle(OHLCSeries.OHLCSeriesRenderStyle.Line);
-    chart.getStyler().setToolTipsEnabled(true);
 
     List<Date> xData = new ArrayList<>();
     List<Double> openData = new ArrayList<>();

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
@@ -9,6 +9,7 @@ import org.knowm.xchart.PieChart;
 import org.knowm.xchart.PieChartBuilder;
 import org.knowm.xchart.PieSeries;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 
 /**
@@ -65,6 +66,12 @@ public class PieChart02 implements ExampleChart<PieChart> {
     //    chart.getStyler().setToolTipsAlwaysVisible(true);
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<PieChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
@@ -29,7 +29,9 @@ public class PieChart02 implements ExampleChart<PieChart> {
 
     ExampleChart<PieChart> exampleChart = new PieChart02();
     PieChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<PieChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -60,7 +62,6 @@ public class PieChart02 implements ExampleChart<PieChart> {
     chart.getStyler().setSeriesColors(sliceColors);
     chart.getStyler().setCustomSeriesLabelFunction(generateSeriesLabel(total));
     // chart.getStyler().setDecimalPattern("#0.000");
-    chart.getStyler().setToolTipsEnabled(true);
     //    chart.getStyler().setToolTipsAlwaysVisible(true);
 
     return chart;

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart01.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.demo.charts.radar;
 import org.knowm.xchart.RadarChart;
 import org.knowm.xchart.RadarChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.Styler.LegendPosition;
 
@@ -53,6 +54,12 @@ public class RadarChart01 implements ExampleChart<RadarChart> {
     chart.addSeries("Experimental System", new double[] {0.37, 0.93, 0.57, 0.55, 0.33, 0.73});
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<RadarChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart01.java
@@ -22,7 +22,9 @@ public class RadarChart01 implements ExampleChart<RadarChart> {
 
     ExampleChart<RadarChart> exampleChart = new RadarChart01();
     RadarChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<RadarChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -31,7 +33,6 @@ public class RadarChart01 implements ExampleChart<RadarChart> {
     // Create Chart
     RadarChart chart =
         new RadarChartBuilder().width(800).height(600).title(getClass().getSimpleName()).build();
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setLegendPosition(LegendPosition.InsideSW);
 
     // Series

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart02.java
@@ -25,7 +25,9 @@ public class RadarChart02 implements ExampleChart<RadarChart> {
 
     ExampleChart<RadarChart> exampleChart = new RadarChart02();
     RadarChart chart = exampleChart.getChart();
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<RadarChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -39,7 +41,6 @@ public class RadarChart02 implements ExampleChart<RadarChart> {
             .title(getClass().getSimpleName())
             .theme(Styler.ChartTheme.GGPlot2)
             .build();
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setRadarRenderStyle(RadarStyler.RadarRenderStyle.Circle);
     chart.getStyler().setSeriesFilled(false);
     chart.getStyler().setRadiiTickMarksCount(4);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart02.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.demo.charts.radar;
 import org.knowm.xchart.RadarChart;
 import org.knowm.xchart.RadarChartBuilder;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.RadarStyler;
 import org.knowm.xchart.style.Styler;
@@ -78,6 +79,12 @@ public class RadarChart02 implements ExampleChart<RadarChart> {
         .setMarker(SeriesMarkers.NONE);
 
     return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<RadarChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/theme/ThemeChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/theme/ThemeChart03.java
@@ -27,7 +27,9 @@ public class ThemeChart03 implements ExampleChart<XYChart> {
 
     ExampleChart<XYChart> exampleChart = new ThemeChart03();
     XYChart chart = exampleChart.getChart();
-    new SwingWrapper<XYChart>(chart).displayChart();
+    SwingWrapper<XYChart> wrapper = new SwingWrapper<XYChart>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
   }
 
   @Override
@@ -47,7 +49,6 @@ public class ThemeChart03 implements ExampleChart<XYChart> {
     // Customize Chart
     chart.getStyler().setPlotGridLinesVisible(false);
     chart.getStyler().setXAxisTickMarkSpacingHint(100);
-    chart.getStyler().setToolTipsEnabled(true);
 
     // Series
     List<Integer> xData = new ArrayList<Integer>();

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/theme/ThemeChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/theme/ThemeChart03.java
@@ -3,6 +3,7 @@ package org.knowm.xchart.demo.charts.theme;
 import java.util.ArrayList;
 import java.util.List;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.XYSeries;
@@ -86,6 +87,12 @@ public class ThemeChart03 implements ExampleChart<XYChart> {
               * Math.exp(-(((integer - mean) * (integer - mean)) / ((2 * std * std)))));
     }
     return yData;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<XYChart> panel) {
+
+    panel.setToolTipsEnabled(true);
   }
 
   @Override

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue106.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue106.java
@@ -30,6 +30,7 @@ public class TestForIssue106 {
       // current default
       XYChart chart = alc.getChart();
       chart.getStyler().setToolTipBackgroundColor(Color.RED);
+      chart.getStyler().setToolTipType(ToolTipType.yLabels);
       chart.setTitle("Red background");
       charts.add(chart);
     }
@@ -44,7 +45,7 @@ public class TestForIssue106 {
     SwingWrapper<XYChart> wrapper = new SwingWrapper<XYChart>(charts);
     wrapper.displayChartMatrix();
     wrapper.getXChartPanel(0).setToolTipsEnabled(true);
-    wrapper.getXChartPanel(2).setToolTipsEnabled(true).setToolTipType(ToolTipType.yLabels);
+    wrapper.getXChartPanel(2).setToolTipsEnabled(true);
     wrapper.getXChartPanel(3).setToolTipsEnabled(true);
   }
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue106.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue106.java
@@ -8,7 +8,7 @@ import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.demo.charts.area.AreaChart03;
-import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.ToolTipType;
 
 public class TestForIssue106 {
 
@@ -19,7 +19,6 @@ public class TestForIssue106 {
     {
       XYChart chart = alc.getChart();
       chart.setTitle("Default data labels");
-      chart.getStyler().setToolTipsEnabled(true);
       charts.add(chart);
     }
     {
@@ -30,21 +29,22 @@ public class TestForIssue106 {
     {
       // current default
       XYChart chart = alc.getChart();
-      chart.getStyler().setToolTipsEnabled(true);
       chart.getStyler().setToolTipBackgroundColor(Color.RED);
-      chart.getStyler().setToolTipType(Styler.ToolTipType.yLabels);
       chart.setTitle("Red background");
       charts.add(chart);
     }
     {
       XYChart chart = alc.getChart();
-      chart.getStyler().setToolTipsEnabled(true);
       chart.getStyler().setToolTipBorderColor(Color.BLUE);
       chart.getStyler().setToolTipFont(new Font(Font.MONOSPACED, Font.PLAIN, 20));
       chart.setTitle("Blue and custom Font");
       charts.add(chart);
     }
 
-    new SwingWrapper<XYChart>(charts).displayChartMatrix();
+    SwingWrapper<XYChart> wrapper = new SwingWrapper<XYChart>(charts);
+    wrapper.displayChartMatrix();
+    wrapper.getXChartPanel(0).setToolTipsEnabled(true);
+    wrapper.getXChartPanel(2).setToolTipsEnabled(true).setToolTipType(ToolTipType.yLabels);
+    wrapper.getXChartPanel(3).setToolTipsEnabled(true);
   }
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue189_1.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue189_1.java
@@ -30,7 +30,6 @@ public class TestForIssue189_1 {
       // current default
       RadarChart chart = alc.getChart();
       chart.setTitle("Radar chart with 3 variables and start angle");
-      chart.getStyler().setToolTipsEnabled(true);
       chart.getStyler().setStartAngleInDegrees(45);
       chart.setRadiiLabels(new String[] {"Sales", "Marketing", "Development"});
       charts.add(chart);
@@ -42,6 +41,8 @@ public class TestForIssue189_1 {
       charts.add(chart);
     }
 
-    new SwingWrapper<RadarChart>(charts).displayChartMatrix();
+    SwingWrapper<RadarChart> wrapper = new SwingWrapper<RadarChart>(charts);
+    wrapper.displayChartMatrix();
+    wrapper.getXChartPanel(2).setToolTipsEnabled(true);
   }
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue210.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue210.java
@@ -65,7 +65,11 @@ public class TestForIssue210 implements ExampleChart<DialChart> {
       chart.getStyler().setAxisTickLabelsVisible(false);
       charts.add(chart);
     }
-    new SwingWrapper<DialChart>(charts).displayChartMatrix();
+    SwingWrapper<DialChart> wrapper = new SwingWrapper<DialChart>(charts);
+    wrapper.displayChartMatrix();
+    for (int i = 0; i < charts.size(); i++) {
+      wrapper.getXChartPanel(i).setToolTipsEnabled(true);
+    }
   }
 
   @Override
@@ -76,7 +80,6 @@ public class TestForIssue210 implements ExampleChart<DialChart> {
 
     // Series
     chart.addSeries("Rate", 0.9381, "93.81 %");
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setLegendVisible(false);
 
     return chart;

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue244.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue244.java
@@ -106,7 +106,11 @@ public class TestForIssue244 {
       charts.add(chart);
     }
 
-    new SwingWrapper(charts).displayChartMatrix();
+    SwingWrapper wrapper = new SwingWrapper(charts);
+    wrapper.displayChartMatrix();
+    for (int i = 0; i < charts.size(); i++) {
+      wrapper.getXChartPanel(i).setToolTipsEnabled(true);
+    }
   }
 
   static Chart getLineChart() {
@@ -115,7 +119,6 @@ public class TestForIssue244 {
         new XYChartBuilder().width(WIDTH).height(HEIGHT).xAxisTitle("X").yAxisTitle("Y").build();
 
     // Customize Chart
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
     // generates sine data
     int size = 30;

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue291.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue291.java
@@ -29,6 +29,7 @@ public class TestForIssue291 {
     final SwingWrapper<XYChart> sw = new SwingWrapper<XYChart>(chart);
 
     sw.displayChart();
+    sw.getXChartPanel().setToolTipsEnabled(true);
 
     boolean seriesShown = true;
     while (true) {
@@ -65,7 +66,6 @@ public class TestForIssue291 {
         new XYChartBuilder().width(WIDTH).height(HEIGHT).xAxisTitle("X").yAxisTitle("Y").build();
 
     // Customize Chart
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
     // generates sine data
     int size = 30;

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue335.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue335.java
@@ -10,7 +10,9 @@ public class TestForIssue335 {
   public static void main(String[] args) {
 
     RadarChart chart = new TestForIssue335().getChart();
-    new SwingWrapper<RadarChart>(chart).displayChart();
+    SwingWrapper<RadarChart> sw = new SwingWrapper<RadarChart>(chart);
+    sw.displayChart();
+    sw.getXChartPanel().setToolTipsEnabled(true);
   }
 
   public RadarChart getChart() {
@@ -18,7 +20,6 @@ public class TestForIssue335 {
     // Create Chart
     RadarChart chart =
         new RadarChartBuilder().width(800).height(600).title("TestForIssue335").build();
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setSeriesFilled(false);
 
     // Series

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue349.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue349.java
@@ -17,6 +17,7 @@ public class TestForIssue349 implements ExampleChart<XYChart> {
     ExampleChart<XYChart> exampleChart = new TestForIssue349();
     XYChart chart = exampleChart.getChart();
     XChartPanel chartPanel = new XChartPanel(chart);
+    chartPanel.setZoomEnabled(true);
 
     // Create and set up the window.
     final JFrame frame = new JFrame("TestForIssue349");
@@ -54,7 +55,6 @@ public class TestForIssue349 implements ExampleChart<XYChart> {
     // Customize Chart
     chart.getStyler().setChartTitleVisible(false);
     chart.getStyler().setLegendVisible(false);
-    chart.getStyler().setZoomEnabled(true);
 
     List<Integer> xData = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     List<Double> yData = Arrays.asList(1.1, 2.2, 7.3, 8.4, 4.5, 6.6, 2.7, 6.8, 4.9, 3.10);

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue370.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue370.java
@@ -19,8 +19,8 @@ public class TestForIssue370 {
     charts.add(testForIssue370.getChart("Group yAxis DecimalPattern Logarithmic", true));
     SwingWrapper<XYChart> wrapper = new SwingWrapper<XYChart>(charts);
     wrapper.displayChartMatrix();
-    wrapper.getXChartPanel(0).setToolTipsEnabled(true).setToolTipsAlwaysVisible(true);
-    wrapper.getXChartPanel(1).setToolTipsEnabled(true).setToolTipsAlwaysVisible(true);
+    wrapper.getXChartPanel(0).setToolTipsEnabled(true);
+    wrapper.getXChartPanel(1).setToolTipsEnabled(true);
   }
 
   public XYChart getChart(String title, boolean isYAxisLogarithmic) {
@@ -40,6 +40,7 @@ public class TestForIssue370 {
     chart.getStyler().setAxisTitlesVisible(false);
     chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Line);
     chart.getStyler().setYAxisLogarithmic(isYAxisLogarithmic);
+    chart.getStyler().setToolTipsAlwaysVisible(true);
 
     // Series
     chart.addSeries("a", new double[] {1, 2, 3, 4, 5}, new double[] {400, 200, 300, 200, 100});

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue370.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue370.java
@@ -17,7 +17,10 @@ public class TestForIssue370 {
     List<XYChart> charts = new ArrayList<>();
     charts.add(testForIssue370.getChart("Group yAxis DecimalPattern", false));
     charts.add(testForIssue370.getChart("Group yAxis DecimalPattern Logarithmic", true));
-    new SwingWrapper<XYChart>(charts).displayChartMatrix();
+    SwingWrapper<XYChart> wrapper = new SwingWrapper<XYChart>(charts);
+    wrapper.displayChartMatrix();
+    wrapper.getXChartPanel(0).setToolTipsEnabled(true).setToolTipsAlwaysVisible(true);
+    wrapper.getXChartPanel(1).setToolTipsEnabled(true).setToolTipsAlwaysVisible(true);
   }
 
   public XYChart getChart(String title, boolean isYAxisLogarithmic) {
@@ -36,8 +39,6 @@ public class TestForIssue370 {
     chart.getStyler().setLegendPosition(LegendPosition.OutsideE);
     chart.getStyler().setAxisTitlesVisible(false);
     chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Line);
-    chart.getStyler().setToolTipsEnabled(true);
-    chart.getStyler().setToolTipsAlwaysVisible(true);
     chart.getStyler().setYAxisLogarithmic(isYAxisLogarithmic);
 
     // Series

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue410.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue410.java
@@ -15,14 +15,14 @@ public class TestForIssue410 {
     BoxChart chart =
         new BoxChartBuilder().title("TestForIssue410").theme(ChartTheme.GGPlot2).build();
 
-    chart.getStyler().setToolTipsEnabled(true);
-
-    // Series
     chart.addSeries("boxOne", Arrays.asList(1000, 5000, 60000));
     return chart;
   }
 
   public static void main(String[] args) {
-    new SwingWrapper<>(getChart()).displayChart();
+    BoxChart chart = getChart();
+    SwingWrapper<BoxChart> sw = new SwingWrapper<>(chart);
+    sw.displayChart();
+    sw.getXChartPanel().setToolTipsEnabled(true);
   }
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue530.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue530.java
@@ -19,7 +19,10 @@ public class TestForIssue530 {
 
   public static void main(String[] args) {
     try {
-      new SwingWrapper<CategoryChart>(getVolumesChart()).displayChart();
+      CategoryChart chart = getVolumesChart();
+      SwingWrapper<CategoryChart> sw = new SwingWrapper<CategoryChart>(chart);
+      sw.displayChart();
+      sw.getXChartPanel().setToolTipsEnabled(true);
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -49,7 +52,6 @@ public class TestForIssue530 {
     styler.setXAxisTickMarkSpacingHint(50);
     styler.setAntiAlias(true);
     styler.setChartTitleBoxBorderColor(Color.LIGHT_GRAY);
-    styler.setToolTipsEnabled(true);
     styler.setOverlapped(false);
     styler.setStacked(true);
     styler.setChartBackgroundColor(Color.DARK_GRAY);

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue545.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue545.java
@@ -14,7 +14,9 @@ public class TestForIssue545 {
   public static void main(String[] args) throws ParseException {
 
     BubbleChart chart = getBubbleChart();
-    new SwingWrapper(chart).displayChart();
+    SwingWrapper<BubbleChart> sw = new SwingWrapper<BubbleChart>(chart);
+    sw.displayChart();
+    sw.getXChartPanel().setToolTipsEnabled(true).setToolTipsAlwaysVisible(true);
   }
 
   public static BubbleChart getBubbleChart() {
@@ -50,8 +52,6 @@ public class TestForIssue545 {
     styler.setYAxisDecimalPattern("%");
     styler.setXAxisTickMarkSpacingHint(50);
     styler.setAntiAlias(true);
-    styler.setToolTipsEnabled(true);
-    styler.setToolTipsAlwaysVisible(true);
     styler.setToolTipFont(new Font("SansSerif", Font.PLAIN, 14));
   }
   public static BubbleChart getChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue545.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue545.java
@@ -16,7 +16,7 @@ public class TestForIssue545 {
     BubbleChart chart = getBubbleChart();
     SwingWrapper<BubbleChart> sw = new SwingWrapper<BubbleChart>(chart);
     sw.displayChart();
-    sw.getXChartPanel().setToolTipsEnabled(true).setToolTipsAlwaysVisible(true);
+    sw.getXChartPanel().setToolTipsEnabled(true);
   }
 
   public static BubbleChart getBubbleChart() {
@@ -53,6 +53,7 @@ public class TestForIssue545 {
     styler.setXAxisTickMarkSpacingHint(50);
     styler.setAntiAlias(true);
     styler.setToolTipFont(new Font("SansSerif", Font.PLAIN, 14));
+    styler.setToolTipsAlwaysVisible(true);
   }
   public static BubbleChart getChart() {
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_1.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_1.java
@@ -120,7 +120,11 @@ public class TestForIssue54_1 {
       charts.add(chart);
     }
 
-    new SwingWrapper(charts).displayChartMatrix();
+    SwingWrapper wrapper = new SwingWrapper(charts);
+    wrapper.displayChartMatrix();
+    for (int i = 0; i < charts.size(); i++) {
+      wrapper.getXChartPanel(i).setToolTipsEnabled(true);
+    }
   }
 
   static Chart getLineChart() {
@@ -128,7 +132,6 @@ public class TestForIssue54_1 {
         new XYChartBuilder().width(WIDTH).height(HEIGHT).xAxisTitle("X").yAxisTitle("Y").build();
 
     // Customize Chart
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
     // generates sine data
     int size = 30;
@@ -171,7 +174,6 @@ public class TestForIssue54_1 {
     chart.setYAxisGroupTitle(2, "c");
 
     chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Area);
-    chart.getStyler().setToolTipsEnabled(true);
 
     // Series
     chart.addSeries("a", new double[] {0, 3, 6, 9, 12}, new double[] {-1, 5, 9, 6, 5});
@@ -197,8 +199,6 @@ public class TestForIssue54_1 {
     chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
     chart.getStyler().setAvailableSpaceFill(.96);
     chart.getStyler().setPlotGridVerticalLinesVisible(false);
-    chart.getStyler().setToolTipsEnabled(true);
-    chart.getStyler().setToolTipType(Styler.ToolTipType.yLabels);
 
     // Series
     List<Integer> data = getGaussianData(1000);
@@ -245,7 +245,6 @@ public class TestForIssue54_1 {
     chart.getStyler().setLegendPosition(LegendPosition.OutsideE);
     chart.getStyler().setAvailableSpaceFill(0);
     chart.getStyler().setOverlapped(true);
-    chart.getStyler().setToolTipsEnabled(true);
 
     // Declare data
     List<String> xAxisKeys =
@@ -279,7 +278,6 @@ public class TestForIssue54_1 {
             .xAxisTitle("X")
             .yAxisTitle("Y")
             .build();
-    chart.getStyler().setToolTipsEnabled(true);
     // Customize Chart
 
     // Series

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_2.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_2.java
@@ -26,7 +26,9 @@ public class TestForIssue54_2 {
     chart.getStyler().setYAxisGroupPosition(0, YAxisPosition.Right);
     chart.setYAxisGroupTitle(1, "sin(x)");
 
-    new SwingWrapper(chart).displayChart();
+    SwingWrapper sw = new SwingWrapper(chart);
+    sw.displayChart();
+    sw.getXChartPanel().setToolTipsEnabled(true);
   }
 
   static Chart getLineChart() {
@@ -35,7 +37,6 @@ public class TestForIssue54_2 {
         new XYChartBuilder().width(WIDTH).height(HEIGHT).xAxisTitle("X").yAxisTitle("Y").build();
 
     // Customize Chart
-    chart.getStyler().setToolTipsEnabled(true);
     chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
     // generates sine data
     int size = 30;

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue593.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue593.java
@@ -26,6 +26,7 @@ public class TestForIssue593 {
     XYChart chart = getChart();
     SwingWrapper<XYChart> sw = new SwingWrapper<>(chart);
     sw.displayChart();
+    sw.getXChartPanel().setCursorEnabled(true);
 
     // Simulate a live chart updating every 500 ms
     List<Double> xData = Arrays.asList(1.0, 2.0, 3.0, 4.0, 5.0);
@@ -50,8 +51,6 @@ public class TestForIssue593 {
             .xAxisTitle("X")
             .yAxisTitle("Y")
             .build();
-
-    chart.getStyler().setCursorEnabled(true);
 
     chart.addSeries("series", new double[]{1, 2, 3, 4, 5}, new double[]{1, 3, 2, 5, 4});
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue770.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue770.java
@@ -32,7 +32,10 @@ public class TestForIssue770 {
 
   public static void main(String[] args) {
 
-    new SwingWrapper<>(getChart()).displayChart();
+    OHLCChart chart = getChart();
+    SwingWrapper<OHLCChart> sw = new SwingWrapper<>(chart);
+    sw.displayChart();
+    sw.getXChartPanel().setZoomEnabled(true).setZoomResetByDoubleClick(true).setZoomResetByButton(true);
   }
 
   public static OHLCChart getChart() {
@@ -46,10 +49,6 @@ public class TestForIssue770 {
             .yAxisTitle("Price")
             .theme(Styler.ChartTheme.GGPlot2)
             .build();
-
-    chart.getStyler().setZoomEnabled(true);
-    chart.getStyler().setZoomResetByDoubleClick(true);
-    chart.getStyler().setZoomResetByButton(true);
 
     // Generate 200 candle bars
     int n = 200;

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue862.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue862.java
@@ -7,7 +7,7 @@ import org.knowm.xchart.BitmapEncoder.BitmapFormat;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
-import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.ToolTipType;
 
 /**
  * Demonstrates the fix for issue #862 — {@link BitmapEncoder#saveBitmap} throws NPE when tooltips
@@ -41,7 +41,9 @@ public class TestForIssue862 {
     System.out.println("Saved /tmp/issue862.png — no NPE.");
 
     // Also show the interactive chart to confirm tooltips still work with a panel.
-    new SwingWrapper<>(chart).displayChart();
+    SwingWrapper<XYChart> sw = new SwingWrapper<>(chart);
+    sw.displayChart();
+    sw.getXChartPanel().setToolTipsEnabled(true).setToolTipsAlwaysVisible(true).setToolTipType(ToolTipType.yLabels);
   }
 
   /**
@@ -58,10 +60,6 @@ public class TestForIssue862 {
             .xAxisTitle("X")
             .yAxisTitle("Y")
             .build();
-
-    chart.getStyler().setToolTipsEnabled(true);
-    chart.getStyler().setToolTipsAlwaysVisible(true);
-    chart.getStyler().setToolTipType(Styler.ToolTipType.yLabels);
 
     chart.addSeries("series", Arrays.asList(1, 2, 3, 4, 5), Arrays.asList(2.0, 4.0, 3.0, 7.0, 5.0));
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue862.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue862.java
@@ -1,28 +1,33 @@
 package org.knowm.xchart.standalone.issues;
 
+import java.awt.Color;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import org.knowm.xchart.BitmapEncoder;
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
 import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
-import org.knowm.xchart.ToolTipType;
+import org.knowm.xchart.style.Styler.LegendPosition;
 
 /**
  * Demonstrates the fix for issue #862 — {@link BitmapEncoder#saveBitmap} throws NPE when tooltips
  * are enabled.
  *
- * <p>Root cause: {@code ToolTips} and {@code Cursor} are only injected into the chart's
- * {@code PlotContent_} from {@code XChartPanel}. When rendering headlessly via {@link
- * BitmapEncoder}, no panel is created, so the fields remain {@code null}. Every {@code doPaint()}
- * override that called {@code toolTips.addData()} guarded only on {@code isToolTipsEnabled()},
- * causing an NPE at runtime.
+ * <p>Root cause: {@code ToolTips} and {@code Cursor} previously self-injected into the chart's
+ * {@code PlotContent_} inside their constructors (called from {@code XChartPanel}). When rendering
+ * headlessly via {@link BitmapEncoder}, no panel is ever created, so those fields remained {@code
+ * null}. Every {@code doPaint()} override that referenced {@code toolTips} therefore threw an NPE.
  *
- * <p>Fix: all {@code isToolTipsEnabled()} / {@code isCursorEnabled()} guards in every {@code
- * PlotContent_*} subclass now also check {@code toolTips != null} / {@code cursor != null}.
+ * <p>Fix: a full two-phase architecture via {@code PlotInteractionData}. Interaction objects ({@code
+ * ToolTips}, {@code ChartZoom}, {@code Cursor}) are owned exclusively by {@code XChartPanel} and
+ * are never wired into the core rendering pipeline. Headless rendering via {@link BitmapEncoder}
+ * is completely unaffected.
  *
- * <p>To verify the fix: calling {@link #getChart()} must not throw. Previously it threw:
+ * <p>Chart code is taken directly from the original bug report (logarithmic Y-axis, "Powers of
+ * Ten" dataset, red tooltip border). Previously it threw:
  *
  * <pre>
  *   java.lang.NullPointerException
@@ -36,33 +41,50 @@ public class TestForIssue862 {
 
     XYChart chart = getChart();
 
-    // Write to /tmp — confirms no NPE during headless rendering with tooltips enabled.
+    // Headless render — must not throw NPE (was the bug).
     BitmapEncoder.saveBitmap(chart, "/tmp/issue862", BitmapFormat.PNG);
     System.out.println("Saved /tmp/issue862.png — no NPE.");
 
-    // Also show the interactive chart to confirm tooltips still work with a panel.
+    // Interactive display — tooltips configured on the panel, not the styler.
     SwingWrapper<XYChart> sw = new SwingWrapper<>(chart);
     sw.displayChart();
-    sw.getXChartPanel().setToolTipsEnabled(true).setToolTipsAlwaysVisible(true).setToolTipType(ToolTipType.yLabels);
+    sw.getXChartPanel()
+        .setToolTipsEnabled(true)
+        .setToolTipsAlwaysVisible(true)
+        .setToolTipType(ToolTipType.yLabels);
   }
 
   /**
-   * Returns an XYChart with tooltips enabled. Calling this method previously triggered an NPE
-   * inside {@code BitmapEncoder.saveBitmap()} before the fix.
+   * Reproduces the exact chart from the bug report. Safe to call headlessly — no tooltip
+   * interaction is wired until an {@code XChartPanel} is created.
    */
   public static XYChart getChart() {
+
+    List<Integer> xData = new ArrayList<>();
+    List<Double> yData = new ArrayList<>();
+    for (int i = -3; i <= 3; i++) {
+      xData.add(i);
+      yData.add(Math.pow(10, i));
+    }
 
     XYChart chart =
         new XYChartBuilder()
             .width(800)
             .height(600)
-            .title("Issue #862 – BitmapEncoder + tooltips (was: NPE)")
-            .xAxisTitle("X")
-            .yAxisTitle("Y")
+            .title("Powers of Ten")
+            .xAxisTitle("Power")
+            .yAxisTitle("Value")
             .build();
 
-    chart.addSeries("series", Arrays.asList(1, 2, 3, 4, 5), Arrays.asList(2.0, 4.0, 3.0, 7.0, 5.0));
+    chart.getStyler().setChartTitleVisible(true);
+    chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
+    chart.getStyler().setYAxisLogarithmic(true);
+    chart.getStyler().setXAxisLabelRotation(45);
+    chart.getStyler().setToolTipBorderColor(Color.RED);
+
+    chart.addSeries("10^x", xData, yData);
 
     return chart;
   }
 }
+

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue862.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue862.java
@@ -41,22 +41,21 @@ public class TestForIssue862 {
 
     XYChart chart = getChart();
 
-    // Headless render — must not throw NPE (was the bug).
+    // Headless render — must not throw NPE (was the bug), and with setToolTipsAlwaysVisible(true)
+    // the PNG now contains rendered tooltip labels.
     BitmapEncoder.saveBitmap(chart, "/tmp/issue862", BitmapFormat.PNG);
-    System.out.println("Saved /tmp/issue862.png — no NPE.");
+    System.out.println("Saved /tmp/issue862.png — no NPE, tooltip labels rendered.");
 
-    // Interactive display — tooltips configured on the panel, not the styler.
+    // Interactive display — hover tooltips configured on the panel.
     SwingWrapper<XYChart> sw = new SwingWrapper<>(chart);
     sw.displayChart();
-    sw.getXChartPanel()
-        .setToolTipsEnabled(true)
-        .setToolTipsAlwaysVisible(true)
-        .setToolTipType(ToolTipType.yLabels);
+    sw.getXChartPanel().setToolTipsEnabled(true);
   }
 
   /**
    * Reproduces the exact chart from the bug report. Safe to call headlessly — no tooltip
-   * interaction is wired until an {@code XChartPanel} is created.
+   * interaction is wired until an {@code XChartPanel} is created. {@code setToolTipsAlwaysVisible}
+   * is a rendering/styler property so tooltip labels appear in BitmapEncoder output too.
    */
   public static XYChart getChart() {
 
@@ -81,6 +80,8 @@ public class TestForIssue862 {
     chart.getStyler().setYAxisLogarithmic(true);
     chart.getStyler().setXAxisLabelRotation(45);
     chart.getStyler().setToolTipBorderColor(Color.RED);
+    chart.getStyler().setToolTipsAlwaysVisible(true);
+    chart.getStyler().setToolTipType(ToolTipType.yLabels);
 
     chart.addSeries("10^x", xData, yData);
 

--- a/xchart/src/main/java/org/knowm/xchart/BoxChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/BoxChart.java
@@ -150,11 +150,13 @@ public class BoxChart extends Chart<BoxStyler, BoxSeries> {
     setWidth(width);
     setHeight(height);
     setSeriesStyles();
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     axisPair.paint(g);
     plot.paint(g);
     chartTitle.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/BubbleChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/BubbleChart.java
@@ -225,6 +225,7 @@ public class BubbleChart extends Chart<BubbleStyler, BubbleSeries> {
     }
     setSeriesStyles();
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     axisPair.paint(g);
@@ -232,6 +233,7 @@ public class BubbleChart extends Chart<BubbleStyler, BubbleSeries> {
     chartTitle.paint(g);
     legend.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 
   /** set the series color based on theme */

--- a/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
@@ -304,6 +304,7 @@ public class CategoryChart extends Chart<CategoryStyler, CategorySeries> {
     }
     setSeriesStyles();
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     axisPair.paint(g);
@@ -311,6 +312,7 @@ public class CategoryChart extends Chart<CategoryStyler, CategorySeries> {
     chartTitle.paint(g);
     legend.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 
   /** set the series color, marker and line style based on theme */

--- a/xchart/src/main/java/org/knowm/xchart/DialChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/DialChart.java
@@ -111,11 +111,13 @@ public class DialChart extends Chart<DialStyler, DialSeries> {
     setWidth(width);
     setHeight(height);
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     plot.paint(g);
     chartTitle.paint(g);
     //    legend.paint(g); // no legend for dial charts
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/HeatMapChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/HeatMapChart.java
@@ -157,6 +157,7 @@ public class HeatMapChart extends Chart<HeatMapStyler, HeatMapSeries> {
     prepareForPaint();
     // setSeriesStyles();
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     axisPair.paint(g);
@@ -164,6 +165,7 @@ public class HeatMapChart extends Chart<HeatMapStyler, HeatMapSeries> {
     chartTitle.paint(g);
     legend.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 
   private List<Integer> arrayToList(int[] data) {

--- a/xchart/src/main/java/org/knowm/xchart/HorizontalBarChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/HorizontalBarChart.java
@@ -211,6 +211,7 @@ public class HorizontalBarChart extends Chart<HorizontalBarStyler, HorizontalBar
 
     setSeriesStyles();
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     axisPair.paint(g);
@@ -218,6 +219,7 @@ public class HorizontalBarChart extends Chart<HorizontalBarStyler, HorizontalBar
     chartTitle.paint(g);
     legend.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 
   /** set the series color, marker and line style based on theme */

--- a/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
@@ -819,6 +819,7 @@ public class OHLCChart extends Chart<OHLCStyler, OHLCSeries> {
     }
     setSeriesStyles();
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     axisPair.paint(g);
@@ -826,6 +827,7 @@ public class OHLCChart extends Chart<OHLCStyler, OHLCSeries> {
     chartTitle.paint(g);
     legend.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 
   /** set the series color, marker and line style based on theme */

--- a/xchart/src/main/java/org/knowm/xchart/PieChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/PieChart.java
@@ -120,12 +120,14 @@ public class PieChart extends Chart<PieStyler, PieSeries> {
     }
     setSeriesStyles();
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     plot.paint(g);
     chartTitle.paint(g);
     legend.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 
   /** set the series color based on theme */

--- a/xchart/src/main/java/org/knowm/xchart/RadarChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/RadarChart.java
@@ -147,12 +147,14 @@ public class RadarChart extends Chart<RadarStyler, RadarSeries> {
 
     setSeriesStyles();
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     plot.paint(g);
     chartTitle.paint(g);
     legend.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 
   /** set the series color based on theme */

--- a/xchart/src/main/java/org/knowm/xchart/SwingWrapper.java
+++ b/xchart/src/main/java/org/knowm/xchart/SwingWrapper.java
@@ -101,34 +101,40 @@ public class SwingWrapper<T extends Chart<?, ?>> {
 
     // Schedule a job for the event-dispatching thread:
     // creating and showing this application's GUI.
-    javax.swing.SwingUtilities.invokeLater(
-        new Runnable() {
+    try {
+      javax.swing.SwingUtilities.invokeAndWait(
+          new Runnable() {
 
-          @Override
-          public void run() {
+            @Override
+            public void run() {
 
-            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-            frame.getContentPane().setLayout(new GridLayout(numRows, numColumns));
+              frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+              frame.getContentPane().setLayout(new GridLayout(numRows, numColumns));
 
-            for (T chart : charts) {
-              if (chart != null) {
-                XChartPanel<T> chartPanel = new XChartPanel<T>(chart);
-                chartPanels.add(chartPanel);
-                frame.add(chartPanel);
-              } else {
-                JPanel chartPanel = new JPanel();
-                frame.getContentPane().add(chartPanel);
+              for (T chart : charts) {
+                if (chart != null) {
+                  XChartPanel<T> chartPanel = new XChartPanel<T>(chart);
+                  chartPanels.add(chartPanel);
+                  frame.add(chartPanel);
+                } else {
+                  JPanel chartPanel = new JPanel();
+                  frame.getContentPane().add(chartPanel);
+                }
               }
-            }
 
-            // Display the window.
-            frame.pack();
-            if (isCentered) {
-              frame.setLocationRelativeTo(null);
+              // Display the window.
+              frame.pack();
+              if (isCentered) {
+                frame.setLocationRelativeTo(null);
+              }
+              frame.setVisible(true);
             }
-            frame.setVisible(true);
-          }
-        });
+          });
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (InvocationTargetException e) {
+      e.printStackTrace();
+    }
 
     return frame;
   }

--- a/xchart/src/main/java/org/knowm/xchart/SwingWrapper.java
+++ b/xchart/src/main/java/org/knowm/xchart/SwingWrapper.java
@@ -62,32 +62,37 @@ public class SwingWrapper<T extends Chart<?, ?>> {
     // Create and set up the window.
     final JFrame frame = new JFrame(windowTitle);
 
-    // Schedule a job for the event-dispatching thread:
-    // creating and showing this application's GUI.
-    try {
-      javax.swing.SwingUtilities.invokeAndWait(
-          new Runnable() {
+    Runnable runnable =
+        new Runnable() {
 
-            @Override
-            public void run() {
+          @Override
+          public void run() {
 
-              frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-              XChartPanel<T> chartPanel = new XChartPanel<T>(charts.get(0));
-              chartPanels.add(chartPanel);
-              frame.add(chartPanel);
+            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+            XChartPanel<T> chartPanel = new XChartPanel<T>(charts.get(0));
+            chartPanels.add(chartPanel);
+            frame.add(chartPanel);
 
-              // Display the window.
-              frame.pack();
-              if (isCentered) {
-                frame.setLocationRelativeTo(null);
-              }
-              frame.setVisible(true);
+            // Display the window.
+            frame.pack();
+            if (isCentered) {
+              frame.setLocationRelativeTo(null);
             }
-          });
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    } catch (InvocationTargetException e) {
-      e.printStackTrace();
+            frame.setVisible(true);
+          }
+        };
+
+    if (javax.swing.SwingUtilities.isEventDispatchThread()) {
+      runnable.run();
+    } else {
+      try {
+        javax.swing.SwingUtilities.invokeAndWait(runnable);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        e.printStackTrace();
+      } catch (InvocationTargetException e) {
+        e.printStackTrace();
+      }
     }
 
     return frame;
@@ -99,41 +104,46 @@ public class SwingWrapper<T extends Chart<?, ?>> {
     // Create and set up the window.
     final JFrame frame = new JFrame(windowTitle);
 
-    // Schedule a job for the event-dispatching thread:
-    // creating and showing this application's GUI.
-    try {
-      javax.swing.SwingUtilities.invokeAndWait(
-          new Runnable() {
+    Runnable runnable =
+        new Runnable() {
 
-            @Override
-            public void run() {
+          @Override
+          public void run() {
 
-              frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-              frame.getContentPane().setLayout(new GridLayout(numRows, numColumns));
+            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+            frame.getContentPane().setLayout(new GridLayout(numRows, numColumns));
 
-              for (T chart : charts) {
-                if (chart != null) {
-                  XChartPanel<T> chartPanel = new XChartPanel<T>(chart);
-                  chartPanels.add(chartPanel);
-                  frame.add(chartPanel);
-                } else {
-                  JPanel chartPanel = new JPanel();
-                  frame.getContentPane().add(chartPanel);
-                }
+            for (T chart : charts) {
+              if (chart != null) {
+                XChartPanel<T> chartPanel = new XChartPanel<T>(chart);
+                chartPanels.add(chartPanel);
+                frame.add(chartPanel);
+              } else {
+                JPanel chartPanel = new JPanel();
+                frame.getContentPane().add(chartPanel);
               }
-
-              // Display the window.
-              frame.pack();
-              if (isCentered) {
-                frame.setLocationRelativeTo(null);
-              }
-              frame.setVisible(true);
             }
-          });
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    } catch (InvocationTargetException e) {
-      e.printStackTrace();
+
+            // Display the window.
+            frame.pack();
+            if (isCentered) {
+              frame.setLocationRelativeTo(null);
+            }
+            frame.setVisible(true);
+          }
+        };
+
+    if (javax.swing.SwingUtilities.isEventDispatchThread()) {
+      runnable.run();
+    } else {
+      try {
+        javax.swing.SwingUtilities.invokeAndWait(runnable);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        e.printStackTrace();
+      } catch (InvocationTargetException e) {
+        e.printStackTrace();
+      }
     }
 
     return frame;

--- a/xchart/src/main/java/org/knowm/xchart/ToolTipType.java
+++ b/xchart/src/main/java/org/knowm/xchart/ToolTipType.java
@@ -1,0 +1,7 @@
+package org.knowm.xchart;
+
+public enum ToolTipType {
+  xAndYLabels,
+  xLabels,
+  yLabels
+}

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -260,6 +260,7 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
 
     if (anyEnabled) {
       chart.enableInteractionData();
+      repaint();
     }
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -59,8 +59,6 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   private Cursor cursor = null;
   private ChartZoom chartZoom = null;
   private boolean toolTipsEnabled = false;
-  private boolean toolTipsAlwaysVisible = false;
-  private ToolTipType toolTipType = ToolTipType.xAndYLabels;
   private boolean zoomEnabled = false;
   private java.awt.Color zoomSelectionColor = new java.awt.Color(0, 0, 0, 40);
   private boolean zoomResetByDoubleClick = true;
@@ -157,20 +155,6 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
     return this;
   }
 
-  public XChartPanel<T> setToolTipsAlwaysVisible(boolean alwaysVisible) {
-
-    this.toolTipsAlwaysVisible = alwaysVisible;
-    rewireInteractions();
-    return this;
-  }
-
-  public XChartPanel<T> setToolTipType(ToolTipType toolTipType) {
-
-    this.toolTipType = toolTipType;
-    rewireInteractions();
-    return this;
-  }
-
   public XChartPanel<T> setZoomEnabled(boolean enabled) {
 
     this.zoomEnabled = enabled;
@@ -219,16 +203,6 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   public boolean isZoomResetByDoubleClick() {
 
     return zoomResetByDoubleClick;
-  }
-
-  public boolean isToolTipsAlwaysVisible() {
-
-    return toolTipsAlwaysVisible;
-  }
-
-  public ToolTipType getToolTipType() {
-
-    return toolTipType;
   }
 
   private void rewireInteractions() {
@@ -280,7 +254,7 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
 
     if (toolTipsEnabled) {
       anyEnabled = true;
-      toolTips = new ToolTips(chart, toolTipsAlwaysVisible, toolTipType);
+      toolTips = new ToolTips(chart, false, chart.getStyler().getToolTipType());
       this.addMouseMotionListener(toolTips);
     }
 

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -32,12 +32,10 @@ import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
 
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
-import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
 import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.chartpart.ChartZoom;
 import org.knowm.xchart.internal.chartpart.Cursor;
-import org.knowm.xchart.internal.chartpart.PlotInteractionData;
 import org.knowm.xchart.internal.chartpart.ToolTips;
 import org.knowm.xchart.style.AxesChartStyler;
 
@@ -258,8 +256,11 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
       this.addMouseMotionListener(toolTips);
     }
 
-    if (anyEnabled) {
+    if (toolTipsEnabled || cursorEnabled) {
       chart.enableInteractionData();
+    }
+
+    if (anyEnabled) {
       repaint();
     }
   }
@@ -272,19 +273,9 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
     Graphics2D g2d = (Graphics2D) g.create();
     chart.paint(g2d, getWidth(), getHeight());
 
-    PlotInteractionData interactionData = chart.getInteractionData();
-    if (interactionData != null) {
-      if (toolTips != null) {
-        toolTips.setData(interactionData);
-        toolTips.paint(g2d);
-      }
-      if (cursor != null) {
-        cursor.setData(interactionData);
-        cursor.paint(g2d);
-      }
-      if (chartZoom != null) {
-        chartZoom.paint(g2d);
-      }
+    chart.consumeInteractionData(g2d, toolTips, cursor);
+    if (chartZoom != null) {
+      chartZoom.paint(g2d);
     }
 
     g2d.dispose();

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -32,6 +32,7 @@ import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
 
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
+import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
 import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.chartpart.ChartZoom;
@@ -39,8 +40,6 @@ import org.knowm.xchart.internal.chartpart.Cursor;
 import org.knowm.xchart.internal.chartpart.PlotInteractionData;
 import org.knowm.xchart.internal.chartpart.ToolTips;
 import org.knowm.xchart.style.AxesChartStyler;
-import org.knowm.xchart.style.OHLCStyler;
-import org.knowm.xchart.style.XYStyler;
 
 /**
  * A Swing JPanel that contains a Chart
@@ -59,6 +58,14 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   private ToolTips toolTips = null;
   private Cursor cursor = null;
   private ChartZoom chartZoom = null;
+  private boolean toolTipsEnabled = false;
+  private boolean toolTipsAlwaysVisible = false;
+  private ToolTipType toolTipType = ToolTipType.xAndYLabels;
+  private boolean zoomEnabled = false;
+  private java.awt.Color zoomSelectionColor = new java.awt.Color(0, 0, 0, 40);
+  private boolean zoomResetByDoubleClick = true;
+  private boolean zoomResetByButton = true;
+  private boolean cursorEnabled = false;
 
   /**
    * Constructor
@@ -91,59 +98,13 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
     this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(ctrlP, "print");
     this.getActionMap().put("print", new PrintAction());
 
-    // Mouse Listener for Zoom. Available for XYCharts and OHLCCharts
-    if ((chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled())
-        || (chart instanceof OHLCChart && ((OHLCStyler) chart.getStyler()).isZoomEnabled())) {
-      chart.enableInteractionData();
-      @SuppressWarnings("unchecked")
-      ChartZoom zoom =
-          new ChartZoom((Chart<? extends AxesChartStyler, ?>) chart, this, resetString);
-      this.chartZoom = zoom;
-      this.addMouseListener(zoom); // for clicking
-      this.addMouseMotionListener(zoom); // for moving
+    rewireInteractions();
 
-      // Escape key resets zoom (fix for issue #930)
-      KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
-      this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(escape, "resetZoom");
-      this.getActionMap()
-          .put(
-              "resetZoom",
-              new AbstractAction() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                  chartZoom.resetZoom();
-                }
-              });
-    }
-
-    // Mouse motion listener for Cursor
-    if (chart instanceof XYChart && ((XYStyler) chart.getStyler()).isCursorEnabled()) {
-      chart.enableInteractionData();
-      cursor = new Cursor(chart);
-      this.addMouseMotionListener(cursor);
-    }
-
-    // Mouse motion listener for Tooltips
-    if (chart.getStyler().isToolTipsEnabled()) {
-      chart.enableInteractionData();
-      toolTips = new ToolTips(chart);
-      this.addMouseMotionListener(toolTips); // for moving
-    }
-
-    // Recalculate Tooltips at component resize
+    // Recalculate interactions at component resize
     this.addComponentListener(
         new ComponentAdapter() {
           public void componentResized(ComponentEvent ev) {
-            if (chart.getStyler().isToolTipsEnabled()) {
-              XChartPanel.this.removeMouseMotionListener(toolTips);
-              toolTips = new ToolTips(chart);
-              XChartPanel.this.addMouseMotionListener(toolTips);
-            }
-            if (cursor != null) {
-              XChartPanel.this.removeMouseMotionListener(cursor);
-              cursor = new Cursor(chart);
-              XChartPanel.this.addMouseMotionListener(cursor);
-            }
+            rewireInteractions();
           }
         });
   }
@@ -187,6 +148,145 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   public void setResetString(String resetString) {
 
     this.resetString = resetString;
+  }
+
+  public XChartPanel<T> setToolTipsEnabled(boolean enabled) {
+
+    this.toolTipsEnabled = enabled;
+    rewireInteractions();
+    return this;
+  }
+
+  public XChartPanel<T> setToolTipsAlwaysVisible(boolean alwaysVisible) {
+
+    this.toolTipsAlwaysVisible = alwaysVisible;
+    rewireInteractions();
+    return this;
+  }
+
+  public XChartPanel<T> setToolTipType(ToolTipType toolTipType) {
+
+    this.toolTipType = toolTipType;
+    rewireInteractions();
+    return this;
+  }
+
+  public XChartPanel<T> setZoomEnabled(boolean enabled) {
+
+    this.zoomEnabled = enabled;
+    rewireInteractions();
+    return this;
+  }
+
+  public XChartPanel<T> setZoomSelectionColor(java.awt.Color color) {
+
+    this.zoomSelectionColor = color;
+    rewireInteractions();
+    return this;
+  }
+
+  public XChartPanel<T> setZoomResetByDoubleClick(boolean reset) {
+
+    this.zoomResetByDoubleClick = reset;
+    rewireInteractions();
+    return this;
+  }
+
+  public XChartPanel<T> setZoomResetByButton(boolean reset) {
+
+    this.zoomResetByButton = reset;
+    rewireInteractions();
+    return this;
+  }
+
+  public XChartPanel<T> setCursorEnabled(boolean enabled) {
+
+    this.cursorEnabled = enabled;
+    rewireInteractions();
+    return this;
+  }
+
+  public java.awt.Color getZoomSelectionColor() {
+
+    return zoomSelectionColor;
+  }
+
+  public boolean isZoomResetByButton() {
+
+    return zoomResetByButton;
+  }
+
+  public boolean isZoomResetByDoubleClick() {
+
+    return zoomResetByDoubleClick;
+  }
+
+  public boolean isToolTipsAlwaysVisible() {
+
+    return toolTipsAlwaysVisible;
+  }
+
+  public ToolTipType getToolTipType() {
+
+    return toolTipType;
+  }
+
+  private void rewireInteractions() {
+
+    if (toolTips != null) {
+      this.removeMouseMotionListener(toolTips);
+      toolTips = null;
+    }
+    if (cursor != null) {
+      this.removeMouseMotionListener(cursor);
+      cursor = null;
+    }
+    if (chartZoom != null) {
+      this.removeMouseListener(chartZoom);
+      this.removeMouseMotionListener(chartZoom);
+      chartZoom = null;
+      this.getInputMap(WHEN_IN_FOCUSED_WINDOW).remove(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0));
+      this.getActionMap().remove("resetZoom");
+    }
+
+    boolean anyEnabled = false;
+
+    if (zoomEnabled && (chart instanceof XYChart || chart instanceof OHLCChart)) {
+      anyEnabled = true;
+      @SuppressWarnings("unchecked")
+      ChartZoom zoom =
+          new ChartZoom((Chart<? extends AxesChartStyler, ?>) chart, this, resetString);
+      this.chartZoom = zoom;
+      this.addMouseListener(zoom);
+      this.addMouseMotionListener(zoom);
+      KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
+      this.getInputMap(WHEN_IN_FOCUSED_WINDOW).put(escape, "resetZoom");
+      this.getActionMap()
+          .put(
+              "resetZoom",
+              new AbstractAction() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                  chartZoom.resetZoom();
+                }
+              });
+    }
+
+    if (cursorEnabled && chart instanceof XYChart) {
+      anyEnabled = true;
+      cursor = new Cursor(chart);
+      this.addMouseMotionListener(cursor);
+    }
+
+    if (toolTipsEnabled) {
+      anyEnabled = true;
+      toolTips = new ToolTips(chart, toolTipsAlwaysVisible, toolTipType);
+      this.addMouseMotionListener(toolTips);
+    }
+
+    if (anyEnabled) {
+      chart.enableInteractionData();
+    }
   }
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -36,6 +36,7 @@ import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
 import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.chartpart.ChartZoom;
 import org.knowm.xchart.internal.chartpart.Cursor;
+import org.knowm.xchart.internal.chartpart.PlotInteractionData;
 import org.knowm.xchart.internal.chartpart.ToolTips;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.OHLCStyler;
@@ -56,6 +57,8 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   private String printString = "Print...";
   private String resetString = "Reset Zoom";
   private ToolTips toolTips = null;
+  private Cursor cursor = null;
+  private ChartZoom chartZoom = null;
 
   /**
    * Constructor
@@ -91,11 +94,13 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
     // Mouse Listener for Zoom. Available for XYCharts and OHLCCharts
     if ((chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled())
         || (chart instanceof OHLCChart && ((OHLCStyler) chart.getStyler()).isZoomEnabled())) {
+      chart.enableInteractionData();
       @SuppressWarnings("unchecked")
-      ChartZoom chartZoom =
+      ChartZoom zoom =
           new ChartZoom((Chart<? extends AxesChartStyler, ?>) chart, this, resetString);
-      this.addMouseListener(chartZoom); // for clicking
-      this.addMouseMotionListener(chartZoom); // for moving
+      this.chartZoom = zoom;
+      this.addMouseListener(zoom); // for clicking
+      this.addMouseMotionListener(zoom); // for moving
 
       // Escape key resets zoom (fix for issue #930)
       KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
@@ -113,11 +118,14 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
 
     // Mouse motion listener for Cursor
     if (chart instanceof XYChart && ((XYStyler) chart.getStyler()).isCursorEnabled()) {
-      this.addMouseMotionListener(new Cursor(chart));
+      chart.enableInteractionData();
+      cursor = new Cursor(chart);
+      this.addMouseMotionListener(cursor);
     }
 
     // Mouse motion listener for Tooltips
     if (chart.getStyler().isToolTipsEnabled()) {
+      chart.enableInteractionData();
       toolTips = new ToolTips(chart);
       this.addMouseMotionListener(toolTips); // for moving
     }
@@ -127,9 +135,14 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
         new ComponentAdapter() {
           public void componentResized(ComponentEvent ev) {
             if (chart.getStyler().isToolTipsEnabled()) {
-              XChartPanel.this.removeMouseListener(toolTips);
+              XChartPanel.this.removeMouseMotionListener(toolTips);
               toolTips = new ToolTips(chart);
               XChartPanel.this.addMouseMotionListener(toolTips);
+            }
+            if (cursor != null) {
+              XChartPanel.this.removeMouseMotionListener(cursor);
+              cursor = new Cursor(chart);
+              XChartPanel.this.addMouseMotionListener(cursor);
             }
           }
         });
@@ -183,6 +196,22 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
 
     Graphics2D g2d = (Graphics2D) g.create();
     chart.paint(g2d, getWidth(), getHeight());
+
+    PlotInteractionData interactionData = chart.getInteractionData();
+    if (interactionData != null) {
+      if (toolTips != null) {
+        toolTips.setData(interactionData);
+        toolTips.paint(g2d);
+      }
+      if (cursor != null) {
+        cursor.setData(interactionData);
+        cursor.paint(g2d);
+      }
+      if (chartZoom != null) {
+        chartZoom.paint(g2d);
+      }
+    }
+
     g2d.dispose();
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -411,6 +411,7 @@ public class XYChart extends Chart<XYStyler, XYSeries> {
     }
     setSeriesStyles();
 
+    if (styler.isToolTipsAlwaysVisible()) enableInteractionData();
     paintBackground(g);
 
     axisPair.paint(g);
@@ -418,6 +419,7 @@ public class XYChart extends Chart<XYStyler, XYSeries> {
     chartTitle.paint(g);
     legend.paint(g);
     annotations.forEach(x -> x.paint(g));
+    paintAlwaysVisibleToolTips(g);
   }
 
   /** set the series color, marker and line style based on theme */

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -305,4 +305,14 @@ public abstract class Chart<ST extends Styler, S extends Series> {
 
     return seriesMap;
   }
+
+  public void enableInteractionData() {
+
+    plot.plotContent.interactionData = new PlotInteractionData();
+  }
+
+  public PlotInteractionData getInteractionData() {
+
+    return plot.plotContent.getInteractionData();
+  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
+import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.internal.series.Series;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.Styler;
@@ -314,5 +315,27 @@ public abstract class Chart<ST extends Styler, S extends Series> {
   public PlotInteractionData getInteractionData() {
 
     return plot.plotContent.getInteractionData();
+  }
+
+  /**
+   * Renders always-visible data-point labels into the chart image. Called at the end of each
+   * chart's {@code paint()} when {@link Styler#isToolTipsAlwaysVisible()} is true. This makes
+   * tooltip labels appear in BitmapEncoder output and any other headless rendering context.
+   *
+   * @param g the graphics context to paint into
+   */
+  protected void paintAlwaysVisibleToolTips(Graphics2D g) {
+
+    if (!styler.isToolTipsAlwaysVisible()) {
+      return;
+    }
+    PlotInteractionData data = getInteractionData();
+    if (data == null) {
+      return;
+    }
+    ToolTipType type = styler.getToolTipType();
+    ToolTips toolTips = new ToolTips(this, true, type);
+    toolTips.setData(data);
+    toolTips.paint(g);
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -312,9 +312,35 @@ public abstract class Chart<ST extends Styler, S extends Series> {
     plot.plotContent.interactionData = new PlotInteractionData();
   }
 
-  public PlotInteractionData getInteractionData() {
+  PlotInteractionData getInteractionData() {
 
     return plot.plotContent.getInteractionData();
+  }
+
+  /**
+   * Called by {@link org.knowm.xchart.XChartPanel} after {@code paint()} to feed collected
+   * interaction data into the hover-tooltip and cursor overlays and paint them on top of the chart.
+   * Keeping this method here avoids exposing the internal {@link PlotInteractionData} type in the
+   * public API.
+   *
+   * @param g the graphics context (same one used for chart painting)
+   * @param toolTips hover-tooltip handler, or {@code null} if not enabled
+   * @param cursor cursor handler, or {@code null} if not enabled
+   */
+  public void consumeInteractionData(Graphics2D g, ToolTips toolTips, Cursor cursor) {
+
+    PlotInteractionData data = getInteractionData();
+    if (data == null) {
+      return;
+    }
+    if (toolTips != null) {
+      toolTips.setData(data);
+      toolTips.paint(g);
+    }
+    if (cursor != null) {
+      cursor.setData(data);
+      cursor.paint(g);
+    }
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
@@ -41,7 +41,6 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
 
     this.xChartPanel = xChartPanel;
     this.chart = chart;
-    chart.plot.plotContent.setChartZoom(this);
 
     resetButton = new ChartButton(chart, xChartPanel, resetString);
     resetButton.addActionListener(this);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
@@ -82,7 +82,7 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
     } else if (x1 == -1 || x2 == -1) {
       return;
     } else {
-      g.setColor(chart.getStyler().getZoomSelectionColor());
+      g.setColor(xChartPanel.getZoomSelectionColor());
       int xStart = Math.min(x1, x2);
       int width = Math.abs(x1 - x2);
       bounds = g.getClipBounds();
@@ -123,7 +123,7 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
       }
 
       filtered = filterXByScreen(smallPoint, bigPoint);
-      resetButton.setVisible(filtered && chart.getStyler().isZoomResetByButton());
+      resetButton.setVisible(filtered && xChartPanel.isZoomResetByButton());
     }
 
     x1 = -1;
@@ -248,7 +248,7 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
     if (!filtered) {
       return;
     }
-    if (chart.getStyler().isZoomResetByDoubleClick() && e.getClickCount() == 2) {
+    if (xChartPanel.isZoomResetByDoubleClick() && e.getClickCount() == 2) {
       resetZoom();
       return;
     }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Cursor.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Cursor.java
@@ -34,6 +34,8 @@ public class Cursor extends MouseAdapter implements ChartPart {
 
   private final Map<String, Series> seriesMap;
 
+  private Rectangle2D plotBounds = null;
+
   private double mouseX;
   private double mouseY;
   private double startX;
@@ -49,8 +51,6 @@ public class Cursor extends MouseAdapter implements ChartPart {
 
     this.chart = chart;
     this.styler = (XYStyler) chart.getStyler();
-    PlotContent_XY plotContent_xy = (PlotContent_XY) (chart.plot.plotContent);
-    plotContent_xy.setCursor(this);
 
     // clear lists
     dataPointList.clear();
@@ -82,11 +82,10 @@ public class Cursor extends MouseAdapter implements ChartPart {
 
   private boolean isMouseOutOfPlotContent() {
 
-    boolean isMouseOut = false;
-    if (!chart.plot.plotContent.getBounds().contains(mouseX, mouseY)) {
-      isMouseOut = true;
+    if (plotBounds == null) {
+      return true;
     }
-    return isMouseOut;
+    return !plotBounds.contains(mouseX, mouseY);
   }
 
   @Override
@@ -128,9 +127,9 @@ public class Cursor extends MouseAdapter implements ChartPart {
     Line2D.Double line = new Line2D.Double();
     line.setLine(
         dataPoint.x,
-        chart.plot.plotContent.getBounds().getY(),
+        plotBounds.getY(),
         dataPoint.x,
-        chart.plot.plotContent.getBounds().getY() + chart.plot.plotContent.getBounds().getHeight());
+        plotBounds.getY() + plotBounds.getHeight());
     g.draw(line);
   }
 
@@ -159,14 +158,12 @@ public class Cursor extends MouseAdapter implements ChartPart {
     startX = mouseX;
     startY = mouseY;
     if (mouseX + MOUSE_SPACING + backgroundWidth
-        > chart.plot.plotContent.getBounds().getX()
-            + chart.plot.plotContent.getBounds().getWidth()) {
+        > plotBounds.getX() + plotBounds.getWidth()) {
       startX = mouseX - backgroundWidth - MOUSE_SPACING;
     }
 
     if (mouseY + MOUSE_SPACING + backgroundHeight
-        > chart.plot.plotContent.getBounds().getY()
-            + chart.plot.plotContent.getBounds().getHeight()) {
+        > plotBounds.getY() + plotBounds.getHeight()) {
       startY = mouseY - backgroundHeight - MOUSE_SPACING;
     }
 
@@ -221,14 +218,17 @@ public class Cursor extends MouseAdapter implements ChartPart {
     g.setTransform(orig);
   }
 
-  void addData(double xOffset, double yOffset, String xValue, String yValue, String seriesName) {
+  public void setData(PlotInteractionData data) {
 
-    DataPoint dataPoint = new DataPoint(xOffset, yOffset, xValue, yValue, seriesName);
-    dataPointList.add(dataPoint);
-  }
-
-  void clearDataPoints() {
-	  dataPointList.clear();
+    dataPointList.clear();
+    if (data == null) {
+      plotBounds = null;
+      return;
+    }
+    plotBounds = data.getPlotBounds();
+    for (PlotInteractionData.CursorData cd : data.getCursorDataList()) {
+      dataPointList.add(new DataPoint(cd.x, cd.y, cd.xValue, cd.yValue, cd.seriesName));
+    }
   }
 
   /** One DataPoint per series, keep the DataPoint closest to mouseX */
@@ -237,10 +237,8 @@ public class Cursor extends MouseAdapter implements ChartPart {
     List<DataPoint> dataPoints = new ArrayList<>();
     for (DataPoint dataPoint : dataPointList) {
       if (dataPoint.shape.contains(mouseX, dataPoint.shape.getBounds().getCenterY())
-          && chart.plot.plotContent.getBounds().getY() < mouseY
-          && chart.plot.plotContent.getBounds().getY()
-                  + chart.plot.plotContent.getBounds().getHeight()
-              > mouseY) {
+          && plotBounds.getY() < mouseY
+          && plotBounds.getY() + plotBounds.getHeight() > mouseY) {
         dataPoints.add(dataPoint);
       }
     }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
@@ -4,19 +4,13 @@ import java.awt.BasicStroke;
 import java.awt.Graphics2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
-import org.knowm.xchart.OHLCChart;
-import org.knowm.xchart.XYChart;
 import org.knowm.xchart.internal.series.Series;
-import org.knowm.xchart.style.OHLCStyler;
 import org.knowm.xchart.style.Styler;
-import org.knowm.xchart.style.XYStyler;
 
 public abstract class PlotContent_<ST extends Styler, S extends Series> implements ChartPart {
 
   final Chart<ST, S> chart;
-  ToolTips toolTips; // tooltips are available for Category, HorizontalBar, OHLC and XY charts
-  ChartZoom chartZoom;
-  //  Cursor cursor;
+  PlotInteractionData interactionData;
 
   // TODO create a PlotContent_Axes class to put this in.
   static final BasicStroke ERROR_BAR_STROKE =
@@ -56,24 +50,12 @@ public abstract class PlotContent_<ST extends Styler, S extends Series> implemen
       g.setClip(bounds);
     }
 
-    if (chart.getStyler().isToolTipsEnabled() && toolTips != null) {
-      toolTips.clearData();
+    if (interactionData != null) {
+      interactionData.clear();
+      interactionData.plotBounds = getBounds();
     }
 
     doPaint(g);
-
-    // after painting the plot content, paint the tooltip(s) if necessary
-    if (chart.getStyler().isToolTipsEnabled() && toolTips != null) {
-      toolTips.paint(g);
-    }
-
-    // TODO put this in PlotContent_XY.
-    if (chartZoom != null
-        && ((chart instanceof XYChart && ((XYStyler) chart.getStyler()).isZoomEnabled())
-            || (chart instanceof OHLCChart
-                && ((OHLCStyler) chart.getStyler()).isZoomEnabled()))) {
-      chartZoom.paint(g);
-    }
 
     g.setClip(saveClip);
   }
@@ -96,11 +78,8 @@ public abstract class PlotContent_<ST extends Styler, S extends Series> implemen
     }
   }
 
-  public void setToolTips(ToolTips toolTips) {
-    this.toolTips = toolTips;
-  }
+  PlotInteractionData getInteractionData() {
 
-  public void setChartZoom(ChartZoom chartZoom) {
-    this.chartZoom = chartZoom;
+    return interactionData;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
@@ -41,7 +41,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
     // Y-Axis
     yTickSpace = boxPlotStyler.getPlotContentSize() * getBounds().getHeight();
     yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
-    boolean toolTipsEnabled = toolTips != null && chart.getStyler().isToolTipsEnabled();
+    boolean toolTipsEnabled = interactionData != null && chart.getStyler().isToolTipsEnabled();
     double gridStep = xTickSpace / chart.getSeriesMap().size();
 
     BoxPlotDataCalculator<ST, S> boxPlotDataCalculator = new BoxPlotDataCalculator<>();
@@ -110,7 +110,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
           g.draw(outPointLine2);
 
           if (toolTipsEnabled) {
-            toolTips.addData(
+            interactionData.addToolTip(
                 xOffset,
                 yOffset,
                 series.getName()
@@ -125,7 +125,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
           series.getMarker().paint(g, xOffset, yOffset, boxPlotStyler.getMarkerSize());
 
           if (toolTipsEnabled) {
-            toolTips.addData(
+            interactionData.addToolTip(
                 xOffset,
                 yOffset,
                 series.getName()
@@ -234,8 +234,8 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
     area.add(new Area(lowLine.getBounds()));
     area.add(new Area(rect.getBounds()));
 
-    if (toolTips != null && boxPlotStyler.isToolTipsEnabled()) {
-      toolTips.addData(
+    if (interactionData != null && boxPlotStyler.isToolTipsEnabled()) {
+      interactionData.addToolTip(
           area,
           xOffset,
           yOffset,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
@@ -41,7 +41,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
     // Y-Axis
     yTickSpace = boxPlotStyler.getPlotContentSize() * getBounds().getHeight();
     yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
-    boolean toolTipsEnabled = interactionData != null && chart.getStyler().isToolTipsEnabled();
+    boolean toolTipsEnabled = interactionData != null;
     double gridStep = xTickSpace / chart.getSeriesMap().size();
 
     BoxPlotDataCalculator<ST, S> boxPlotDataCalculator = new BoxPlotDataCalculator<>();
@@ -234,7 +234,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
     area.add(new Area(lowLine.getBounds()));
     area.add(new Area(rect.getBounds()));
 
-    if (interactionData != null && boxPlotStyler.isToolTipsEnabled()) {
+    if (interactionData != null) {
       interactionData.addToolTip(
           area,
           xOffset,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
@@ -131,8 +131,8 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
           g.draw(bubble);
 
           // add tooltips
-          if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
-            toolTips.addData(
+          if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+            interactionData.addToolTip(
                 bubble,
                 xOffset,
                 yOffset,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
@@ -131,7 +131,7 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
           g.draw(bubble);
 
           // add tooltips
-          if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+          if (interactionData != null) {
             interactionData.addToolTip(
                 bubble,
                 xOffset,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -484,7 +484,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
           g.draw(line);
         }
         // add data labels
-        if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+        if (interactionData != null) {
           Rectangle2D.Double rect =
               new Rectangle2D.Double(xOffset, yOffset, barWidth, Math.abs(yOffset - zeroOffset));
           double yPoint;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -484,7 +484,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
           g.draw(line);
         }
         // add data labels
-        if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
+        if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
           Rectangle2D.Double rect =
               new Rectangle2D.Double(xOffset, yOffset, barWidth, Math.abs(yOffset - zeroOffset));
           double yPoint;
@@ -494,7 +494,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
             yPoint = yOffset;
           }
 
-          toolTips.addData(
+          interactionData.addToolTip(
               rect,
               xOffset,
               yPoint,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Dial.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Dial.java
@@ -223,7 +223,7 @@ public class PlotContent_Dial<ST extends DialStyler, S extends DialSeries>
       double yOffset = yCenter - Math.sin(radians) * (yDiameter * arrowLengthPercentage);
 
       Path2D.Double path = new Path2D.Double();
-      if (toolTips != null && styler.isToolTipsEnabled()) {
+      if (interactionData != null && styler.isToolTipsEnabled()) {
         String label = series.getLabel();
         if (label == null) {
           if (styler.getDecimalPattern() != null) {
@@ -233,7 +233,7 @@ public class PlotContent_Dial<ST extends DialStyler, S extends DialSeries>
             label = df.format(value);
           }
         }
-        toolTips.addData(path, xOffset, yOffset + 10, 0, label);
+        interactionData.addToolTip(path, xOffset, yOffset + 10, 0, label);
       }
       path.moveTo(xCenter, yCenter);
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Dial.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Dial.java
@@ -223,7 +223,7 @@ public class PlotContent_Dial<ST extends DialStyler, S extends DialSeries>
       double yOffset = yCenter - Math.sin(radians) * (yDiameter * arrowLengthPercentage);
 
       Path2D.Double path = new Path2D.Double();
-      if (interactionData != null && styler.isToolTipsEnabled()) {
+      if (interactionData != null) {
         String label = series.getLabel();
         if (label == null) {
           if (styler.getDecimalPattern() != null) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
@@ -95,7 +95,7 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
         showValue(g, rect, df.format(numbers[2]));
       }
 
-      if (interactionData != null && heatMapStyler.isToolTipsEnabled()) {
+      if (interactionData != null) {
         interactionData.addToolTip(
             rect,
             rect.getCenterX(),

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
@@ -95,8 +95,8 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
         showValue(g, rect, df.format(numbers[2]));
       }
 
-      if (toolTips != null && heatMapStyler.isToolTipsEnabled()) {
-        toolTips.addData(
+      if (interactionData != null && heatMapStyler.isToolTipsEnabled()) {
+        interactionData.addToolTip(
             rect,
             rect.getCenterX(),
             rect.getCenterY() + heatMapStyler.getToolTipFont().getSize(),

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HorizontalBar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HorizontalBar.java
@@ -171,7 +171,7 @@ public class PlotContent_HorizontalBar<
         }
 
         // add data labels
-        if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+        if (interactionData != null) {
           Rectangle2D.Double rect =
               new Rectangle2D.Double(
                   zeroOffset, yOffset, Math.abs(xOffset - zeroOffset), barHeight);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HorizontalBar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HorizontalBar.java
@@ -171,7 +171,7 @@ public class PlotContent_HorizontalBar<
         }
 
         // add data labels
-        if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
+        if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
           Rectangle2D.Double rect =
               new Rectangle2D.Double(
                   zeroOffset, yOffset, Math.abs(xOffset - zeroOffset), barHeight);
@@ -182,7 +182,7 @@ public class PlotContent_HorizontalBar<
             xPoint = xOffset;
           }
 
-          toolTips.addData(
+          interactionData.addToolTip(
               rect,
               xPoint,
               yOffset,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -139,7 +139,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
           }
 
           // add tooltips
-          if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+          if (interactionData != null) {
             interactionData.addToolTip(
                 xOffset,
                 yOffset,
@@ -250,7 +250,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
               g.draw(line);
               final double xStart = xOffset - candleHalfWidth;
               final double xEnd = xOffset + candleHalfWidth;
-              if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+              if (interactionData != null) {
                 rect.setRect(
                     xOffset - lineWidth / 2, highOffset, lineWidth, lowOffset - highOffset);
                 toolTipArea = new Area(rect);
@@ -266,7 +266,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                   // Doji: open == close, draw a horizontal line across the candle width
                   line.setLine(xStart, openOffset, xEnd, openOffset);
                   g.draw(line);
-                  if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+                  if (interactionData != null) {
                     rect.setRect(xStart, openOffset - lineWidth / 2, xEnd - xStart, lineWidth);
                     toolTipArea.add(new Area(rect));
                   }
@@ -278,7 +278,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                       Math.abs(closeOffset - openOffset));
                   g.fill(rect);
                   // add data labels
-                  if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+                  if (interactionData != null) {
                     toolTipArea.add(new Area(rect));
                   }
                 }
@@ -289,7 +289,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                 g.draw(line);
                 line.setLine(xOffset, closeOffset, xEnd, closeOffset);
                 g.draw(line);
-                if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+                if (interactionData != null) {
                   rect.setRect(xStart, openOffset - lineWidth / 2, xOffset - xStart, lineWidth);
                   toolTipArea.add(new Area(rect));
                   rect.setRect(xOffset, closeOffset - lineWidth / 2, xEnd - xOffset, lineWidth);
@@ -300,7 +300,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
           }
 
           // add tooltips
-          if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+          if (interactionData != null) {
 
             StringBuilder sb = new StringBuilder();
             if (series.getVolumeData() != null) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -139,8 +139,8 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
           }
 
           // add tooltips
-          if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
-            toolTips.addData(
+          if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+            interactionData.addToolTip(
                 xOffset,
                 yOffset,
                 chart.getXAxisFormat().format(x),
@@ -250,7 +250,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
               g.draw(line);
               final double xStart = xOffset - candleHalfWidth;
               final double xEnd = xOffset + candleHalfWidth;
-              if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
+              if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
                 rect.setRect(
                     xOffset - lineWidth / 2, highOffset, lineWidth, lowOffset - highOffset);
                 toolTipArea = new Area(rect);
@@ -266,7 +266,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                   // Doji: open == close, draw a horizontal line across the candle width
                   line.setLine(xStart, openOffset, xEnd, openOffset);
                   g.draw(line);
-                  if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
+                  if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
                     rect.setRect(xStart, openOffset - lineWidth / 2, xEnd - xStart, lineWidth);
                     toolTipArea.add(new Area(rect));
                   }
@@ -278,7 +278,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                       Math.abs(closeOffset - openOffset));
                   g.fill(rect);
                   // add data labels
-                  if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
+                  if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
                     toolTipArea.add(new Area(rect));
                   }
                 }
@@ -289,7 +289,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
                 g.draw(line);
                 line.setLine(xOffset, closeOffset, xEnd, closeOffset);
                 g.draw(line);
-                if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
+                if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
                   rect.setRect(xStart, openOffset - lineWidth / 2, xOffset - xStart, lineWidth);
                   toolTipArea.add(new Area(rect));
                   rect.setRect(xOffset, closeOffset - lineWidth / 2, xEnd - xOffset, lineWidth);
@@ -300,7 +300,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
           }
 
           // add tooltips
-          if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
+          if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
 
             StringBuilder sb = new StringBuilder();
             if (series.getVolumeData() != null) {
@@ -322,7 +322,7 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
             sb.append(System.lineSeparator())
                 .append("high: ")
                 .append(chart.getYAxisFormat().format(highOrig));
-            toolTips.addData(toolTipArea, xOffset, highOffset, 0, sb.toString());
+            interactionData.addToolTip(toolTipArea, xOffset, highOffset, 0, sb.toString());
           }
         }
       }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -193,7 +193,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
       // TOOLTIPS ////////////////////////////////////////////////////
       // TOOLTIPS ////////////////////////////////////////////////////
 
-      if (interactionData != null && pieStyler.isToolTipsEnabled()) {
+      if (interactionData != null) {
         // add data labels
         // maybe another option to construct this label
         // TODO use tool tip label type enum and customize this label

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -193,7 +193,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
       // TOOLTIPS ////////////////////////////////////////////////////
       // TOOLTIPS ////////////////////////////////////////////////////
 
-      if (toolTips != null && pieStyler.isToolTipsEnabled()) {
+      if (interactionData != null && pieStyler.isToolTipsEnabled()) {
         // add data labels
         // maybe another option to construct this label
         // TODO use tool tip label type enum and customize this label
@@ -209,7 +209,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
                 - Math.sin(Math.toRadians(angle))
                     * (pieBounds.getHeight() / 2 * pieStyler.getLabelsDistance());
 
-        toolTips.addData(toolTipShape, xOffset, yOffset + 10, 0, toolTipLabel);
+        interactionData.addToolTip(toolTipShape, xOffset, yOffset + 10, 0, toolTipLabel);
       }
 
       // TOOLTIPS ////////////////////////////////////////////////////

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
@@ -233,7 +233,7 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
         }
 
         // add data labels
-        if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+        if (interactionData != null) {
           String label = null;
           if (tooltipOverrides != null) {
             label = tooltipOverrides[i];

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
@@ -233,7 +233,7 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
         }
 
         // add data labels
-        if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
+        if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
           String label = null;
           if (tooltipOverrides != null) {
             label = tooltipOverrides[i];
@@ -242,7 +242,7 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
             String ystr = decimalFormat.format(value);
             label = series.getName() + " (" + radiiLabels[i] + ": " + ystr + ")";
           }
-          this.toolTips.addData(xOffset, yOffset, label);
+          interactionData.addToolTip(xOffset, yOffset, label);
         }
       }
       path.closePath();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -15,8 +15,6 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
 
   private final ST xyStyler;
 
-  Cursor cursor;
-
   /**
    * Constructor
    *
@@ -48,10 +46,6 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
     if (xyStyler.isXAxisLogarithmic()) {
       xMin = Math.log10(xMin);
       xMax = Math.log10(xMax);
-    }
-
-    if (cursor != null) {
-        cursor.clearDataPoints();
     }
 
     Map<String, S> map = chart.getSeriesMap();
@@ -304,15 +298,15 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
         }
 
         // add tooltips
-        if (toolTips != null && chart.getStyler().isToolTipsEnabled()) {
-          toolTips.addData(
+        if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+          interactionData.addToolTip(
               xOffset,
               yOffset,
               chart.getXAxisFormat().format(x),
               chart.getYAxisFormat(series.getYAxisDecimalPattern()).format(yOrig));
         }
 
-        if (cursor != null && xyStyler.isCursorEnabled()) {
+        if (interactionData != null && xyStyler.isCursorEnabled()) {
           Format xFormat;
           Format yFormat;
           if (xyStyler.getCustomCursorXDataFormattingFunction() == null) {
@@ -325,7 +319,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
           } else {
             yFormat = new Formatter_Custom(xyStyler.getCustomCursorYDataFormattingFunction());
           }
-          cursor.addData(
+          interactionData.addCursorPoint(
               xOffset, yOffset, xFormat.format(x), yFormat.format(yOrig), series.getName());
         }
       }
@@ -338,9 +332,6 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
       // close any open path for area charts
       g.setColor(series.getFillColor());
       closePathXY(g, path, previousX, yZeroOffset, polygonStartX, polygonStartY);
-    }
-    if (cursor != null && chart.getStyler().isCursorEnabled()) {
-      cursor.paint(g);
     }
   }
 
@@ -360,9 +351,5 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
       path.closePath();
       g.fill(path);
     }
-  }
-
-  public void setCursor(Cursor cursor) {
-    this.cursor = cursor;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -298,7 +298,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
         }
 
         // add tooltips
-        if (interactionData != null && chart.getStyler().isToolTipsEnabled()) {
+        if (interactionData != null) {
           interactionData.addToolTip(
               xOffset,
               yOffset,
@@ -306,7 +306,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
               chart.getYAxisFormat(series.getYAxisDecimalPattern()).format(yOrig));
         }
 
-        if (interactionData != null && xyStyler.isCursorEnabled()) {
+        if (interactionData != null) {
           Format xFormat;
           Format yFormat;
           if (xyStyler.getCustomCursorXDataFormattingFunction() == null) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotInteractionData.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotInteractionData.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PlotInteractionData {
+class PlotInteractionData {
 
   Rectangle2D plotBounds;
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotInteractionData.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotInteractionData.java
@@ -1,0 +1,102 @@
+package org.knowm.xchart.internal.chartpart;
+
+import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PlotInteractionData {
+
+  Rectangle2D plotBounds;
+
+  Rectangle2D getPlotBounds() {
+
+    return plotBounds;
+  }
+
+  private final List<ToolTipData> toolTipDataList = new ArrayList<>();
+  private final List<CursorData> cursorDataList = new ArrayList<>();
+
+  void clear() {
+    toolTipDataList.clear();
+    cursorDataList.clear();
+  }
+
+  List<ToolTipData> getToolTipDataList() {
+    return Collections.unmodifiableList(toolTipDataList);
+  }
+
+  List<CursorData> getCursorDataList() {
+    return Collections.unmodifiableList(cursorDataList);
+  }
+
+  // Pattern 1: x+y label pair, default ellipse hit shape
+  void addToolTip(double x, double y, String xValue, String yValue) {
+    toolTipDataList.add(new ToolTipData(null, x, y, 0, xValue, yValue, null));
+  }
+
+  // Pattern 2: single label, default ellipse hit shape
+  void addToolTip(double x, double y, String label) {
+    toolTipDataList.add(new ToolTipData(null, x, y, 0, null, null, label));
+  }
+
+  // Pattern 3: x+y label pair with explicit hit shape
+  void addToolTip(Shape shape, double x, double y, double w, String xValue, String yValue) {
+    toolTipDataList.add(new ToolTipData(shape, x, y, w, xValue, yValue, null));
+  }
+
+  // Pattern 4: single label with explicit hit shape
+  void addToolTip(Shape shape, double x, double y, double w, String label) {
+    toolTipDataList.add(new ToolTipData(shape, x, y, w, null, null, label));
+  }
+
+  void addCursorPoint(double x, double y, String xValue, String yValue, String seriesName) {
+    cursorDataList.add(new CursorData(x, y, xValue, yValue, seriesName));
+  }
+
+  static final class ToolTipData {
+
+    final Shape shape; // null means use default ellipse
+    final double x;
+    final double y;
+    final double w;
+    final String xValue; // non-null for x+y pair
+    final String yValue; // non-null for x+y pair
+    final String label; // non-null for single-label case
+
+    ToolTipData(
+        Shape shape,
+        double x,
+        double y,
+        double w,
+        String xValue,
+        String yValue,
+        String label) {
+      this.shape = shape;
+      this.x = x;
+      this.y = y;
+      this.w = w;
+      this.xValue = xValue;
+      this.yValue = yValue;
+      this.label = label;
+    }
+  }
+
+  static final class CursorData {
+
+    final double x;
+    final double y;
+    final String xValue;
+    final String yValue;
+    final String seriesName;
+
+    CursorData(double x, double y, String xValue, String yValue, String seriesName) {
+      this.x = x;
+      this.y = y;
+      this.xValue = xValue;
+      this.yValue = yValue;
+      this.seriesName = seriesName;
+    }
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
@@ -1,7 +1,6 @@
 package org.knowm.xchart.internal.chartpart;
 
 import java.awt.Graphics2D;
-import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -33,6 +32,7 @@ public class ToolTips extends MouseAdapter implements ChartPart {
   // The tool tips and currently shown Tooltip
   private final List<ToolTip> toolTipList = new ArrayList<>();
   private ToolTip tooltip = null;
+  private Rectangle2D plotBounds = null;
 
   /**
    * Constructor
@@ -43,7 +43,6 @@ public class ToolTips extends MouseAdapter implements ChartPart {
 
     this.chart = chart;
     this.styler = chart.getStyler();
-    chart.plot.plotContent.setToolTips(this);
   }
 
   ////////////////////////////////////////////
@@ -155,16 +154,10 @@ public class ToolTips extends MouseAdapter implements ChartPart {
 
     //    System.out.println("paintToolTip");
 
-    int leftEdge = (int) chart.plot.plotContent.getBounds().getX();
-    int rightEdge =
-        (int)
-            (chart.plot.plotContent.getBounds().getX()
-                + chart.plot.plotContent.getBounds().getWidth());
-    int topEdge = (int) chart.plot.plotContent.getBounds().getY();
-    int bottomEdge =
-        (int)
-            (chart.plot.plotContent.getBounds().getY()
-                + chart.plot.plotContent.getBounds().getHeight());
+    int leftEdge = (int) plotBounds.getX();
+    int rightEdge = (int) (plotBounds.getX() + plotBounds.getWidth());
+    int topEdge = (int) plotBounds.getY();
+    int bottomEdge = (int) (plotBounds.getY() + plotBounds.getHeight());
     //    System.out.println("leftEdge = " + leftEdge);
     //    System.out.println("rightEdge = " + rightEdge);
     //    System.out.println("topEdge = " + topEdge);
@@ -237,14 +230,13 @@ public class ToolTips extends MouseAdapter implements ChartPart {
 
     //    System.out.println("paintMultiLineToolTip");
 
-    Rectangle clipBounds = g.getClipBounds();
     double startX = tooltip.x;
     double startY = tooltip.y;
-    if (tooltip.x + MOUSE_MARGIN + backgroundWidth > clipBounds.getX() + clipBounds.getWidth()) {
+    if (tooltip.x + MOUSE_MARGIN + backgroundWidth > plotBounds.getX() + plotBounds.getWidth()) {
       startX = tooltip.x - backgroundWidth - MOUSE_MARGIN;
     }
 
-    if (tooltip.y + MOUSE_MARGIN + backgroundHeight > clipBounds.getY() + clipBounds.getHeight()) {
+    if (tooltip.y + MOUSE_MARGIN + backgroundHeight > plotBounds.getY() + plotBounds.getHeight()) {
       startY = tooltip.y - backgroundHeight - MOUSE_MARGIN;
     }
 
@@ -330,6 +322,31 @@ public class ToolTips extends MouseAdapter implements ChartPart {
 
   public void clearData() {
     toolTipList.clear();
+  }
+
+  public void setData(PlotInteractionData data) {
+
+    clearData();
+    if (data == null) {
+      plotBounds = null;
+      return;
+    }
+    plotBounds = data.getPlotBounds();
+    for (PlotInteractionData.ToolTipData td : data.getToolTipDataList()) {
+      if (td.label != null) {
+        if (td.shape != null) {
+          addData(td.shape, td.x, td.y, td.w, td.label);
+        } else {
+          addData(td.x, td.y, td.label);
+        }
+      } else {
+        if (td.shape != null) {
+          addData(td.shape, td.x, td.y, td.w, td.xValue, td.yValue);
+        } else {
+          addData(td.x, td.y, td.xValue, td.yValue);
+        }
+      }
+    }
   }
 
   static class ToolTip {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
@@ -12,6 +12,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.style.BoxStyler;
 import org.knowm.xchart.style.HorizontalBarStyler;
 import org.knowm.xchart.style.OHLCStyler;
@@ -28,6 +29,8 @@ public class ToolTips extends MouseAdapter implements ChartPart {
 
   private final Chart chart;
   private final Styler styler;
+  private final boolean alwaysVisible;
+  private final ToolTipType toolTipType;
 
   // The tool tips and currently shown Tooltip
   private final List<ToolTip> toolTipList = new ArrayList<>();
@@ -38,11 +41,15 @@ public class ToolTips extends MouseAdapter implements ChartPart {
    * Constructor
    *
    * @param chart
+   * @param alwaysVisible
+   * @param toolTipType
    */
-  public ToolTips(Chart chart) {
+  public ToolTips(Chart chart, boolean alwaysVisible, ToolTipType toolTipType) {
 
     this.chart = chart;
     this.styler = chart.getStyler();
+    this.alwaysVisible = alwaysVisible;
+    this.toolTipType = toolTipType;
   }
 
   ////////////////////////////////////////////
@@ -107,7 +114,7 @@ public class ToolTips extends MouseAdapter implements ChartPart {
   @Override
   public void paint(Graphics2D g) {
 
-    if (styler.isToolTipsAlwaysVisible()) {
+    if (this.alwaysVisible) {
       for (ToolTip tooltip : toolTipList) {
         paintToolTip(g, tooltip);
       }
@@ -307,7 +314,7 @@ public class ToolTips extends MouseAdapter implements ChartPart {
 
   private String getLabel(String xValue, String yValue) {
 
-    switch (styler.getToolTipType()) {
+    switch (this.toolTipType) {
       case xAndYLabels:
         return "(" + xValue + ", " + yValue + ")";
       case xLabels:

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Function;
 
-import org.knowm.xchart.style.colors.ChartColor;
-
 public abstract class AxesChartStyler extends Styler {
 
   // Chart Axes ///////////////////////////////
@@ -98,12 +96,6 @@ public abstract class AxesChartStyler extends Styler {
   private TextAlignment yAxisLabelAlignment = TextAlignment.Left;
   private int xAxisLabelRotation = 0;
 
-  // Zoom ///////////////////////////
-  private boolean isZoomEnabled;
-  private Color zoomSelectionColor;
-  private boolean zoomResetByDoubleClick;
-  private boolean zoomResetByButton;
-
   @Override
   void setAllStyles() {
 
@@ -144,12 +136,6 @@ public abstract class AxesChartStyler extends Styler {
     // Error Bars ///////////////////////////////
     this.errorBarsColor = theme.getErrorBarsColor();
     this.isErrorBarsColorSeriesColor = theme.isErrorBarsColorSeriesColor();
-
-    // Zoom ///////////////////////////
-    this.isZoomEnabled = false;
-    this.zoomSelectionColor = ChartColor.LIGHT_GREY.getColorTranslucent();
-    this.zoomResetByDoubleClick = true;
-    this.zoomResetByButton = true;
 
     // Formatting ////////////////////////////////
     this.locale = Locale.getDefault();
@@ -1065,52 +1051,6 @@ public abstract class AxesChartStyler extends Styler {
   public AxesChartStyler setXAxisLabelRotation(int xAxisLabelRotation) {
 
     this.xAxisLabelRotation = xAxisLabelRotation;
-    return this;
-  }
-
-  // Zoom ///////////////////////////////
-
-  public boolean isZoomEnabled() {
-
-    return isZoomEnabled;
-  }
-
-  public AxesChartStyler setZoomEnabled(boolean isZoomEnabled) {
-
-    this.isZoomEnabled = isZoomEnabled;
-    return this;
-  }
-
-  public Color getZoomSelectionColor() {
-
-    return zoomSelectionColor;
-  }
-
-  public AxesChartStyler setZoomSelectionColor(Color zoomSelectionColor) {
-
-    this.zoomSelectionColor = zoomSelectionColor;
-    return this;
-  }
-
-  public boolean isZoomResetByDoubleClick() {
-
-    return zoomResetByDoubleClick;
-  }
-
-  public AxesChartStyler setZoomResetByDoubleClick(boolean zoomResetByDoubleClick) {
-
-    this.zoomResetByDoubleClick = zoomResetByDoubleClick;
-    return this;
-  }
-
-  public boolean isZoomResetByButton() {
-
-    return zoomResetByButton;
-  }
-
-  public AxesChartStyler setZoomResetByButton(boolean zoomResetByButton) {
-
-    this.zoomResetByButton = zoomResetByButton;
     return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/OHLCStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/OHLCStyler.java
@@ -1,6 +1,5 @@
 package org.knowm.xchart.style;
 
-import java.awt.Color;
 import org.knowm.xchart.OHLCSeries;
 import org.knowm.xchart.OHLCSeries.OHLCSeriesRenderStyle;
 import org.knowm.xchart.style.theme.Theme;
@@ -48,35 +47,5 @@ public class OHLCStyler extends AxesChartStyler {
 
     this.theme = theme;
     setAllStyles();
-  }
-
-  // Zoom \u2014 covariant overrides ///////////////////////////////
-
-  @Override
-  public OHLCStyler setZoomEnabled(boolean isZoomEnabled) {
-
-    super.setZoomEnabled(isZoomEnabled);
-    return this;
-  }
-
-  @Override
-  public OHLCStyler setZoomSelectionColor(Color zoomSelectionColor) {
-
-    super.setZoomSelectionColor(zoomSelectionColor);
-    return this;
-  }
-
-  @Override
-  public OHLCStyler setZoomResetByDoubleClick(boolean zoomResetByDoubleClick) {
-
-    super.setZoomResetByDoubleClick(zoomResetByDoubleClick);
-    return this;
-  }
-
-  @Override
-  public OHLCStyler setZoomResetByButton(boolean zoomResetByButton) {
-
-    super.setZoomResetByButton(zoomResetByButton);
-    return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -77,9 +77,6 @@ public abstract class Styler {
   private ChartButtonPosition chartButtonPosition;
 
   // Tool Tips ///////////////////////////////
-  private boolean isToolTipsEnabled;
-  private boolean isToolTipsAlwaysVisible;
-  private ToolTipType toolTipType;
   private Color toolTipBackgroundColor;
   private Color toolTipBorderColor;
   private Font toolTipFont;
@@ -164,8 +161,6 @@ public abstract class Styler {
 
     // Tool Tips ///////////////////////////////
 
-    isToolTipsEnabled = theme.isToolTipsEnabled();
-    toolTipType = theme.getToolTipType();
     toolTipBackgroundColor = theme.getToolTipBackgroundColor();
     toolTipBorderColor = theme.getToolTipBorderColor();
     toolTipFont = theme.getToolTipFont();
@@ -751,45 +746,6 @@ public abstract class Styler {
   }
 
   // Tool Tips ///////////////////////////////
-
-  public boolean isToolTipsEnabled() {
-
-    return isToolTipsEnabled;
-  }
-
-  public Styler setToolTipsEnabled(boolean toolTipsEnabled) {
-
-    isToolTipsEnabled = toolTipsEnabled;
-    return this;
-  }
-
-  public boolean isToolTipsAlwaysVisible() {
-
-    return isToolTipsAlwaysVisible;
-  }
-
-  public Styler setToolTipsAlwaysVisible(boolean toolTipsAlwaysVisible) {
-
-    isToolTipsAlwaysVisible = toolTipsAlwaysVisible;
-    return this;
-  }
-
-  public ToolTipType getToolTipType() {
-
-    return toolTipType;
-  }
-
-  public Styler setToolTipType(ToolTipType toolTipType) {
-
-    this.toolTipType = toolTipType;
-    return this;
-  }
-
-  public enum ToolTipType {
-    xLabels,
-    yLabels,
-    xAndYLabels
-  }
 
   public Color getToolTipBackgroundColor() {
 

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -6,6 +6,7 @@ import java.awt.Font;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.style.colors.ChartColor;
 import org.knowm.xchart.style.markers.Marker;
 import org.knowm.xchart.style.theme.GGPlot2Theme;
@@ -81,6 +82,8 @@ public abstract class Styler {
   private Color toolTipBorderColor;
   private Font toolTipFont;
   private Color toolTipHighlightColor;
+  private boolean toolTipsAlwaysVisible;
+  private ToolTipType toolTipType;
 
   // Misc. ///////////////////////////////
   private boolean antiAlias = true;
@@ -165,6 +168,8 @@ public abstract class Styler {
     toolTipBorderColor = theme.getToolTipBorderColor();
     toolTipFont = theme.getToolTipFont();
     toolTipHighlightColor = theme.getToolTipHighlightColor();
+    toolTipsAlwaysVisible = false;
+    toolTipType = ToolTipType.xAndYLabels;
 
     // Formatting
     decimalPattern = null;
@@ -788,6 +793,40 @@ public abstract class Styler {
   public Styler setToolTipHighlightColor(Color toolTipHighlightColor) {
 
     this.toolTipHighlightColor = toolTipHighlightColor;
+    return this;
+  }
+
+  public boolean isToolTipsAlwaysVisible() {
+
+    return toolTipsAlwaysVisible;
+  }
+
+  /**
+   * When true, all data-point labels are rendered into the chart image (visible in BitmapEncoder
+   * output and Swing panels alike). This is a rendering/visual property; enable hover tooltips
+   * separately via {@link XChartPanel#setToolTipsEnabled(boolean)}.
+   *
+   * @param toolTipsAlwaysVisible true to render labels for every data point
+   */
+  public Styler setToolTipsAlwaysVisible(boolean toolTipsAlwaysVisible) {
+
+    this.toolTipsAlwaysVisible = toolTipsAlwaysVisible;
+    return this;
+  }
+
+  public ToolTipType getToolTipType() {
+
+    return toolTipType;
+  }
+
+  /**
+   * Sets which label components to render when tooltips are visible (x value, y value, or both).
+   *
+   * @param toolTipType the label type to display
+   */
+  public Styler setToolTipType(ToolTipType toolTipType) {
+
+    this.toolTipType = toolTipType;
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/style/XYStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/XYStyler.java
@@ -12,7 +12,6 @@ public class XYStyler extends AxesChartStyler {
 
   // Cursor ////////////////////////////////
 
-  private boolean isCursorEnabled;
   private Color cursorColor;
   private float cursorLineWidth;
   private Font cursorFont;
@@ -37,7 +36,6 @@ public class XYStyler extends AxesChartStyler {
     xySeriesRenderStyle = XYSeriesRenderStyle.Line; // set default to line
 
     // Cursor ////////////////////////////////
-    this.isCursorEnabled = theme.isCursorEnabled();
     this.cursorColor = theme.getCursorColor();
     this.cursorLineWidth = theme.getCursorSize();
     this.cursorFont = theme.getCursorFont();
@@ -70,48 +68,6 @@ public class XYStyler extends AxesChartStyler {
   public XYStyler setDefaultSeriesRenderStyle(XYSeriesRenderStyle xySeriesRenderStyle) {
 
     this.xySeriesRenderStyle = xySeriesRenderStyle;
-    return this;
-  }
-
-  // Zoom — covariant overrides ///////////////////////////////
-
-  @Override
-  public XYStyler setZoomEnabled(boolean isZoomEnabled) {
-
-    super.setZoomEnabled(isZoomEnabled);
-    return this;
-  }
-
-  @Override
-  public XYStyler setZoomSelectionColor(Color zoomSelectionColor) {
-
-    super.setZoomSelectionColor(zoomSelectionColor);
-    return this;
-  }
-
-  @Override
-  public XYStyler setZoomResetByDoubleClick(boolean zoomResetByDoubleClick) {
-
-    super.setZoomResetByDoubleClick(zoomResetByDoubleClick);
-    return this;
-  }
-
-  @Override
-  public XYStyler setZoomResetByButton(boolean zoomResetByButton) {
-
-    super.setZoomResetByButton(zoomResetByButton);
-    return this;
-  }
-
-  // Cursor ///////////////////////////////
-
-  public boolean isCursorEnabled() {
-    return isCursorEnabled;
-  }
-
-  public XYStyler setCursorEnabled(boolean isCursorEnabled) {
-
-    this.isCursorEnabled = isCursorEnabled;
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/style/theme/AbstractBaseTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/theme/AbstractBaseTheme.java
@@ -307,12 +307,6 @@ public abstract class AbstractBaseTheme implements Theme {
   // Cursor ///////////////////////////////
 
   @Override
-  public boolean isCursorEnabled() {
-
-    return false;
-  }
-
-  @Override
   public Color getCursorColor() {
 
     return Color.BLACK;

--- a/xchart/src/main/java/org/knowm/xchart/style/theme/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/theme/Theme.java
@@ -148,16 +148,6 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
 
   // ToolTips ///////////////////////////////
 
-  default boolean isToolTipsEnabled() {
-
-    return false;
-  }
-
-  default Styler.ToolTipType getToolTipType() {
-
-    return Styler.ToolTipType.xAndYLabels;
-  }
-
   default Font getToolTipFont() {
 
     return BASE_FONT;
@@ -214,8 +204,6 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
 
   // Cursor ///////////////////////////////
 
-  boolean isCursorEnabled();
-
   Color getCursorColor();
 
   float getCursorSize();
@@ -225,12 +213,6 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
   Color getCursorFontColor();
 
   Color getCursorBackgroundColor();
-
-  // Zoom /////////////////////////////////////
-
-  default boolean isZoomEnabled() {
-    return false;
-  }
 
   // Bar Charts ///////////////////////////////
 

--- a/xchart/src/test/java/org/knowm/xchart/BitmapEncoderTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/BitmapEncoderTest.java
@@ -24,18 +24,26 @@ public class BitmapEncoderTest {
     assertEquals(".bmp", BitmapEncoder.addFileExtension(".BmP", BitmapEncoder.BitmapFormat.BMP));
   }
 
-  /** Regression test for issue #862: BitmapEncoder must not NPE when tooltips are enabled. */
+  /**
+   * Regression test for issue #862: BitmapEncoder must not NPE when always-visible tooltips are
+   * enabled. Tooltips should be rendered into the image.
+   */
   @Test
-  public void getBufferedImageDoesNotNPEWithToolTipsEnabled() {
+  public void getBufferedImageRendersAlwaysVisibleToolTips() {
     XYChart chart = new XYChartBuilder().width(400).height(300).build();
     chart.addSeries("series", new double[] {1, 2, 3}, new double[] {4, 5, 6});
+    chart.getStyler().setToolTipsAlwaysVisible(true);
 
     assertDoesNotThrow(() -> BitmapEncoder.getBufferedImage(chart));
   }
 
-  /** Regression test for issue #862: zoom-enabled charts must not NPE with BitmapEncoder. */
+  /**
+   * Regression test for issue #862: BitmapEncoder must not NPE when headless-rendering a chart
+   * where hover tooltips would be enabled in a panel at runtime. Since zoom/hover are panel-owned,
+   * they must not affect headless rendering.
+   */
   @Test
-  public void getBufferedImageDoesNotNPEWithZoomEnabled() {
+  public void getBufferedImageDoesNotNPEHeadless() {
     XYChart chart = new XYChartBuilder().width(400).height(300).build();
     chart.addSeries("series", new double[] {1, 2, 3}, new double[] {4, 5, 6});
 

--- a/xchart/src/test/java/org/knowm/xchart/BitmapEncoderTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/BitmapEncoderTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import org.knowm.xchart.style.Styler;
 
 public class BitmapEncoderTest {
 
@@ -29,9 +28,6 @@ public class BitmapEncoderTest {
   @Test
   public void getBufferedImageDoesNotNPEWithToolTipsEnabled() {
     XYChart chart = new XYChartBuilder().width(400).height(300).build();
-    chart.getStyler().setToolTipsEnabled(true);
-    chart.getStyler().setToolTipsAlwaysVisible(true);
-    chart.getStyler().setToolTipType(Styler.ToolTipType.yLabels);
     chart.addSeries("series", new double[] {1, 2, 3}, new double[] {4, 5, 6});
 
     assertDoesNotThrow(() -> BitmapEncoder.getBufferedImage(chart));
@@ -41,7 +37,6 @@ public class BitmapEncoderTest {
   @Test
   public void getBufferedImageDoesNotNPEWithZoomEnabled() {
     XYChart chart = new XYChartBuilder().width(400).height(300).build();
-    chart.getStyler().setZoomEnabled(true);
     chart.addSeries("series", new double[] {1, 2, 3}, new double[] {4, 5, 6});
 
     assertDoesNotThrow(() -> BitmapEncoder.getBufferedImage(chart));


### PR DESCRIPTION
## Motivation

The Swing-interactive features (`ToolTips`, `ChartZoom`, `Cursor`) were tightly coupled into the core `PlotContent_*` rendering pipeline in two problematic ways:

1. **Self-injection anti-pattern**: `ToolTips`, `ChartZoom`, and `Cursor` constructors wrote themselves directly into `chart.plot.plotContent` via package-private field access. This caused NPEs when `BitmapEncoder.saveBitmap()` was called while these objects were still wired in (issue #862 root cause).

2. **Styler pollution**: Feature flags like `isToolTipsEnabled`, `isZoomEnabled`, and `isCursorEnabled` lived on `Styler`/`AxesChartStyler`/`XYStyler` -- chart *visual style* classes -- even though they control Swing panel behavior that is irrelevant during headless rendering.

## Approach

### Commit 1: Option C two-phase data collection (`PlotInteractionData`)

Introduces a plain data-transfer struct `PlotInteractionData` that `PlotContent_*` populates during rendering, replacing direct calls to `toolTips.addData()` and `cursor.addData()`. `XChartPanel` reads the struct after `chart.paint()` and drives all interaction painting.

- New `PlotInteractionData.java`: holds `ToolTipData` list, `CursorData` list, and `plotBounds`
- `Chart.java`: adds `enableInteractionData()` / `getInteractionData()` public methods
- All 11 `PlotContent_*` subclasses: replace `toolTips.addData()` / `cursor.addData()` calls with `interactionData.addToolTip()` / `interactionData.addCursorPoint()`
- `PlotContent_.java`: removes `toolTips` / `chartZoom` fields and the three nullable-field setters
- `ToolTips` / `Cursor`: remove self-injection from constructors; add `setData(PlotInteractionData)` to consume the struct and replace all `chart.plot.plotContent.getBounds()` calls
- `ChartZoom`: remove self-injection (one line)
- `XChartPanel`: `cursor` and `chartZoom` become fields; calls `enableInteractionData()` in constructor; `paintComponent()` does two-phase render -> read -> paint interactions

### Commit 2: Move interaction feature flags off Styler to XChartPanel

`isToolTipsEnabled`, `isToolTipsAlwaysVisible`, `ToolTipType`, `isZoomEnabled`, `zoomSelectionColor`, `zoomResetByDoubleClick`, `zoomResetByButton`, and `isCursorEnabled` are panel behaviors, not chart styles.

- Removes all 8 flags from `Styler`, `AxesChartStyler`, `XYStyler`, `OHLCStyler`, `Theme`, and `AbstractBaseTheme`
- `ToolTipType` promoted to a top-level public enum (`org.knowm.xchart.ToolTipType`) instead of a `Styler` inner type
- `XChartPanel` gains 8 fields with fluent setters and a private `rewireInteractions()` method
- `PlotContent_*` tooltip guards simplify from `interactionData != null && styler.isToolTipsEnabled()` to just `interactionData != null`
- `ChartZoom` reads zoom config from `xChartPanel` getters instead of `chart.getStyler()`

## New user API (breaking change)

Before:
```java
chart.getStyler().setToolTipsEnabled(true);
chart.getStyler().setZoomEnabled(true);
// ((XYStyler) chart.getStyler()).setCursorEnabled(true);
XChartPanel<XYChart> panel = new XChartPanel<>(chart);
```

After:
```java
XChartPanel<XYChart> panel = new XChartPanel<>(chart);
panel.setToolTipsEnabled(true)
     .setZoomEnabled(true)
     .setCursorEnabled(true)
     .setToolTipType(ToolTipType.yLabels);
```

## Testing

All 44 existing tests pass. The `BitmapEncoderTest` was updated to reflect that interaction setup now belongs on the panel, not the chart styler.