### PR TITLE
Fix IDE warnings across xchart, xchart-demo, and xchart-site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ target/
 javadoc/
 bin/
 log/
-*.class
 
 # Misc.
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target/
 javadoc/
 bin/
 log/
+*.class
 
 # Misc.
 .DS_Store

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/ChartInfo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/ChartInfo.java
@@ -5,7 +5,7 @@ import org.knowm.xchart.demo.charts.ExampleChart;
 public final class ChartInfo {
 
   private final String exampleChartName;
-  private final ExampleChart exampleChart;
+  private final ExampleChart<?> exampleChart;
 
   /**
    * Constructor
@@ -13,7 +13,7 @@ public final class ChartInfo {
    * @param exampleChartName
    * @param exampleChart
    */
-  public ChartInfo(String exampleChartName, ExampleChart exampleChart) {
+  public ChartInfo(String exampleChartName, ExampleChart<?> exampleChart) {
 
     this.exampleChartName = exampleChartName;
     this.exampleChart = exampleChart;
@@ -24,7 +24,7 @@ public final class ChartInfo {
     return exampleChartName;
   }
 
-  public ExampleChart getExampleChart() {
+  public ExampleChart<?> getExampleChart() {
 
     return exampleChart;
   }

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/ChartStylePanel.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/ChartStylePanel.java
@@ -526,9 +526,9 @@ public class ChartStylePanel extends JPanel {
   }
 
   private EditorTable table;
-  private XChartPanel chartPanel;
+  private XChartPanel<?> chartPanel;
 
-  public ChartStylePanel(XChartPanel chartPanel) {
+  public ChartStylePanel(XChartPanel<?> chartPanel) {
     this.chartPanel = chartPanel;
     table = new EditorTable(this, chartPanel.getChart());
     JScrollPane scrollpane = new JScrollPane(table);
@@ -538,7 +538,7 @@ public class ChartStylePanel extends JPanel {
     setPreferredSize(new Dimension(800, 600));
   }
 
-  public void changeChart(XChartPanel chartPanel) {
+  public void changeChart(XChartPanel<?> chartPanel) {
 
     this.chartPanel = chartPanel;
     table.changeChart(chartPanel.getChart());

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/ChartStylePanel.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/ChartStylePanel.java
@@ -78,22 +78,22 @@ public class ChartStylePanel extends JPanel {
     ChartStylePanel csp;
     Object additionalParameter;
 
-    static HashMap<Class, TableCellEditor> editorMap;
-    static Class[] assignableClasses = {
+    static HashMap<Class<?>, TableCellEditor> editorMap;
+    static Class<?>[] assignableClasses = {
       Theme.class, BasicStroke.class, Marker.class, TimeZone.class
     };
 
     static {
-      editorMap = new HashMap<Class, TableCellEditor>();
+      editorMap = new HashMap<>();
       {
-        JComboBox comboBox = new JComboBox(new Boolean[] {Boolean.TRUE, Boolean.FALSE});
+        JComboBox<Boolean> comboBox = new JComboBox<>(new Boolean[] {Boolean.TRUE, Boolean.FALSE});
         TableCellEditor cellEditor = new DefaultCellEditor(comboBox);
         editorMap.put(Boolean.class, cellEditor);
         editorMap.put(Boolean.TYPE, cellEditor);
       }
 
       {
-        Class[][] clsArr = {
+        Class<?>[][] clsArr = {
           {int.class, Integer.class},
           {byte.class, Byte.class},
           {short.class, Short.class},
@@ -103,17 +103,17 @@ public class ChartStylePanel extends JPanel {
           {String.class, String.class}
         };
 
-        for (Class[] classes : clsArr) {
+        for (Class<?>[] classes : clsArr) {
           GenericEditorWithClass editor = new GenericEditorWithClass(classes[1]);
-          for (Class class1 : classes) {
+          for (Class<?> class1 : classes) {
             editorMap.put(class1, editor);
           }
         }
       }
 
       {
-        JComboBox comboBox =
-            new JComboBox(new Theme[] {new XChartTheme(), new GGPlot2Theme(), new MatlabTheme()});
+        JComboBox<Theme> comboBox =
+            new JComboBox<>(new Theme[] {new XChartTheme(), new GGPlot2Theme(), new MatlabTheme()});
         editorMap.put(Theme.class, new DefaultCellEditor(comboBox));
       }
 
@@ -125,7 +125,7 @@ public class ChartStylePanel extends JPanel {
           new LabelValue("DASH_DASH", SeriesLines.DASH_DASH),
           new LabelValue("DASH_DOT", SeriesLines.DASH_DOT)
         };
-        JComboBox comboBox = new JComboBox(values);
+        JComboBox<LabelValue> comboBox = new JComboBox<>(values);
         editorMap.put(BasicStroke.class, new DefaultCellEditor(comboBox));
       }
       {
@@ -156,13 +156,13 @@ public class ChartStylePanel extends JPanel {
           new LabelValue("GGPlot2 Tick Marks", new BasicStroke(1.5f)), //
           new LabelValue("Matlab Tick Marks", new BasicStroke(.5f)), //
         };
-        JComboBox comboBox = new JComboBox(values);
+        JComboBox<LabelValue> comboBox = new JComboBox<>(values);
         editorMap.put(Stroke.class, new DefaultCellEditor(comboBox));
       }
 
       {
         Marker[] seriesMarkers = new BaseSeriesMarkers().getSeriesMarkers();
-        JComboBox comboBox = new JComboBox(seriesMarkers);
+        JComboBox<Marker> comboBox = new JComboBox<>(seriesMarkers);
         editorMap.put(Marker.class, new DefaultCellEditor(comboBox));
       }
 
@@ -178,7 +178,7 @@ public class ChartStylePanel extends JPanel {
               Locale.GERMAN,
               Locale.forLanguageTag("tr-TR")
             };
-        JComboBox comboBox = new JComboBox(values);
+        JComboBox<Locale> comboBox = new JComboBox<>(values);
         editorMap.put(Locale.class, new DefaultCellEditor(comboBox));
       }
 
@@ -188,7 +188,7 @@ public class ChartStylePanel extends JPanel {
         for (int i = 0; i < values.length; i++) {
           values[i] = TimeZone.getTimeZone(availableIDs[i]);
         }
-        JComboBox comboBox = new JComboBox(values);
+        JComboBox<TimeZone> comboBox = new JComboBox<>(values);
         editorMap.put(TimeZone.class, new DefaultCellEditor(comboBox));
       }
     }
@@ -220,19 +220,19 @@ public class ChartStylePanel extends JPanel {
 
       try {
         Object val = getValue();
-        Class cls = val == null ? getValueClass() : val.getClass();
+        Class<?> cls = val == null ? getValueClass() : val.getClass();
         cellEditor = editorMap.get(cls);
         if (cellEditor != null) {
           return;
         }
 
         if (cls.isEnum()) {
-          JComboBox comboBox = new JComboBox(cls.getEnumConstants());
+          JComboBox<Object> comboBox = new JComboBox<>(cls.getEnumConstants());
           cellEditor = new DefaultCellEditor(comboBox);
           return;
         }
 
-        for (Class class1 : assignableClasses) {
+        for (Class<?> class1 : assignableClasses) {
           if (class1.isAssignableFrom(cls)) {
             cellEditor = editorMap.get(class1);
             return;
@@ -316,7 +316,7 @@ public class ChartStylePanel extends JPanel {
       return cellEditor;
     }
 
-    public Class getValueClass() {
+    public Class<?> getValueClass() {
 
       if (readMethod == null) {
         // obj is array
@@ -354,11 +354,11 @@ public class ChartStylePanel extends JPanel {
 
   static class GenericEditorWithClass extends DefaultCellEditor {
 
-    Class[] argTypes = new Class[] {String.class};
-    java.lang.reflect.Constructor constructor;
+    Class<?>[] argTypes = new Class<?>[] {String.class};
+    java.lang.reflect.Constructor<?> constructor;
     Object value;
 
-    public GenericEditorWithClass(Class cls) {
+    public GenericEditorWithClass(Class<?> cls) {
       super(new JTextField());
       getComponent().setName("Table.editor");
       try {
@@ -409,11 +409,11 @@ public class ChartStylePanel extends JPanel {
 
   public static class EditorTableModel extends DefaultTableModel {
     ArrayList<EditableProperty> properties;
-    Chart chart;
+    Chart<?, ?> chart;
     int rowCount;
     ChartStylePanel csp;
 
-    public EditorTableModel(ChartStylePanel csp, Chart chart) {
+    public EditorTableModel(ChartStylePanel csp, Chart<?, ?> chart) {
       this.csp = csp;
       addColumn("Name");
       addColumn("Type");
@@ -421,7 +421,7 @@ public class ChartStylePanel extends JPanel {
       changeChart(chart);
     }
 
-    public void changeChart(Chart chart) {
+    public void changeChart(Chart<?, ?> chart) {
 
       this.chart = chart;
       properties = getProperties(csp, chart);
@@ -487,7 +487,7 @@ public class ChartStylePanel extends JPanel {
   public static class EditorTable extends JTable {
     EditorTableModel tableModel;
 
-    public EditorTable(ChartStylePanel csp, Chart chart) {
+    public EditorTable(ChartStylePanel csp, Chart<?, ?> chart) {
       tableModel = new EditorTableModel(csp, chart);
 
       setModel(tableModel);
@@ -503,7 +503,7 @@ public class ChartStylePanel extends JPanel {
       setAutoCreateRowSorter(true);
     }
 
-    public void changeChart(Chart chart) {
+    public void changeChart(Chart<?, ?> chart) {
 
       tableModel.changeChart(chart);
     }
@@ -517,7 +517,7 @@ public class ChartStylePanel extends JPanel {
       if (editor != null) {
         return editor;
       }
-      Class valueClass = se.getValueClass();
+      Class<?> valueClass = se.getValueClass();
       TableCellEditor defaultEditor = getDefaultEditor(valueClass);
 
       // System.out.println(valueClass + "=>" + defaultEditor);
@@ -575,7 +575,7 @@ public class ChartStylePanel extends JPanel {
               "YAxisAlignment",
               "YAxisGroupPosition"));
 
-  public static ArrayList<EditableProperty> getProperties(ChartStylePanel csp, Chart chart) {
+  public static ArrayList<EditableProperty> getProperties(ChartStylePanel csp, Chart<?, ?> chart) {
 
     if (chart == null) {
       return new ArrayList<EditableProperty>();
@@ -585,10 +585,10 @@ public class ChartStylePanel extends JPanel {
         getObjectProperties(csp, chart.getStyler(), "styler.", skipSet);
     list.addAll(list2);
 
-    Map<String, Series> seriesMap = chart.getSeriesMap();
+    Map<String, ? extends Series> seriesMap = chart.getSeriesMap();
     int ind = 0;
     TreeSet<Integer> seriesIndSet = new TreeSet<Integer>();
-    for (Entry<String, Series> e : seriesMap.entrySet()) {
+    for (Entry<String, ? extends Series> e : seriesMap.entrySet()) {
       Series series = e.getValue();
       list2 = getObjectProperties(csp, series, "series[" + e.getKey() + "].", skipSet);
       list.addAll(list2);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartDemo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartDemo.java
@@ -33,7 +33,7 @@ public class XChartDemo extends JPanel implements TreeSelectionListener {
   private final JTree tree;
 
   /** The panel for chart */
-  protected XChartPanel chartPanel;
+  protected XChartPanel<?> chartPanel;
 
   Timer timer = new Timer();
 
@@ -57,7 +57,7 @@ public class XChartDemo extends JPanel implements TreeSelectionListener {
     JScrollPane treeView = new JScrollPane(tree);
 
     // Create Chart Panel
-    chartPanel = new XChartPanel(new AreaChart01().getChart());
+    chartPanel = new XChartPanel<>(new AreaChart01().getChart());
 
     // Add the scroll panes to a split pane.
     splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
@@ -86,9 +86,8 @@ public class XChartDemo extends JPanel implements TreeSelectionListener {
     if (node.isLeaf()) {
       ChartInfo chartInfo = (ChartInfo) nodeInfo;
       // displayURL(chartInfo.bookURL);
-      ExampleChart exampleChart = chartInfo.getExampleChart();
-      chartPanel = new XChartPanel(exampleChart.getChart());
-      exampleChart.customizePanel(chartPanel);
+      ExampleChart<?> exampleChart = chartInfo.getExampleChart();
+      updateChartPanel(exampleChart);
       splitPane.setBottomComponent(chartPanel);
 
       // start running a simulated data feed for the sample real-time plot
@@ -113,6 +112,16 @@ public class XChartDemo extends JPanel implements TreeSelectionListener {
     }
   }
 
+  private void updateChartPanel(ExampleChart<?> exampleChart) {
+    doUpdateChartPanel(exampleChart);
+  }
+
+  private <C extends Chart<?, ?>> void doUpdateChartPanel(ExampleChart<C> exampleChart) {
+    XChartPanel<C> panel = new XChartPanel<>(exampleChart.getChart());
+    exampleChart.customizePanel(panel);
+    chartPanel = panel;
+  }
+
   /**
    * Create the tree
    *
@@ -127,7 +136,7 @@ public class XChartDemo extends JPanel implements TreeSelectionListener {
 
     List<ExampleChart<Chart<Styler, Series>>> exampleList = DemoChartsUtil.getAllDemoCharts();
     String categoryName = "";
-    for (ExampleChart exampleChart : exampleList) {
+    for (ExampleChart<Chart<Styler, Series>> exampleChart : exampleList) {
       String name = exampleChart.getClass().getSimpleName();
       name = name.substring(0, name.indexOf("Chart"));
       if (!categoryName.equals(name)) {

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartStyleDemo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartStyleDemo.java
@@ -21,7 +21,7 @@ public class XChartStyleDemo extends XChartDemo {
 
   @Override
   public void valueChanged(TreeSelectionEvent e) {
-    XChartPanel oldChartPanel = chartPanel;
+    XChartPanel<?> oldChartPanel = chartPanel;
     super.valueChanged(e);
     if (chartPanel != oldChartPanel) {
       stylePanel.changeChart(chartPanel);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart07.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart07.java
@@ -10,7 +10,6 @@ import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
-import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.Styler.LegendPosition;
 
 /**

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart11.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart11.java
@@ -5,7 +5,6 @@ import java.awt.Font;
 import java.util.Random;
 import org.knowm.xchart.CategoryChart;
 import org.knowm.xchart.CategoryChartBuilder;
-import org.knowm.xchart.CategorySeries;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.demo.charts.ExampleChart;
 
@@ -72,10 +71,8 @@ public class BarChart11 implements ExampleChart<CategoryChart> {
     chart.getStyler().setLabelsRotation(45);
 
     // Series
-    CategorySeries series1 =
-        chart.addSeries("series1", getLinearValues(0, 200, 6), getRandomValues(10, 50, 6));
-    CategorySeries series2 =
-        chart.addSeries("series2", getLinearValues(0, 200, 6), getRandomValues(10, 50, 6));
+    chart.addSeries("series1", getLinearValues(0, 200, 6), getRandomValues(10, 50, 6));
+    chart.addSeries("series2", getLinearValues(0, 200, 6), getRandomValues(10, 50, 6));
 
     return chart;
   }

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart12.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart12.java
@@ -85,9 +85,9 @@ public class BarChart12 implements ExampleChart<CategoryChart> {
     }
 
     // Series
-    CategorySeries staked1 = chart.addSeries("Period 1", months, period1Values);
-    CategorySeries staked2 = chart.addSeries("Period 2", months, period2Values);
-    CategorySeries staked3 = chart.addSeries("Period 3", months, period3Values);
+    chart.addSeries("Period 1", months, period1Values);
+    chart.addSeries("Period 2", months, period2Values);
+    chart.addSeries("Period 3", months, period3Values);
     CategorySeries overlappedLine = chart.addSeries("Average", months, averageValues);
     overlappedLine.setOverlapped(true);
     overlappedLine.setChartCategorySeriesRenderStyle(CategorySeries.CategorySeriesRenderStyle.Line);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/dial/DialChart02.java
@@ -5,7 +5,6 @@ import java.awt.Color;
 import java.awt.Font;
 import org.knowm.xchart.DialChart;
 import org.knowm.xchart.DialChartBuilder;
-import org.knowm.xchart.DialSeries;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.ExampleChart;
@@ -46,7 +45,7 @@ public class DialChart02 implements ExampleChart<DialChart> {
             .build();
 
     // Series
-    DialSeries series = chart.addSeries("Rate", 0.55, "55 %");
+    chart.addSeries("Rate", 0.55, "55 %");
 
     chart.getStyler().setLegendVisible(true);
     chart.getStyler().setArcAngle(330);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart08.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/line/LineChart08.java
@@ -62,7 +62,7 @@ public class LineChart08 implements ExampleChart<XYChart> {
     // chart.getStyler().setXAxisLabelRotation(0);
 
     // Series
-    XYSeries series = chart.addSeries("10^x", xData, yData);
+    chart.addSeries("10^x", xData, yData);
 
     return chart;
   }

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart02.java
@@ -1,7 +1,6 @@
 package org.knowm.xchart.demo.charts.pie;
 
 import java.awt.Color;
-import java.util.Collection;
 import java.util.function.Function;
 import java.util.stream.Stream;
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/Example0.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/Example0.java
@@ -16,6 +16,6 @@ public class Example0 {
     XYChart chart = QuickChart.getChart("Sample Chart", "X", "Y", "y(x)", xData, yData);
 
     // Show it
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/JavaFXDemo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/JavaFXDemo.java
@@ -21,7 +21,7 @@ public class JavaFXDemo extends Application {
   public void start(Stage stage) {
 
     final SwingNode swingNode = new SwingNode();
-    JPanel chartPanel = new XChartPanel(new AreaChart01().getChart());
+    JPanel chartPanel = new XChartPanel<>(new AreaChart01().getChart());
     swingNode.setContent(chartPanel);
     Scene scene = new Scene(new StackPane(swingNode), 640, 480);
     stage.setScene(scene);

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/SwingDemo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/SwingDemo.java
@@ -20,7 +20,7 @@ public class SwingDemo {
     frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 
     // Add content to the window.
-    JPanel chartPanel = new XChartPanel(new AreaChart01().getChart());
+    JPanel chartPanel = new XChartPanel<>(new AreaChart01().getChart());
     frame.add(chartPanel);
 
     // Display the window.

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForExtremeEdgeCaseData.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForExtremeEdgeCaseData.java
@@ -1,6 +1,5 @@
 package org.knowm.xchart.standalone.issues;
 
-import java.io.IOException;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue1.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue1.java
@@ -5,16 +5,16 @@ import java.util.List;
 import org.knowm.xchart.BitmapEncoder;
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
 import org.knowm.xchart.XYChart;
-import org.knowm.xchart.internal.chartpart.Chart;
+
 
 /** Creates a list of Charts and saves it as a PNG file. */
 public class TestForIssue1 {
 
   public static void main(String[] args) throws Exception {
 
-    List<Chart> charts =
+    List<XYChart> charts =
         Arrays.asList(
-            new Chart[] {
+            new XYChart[] {
               createChart("chart1", new double[] {2.0, 1.0, 0.0}),
               createChart("chart2", new double[] {3.0, 4.0, 0.0}),
               createChart("chart3", new double[] {4.0, 1.5, 0.0}),

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue127.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue127.java
@@ -23,15 +23,15 @@ public class TestForIssue127 {
         new XYChartBuilder().width(640).height(480).xAxisTitle("x").yAxisTitle("y").build();
     chart.setTitle("TEst");
     chart.getStyler().setLegendVisible(false);
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
     Thread.sleep(1000);
 
     chart.addSeries("test", x, y);
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
     Thread.sleep(1000);
 
     chart.removeSeries("test");
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
     Thread.sleep(1000);
 
     DateFormat sdf = new SimpleDateFormat("dd-HH-mm");
@@ -45,7 +45,7 @@ public class TestForIssue127 {
     yDate.add(3d);
     yDate.add(5d);
     chart.addSeries("test2", xDate, yDate);
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
     Thread.sleep(1000);
   }
   public static XYChart getChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue205.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue205.java
@@ -12,7 +12,7 @@ public class TestForIssue205 {
 
   public static CategoryChart getChart() {
 
-    List<Double> myData = new ArrayList();
+    List<Double> myData = new ArrayList<>();
     myData.add(10.0);
     myData.add(20.0);
     myData.add(10.0);

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue244.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue244.java
@@ -5,8 +5,6 @@ import java.util.List;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
-import org.knowm.xchart.internal.chartpart.Chart;
-import org.knowm.xchart.internal.series.Series;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.Styler.YAxisPosition;
@@ -18,17 +16,16 @@ public class TestForIssue244 {
 
   public static void main(String[] args) {
 
-    List<Chart> charts = new ArrayList<Chart>();
+    List<XYChart> charts = new ArrayList<>();
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("Default axis");
       charts.add(chart);
     }
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("sin(x) on second axis");
-      Series series = (Series) chart.getSeriesMap().get("y=sin(x)");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("y=sin(x)").setYAxisGroup(1);
       chart.setYAxisGroupTitle(1, "sin(x) [-1, 1]");
       chart.setYAxisGroupTitle(0, "cos(x) [-10, 10]");
       chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Right);
@@ -36,30 +33,28 @@ public class TestForIssue244 {
     }
 
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("2 axis, default y max & y min");
-      Series series = (Series) chart.getSeriesMap().get("y=sin(x)");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("y=sin(x)").setYAxisGroup(1);
       chart.setYAxisGroupTitle(1, "sin(x) [-1, 1]");
       chart.setYAxisGroupTitle(0, "cos(x) [-10, 10]");
       chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Right);
 
-      AxesChartStyler styler = (AxesChartStyler) chart.getStyler();
+      AxesChartStyler styler = chart.getStyler();
       styler.setYAxisMax(20.0);
       styler.setYAxisMin(-20.0);
 
       charts.add(chart);
     }
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("2 axis, max on group 0");
-      Series series = (Series) chart.getSeriesMap().get("y=sin(x)");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("y=sin(x)").setYAxisGroup(1);
       chart.setYAxisGroupTitle(1, "sin(x) [-1, 1]");
       chart.setYAxisGroupTitle(0, "cos(x) [-10, 10]");
       chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Right);
 
-      AxesChartStyler styler = (AxesChartStyler) chart.getStyler();
+      AxesChartStyler styler = chart.getStyler();
       styler.setYAxisMax(0, 20.0);
       styler.setYAxisMin(0, -20.0);
 
@@ -67,15 +62,14 @@ public class TestForIssue244 {
     }
 
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("2 axis, max on group 0, 1");
-      Series series = (Series) chart.getSeriesMap().get("y=sin(x)");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("y=sin(x)").setYAxisGroup(1);
       chart.setYAxisGroupTitle(1, "sin(x) [-1, 1]");
       chart.setYAxisGroupTitle(0, "cos(x) [-10, 10]");
       chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Right);
 
-      AxesChartStyler styler = (AxesChartStyler) chart.getStyler();
+      AxesChartStyler styler = chart.getStyler();
       styler.setYAxisMax(0, 20.0);
       styler.setYAxisMin(0, -20.0);
       styler.setYAxisMax(1, 2.0);
@@ -85,15 +79,14 @@ public class TestForIssue244 {
     }
 
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("2 axis, max on group 0, 1, and default max");
-      Series series = (Series) chart.getSeriesMap().get("y=sin(x)");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("y=sin(x)").setYAxisGroup(1);
       chart.setYAxisGroupTitle(1, "sin(x) [-1, 1]");
       chart.setYAxisGroupTitle(0, "cos(x) [-10, 10]");
       chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Right);
 
-      AxesChartStyler styler = (AxesChartStyler) chart.getStyler();
+      AxesChartStyler styler = chart.getStyler();
       // these 2 lines will be overwritten by group max settings
       styler.setYAxisMax(100.0);
       styler.setYAxisMin(-100.0);
@@ -106,14 +99,14 @@ public class TestForIssue244 {
       charts.add(chart);
     }
 
-    SwingWrapper wrapper = new SwingWrapper(charts);
+    SwingWrapper<XYChart> wrapper = new SwingWrapper<>(charts);
     wrapper.displayChartMatrix();
     for (int i = 0; i < charts.size(); i++) {
       wrapper.getXChartPanel(i).setToolTipsEnabled(true);
     }
   }
 
-  static Chart getLineChart() {
+  static XYChart getLineChart() {
 
     XYChart chart =
         new XYChartBuilder().width(WIDTH).height(HEIGHT).xAxisTitle("X").yAxisTitle("Y").build();
@@ -142,7 +135,7 @@ public class TestForIssue244 {
   }
   public static XYChart getChart() {
 
-    return (XYChart) getLineChart();
+    return getLineChart();
   }
 
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue285.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue285.java
@@ -10,13 +10,13 @@ import org.knowm.xchart.demo.charts.line.LineChart01;
 import org.knowm.xchart.demo.charts.line.LineChart02;
 import org.knowm.xchart.demo.charts.pie.PieChart01;
 import org.knowm.xchart.demo.charts.pie.PieChart02;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.IChart;
 
 public class TestForIssue285 {
 
   public static void main(String[] args) throws IOException {
 
-    List<Chart<?, ?>> charts = new ArrayList<>();
+    List<IChart> charts = new ArrayList<>();
     charts.add(new AreaChart01().getChart());
     charts.add(new AreaChart02().getChart());
     charts.add(new LineChart01().getChart());

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue285.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue285.java
@@ -16,7 +16,7 @@ public class TestForIssue285 {
 
   public static void main(String[] args) throws IOException {
 
-    List<Chart> charts = new ArrayList<>();
+    List<Chart<?, ?>> charts = new ArrayList<>();
     charts.add(new AreaChart01().getChart());
     charts.add(new AreaChart02().getChart());
     charts.add(new LineChart01().getChart());

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue289.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue289.java
@@ -1,7 +1,6 @@
 package org.knowm.xchart.standalone.issues;
 
 import java.awt.Color;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.knowm.xchart.SwingWrapper;

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue315.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue315.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYSeries;
-import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.style.Styler.LegendPosition;
 
 public class TestForIssue315 {
@@ -32,7 +31,7 @@ public class TestForIssue315 {
 
   public static void main(String[] args) {
 
-    List<Chart> charts = new ArrayList<Chart>();
+    List<XYChart> charts = new ArrayList<>();
     boolean[] options = {true, false};
     for (boolean g0 : options) {
       for (boolean g1 : options) {
@@ -46,7 +45,7 @@ public class TestForIssue315 {
       }
     }
 
-    new SwingWrapper(charts).displayChartMatrix();
+    new SwingWrapper<>(charts).displayChartMatrix();
   }
   public static XYChart getChart() {
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue325.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue325.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
-import org.knowm.xchart.internal.chartpart.Chart;
 
 public class TestForIssue325 {
 
@@ -13,7 +12,7 @@ public class TestForIssue325 {
 
   public static void main(String[] args) {
 
-    List<Chart> charts = new ArrayList<>();
+    List<XYChart> charts = new ArrayList<>();
     int[] multiples = {1, 1000};
     int[] widths = {0, 15, 55};
     for (int m : multiples) {
@@ -24,7 +23,7 @@ public class TestForIssue325 {
       }
     }
 
-    new SwingWrapper(charts, charts.size() / widths.length, widths.length).displayChartMatrix();
+    new SwingWrapper<>(charts, charts.size() / widths.length, widths.length).displayChartMatrix();
 
     try {
       // wait frame to appear

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue349.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue349.java
@@ -16,7 +16,7 @@ public class TestForIssue349 implements ExampleChart<XYChart> {
 
     ExampleChart<XYChart> exampleChart = new TestForIssue349();
     XYChart chart = exampleChart.getChart();
-    XChartPanel chartPanel = new XChartPanel(chart);
+    XChartPanel<XYChart> chartPanel = new XChartPanel<>(chart);
     chartPanel.setZoomEnabled(true);
 
     // Create and set up the window.

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue390.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue390.java
@@ -16,10 +16,7 @@ public class TestForIssue390 {
 
     Random rand = new Random();
 
-    double min = 0;
-    double max = 20;
     int nbServices = 20;
-    int nbInstances = 50;
 
     long s = 24;
     rand.setSeed(s);

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue390.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue390.java
@@ -58,7 +58,7 @@ public class TestForIssue390 {
   public static void main(String[] args) throws IOException {
 
     XYChart chart = getChart();
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.PNG);
   }
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue545.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue545.java
@@ -4,7 +4,6 @@ import java.awt.Font;
 import java.text.ParseException;
 import org.knowm.xchart.BubbleChart;
 import org.knowm.xchart.BubbleChartBuilder;
-import org.knowm.xchart.BubbleSeries;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.style.BubbleStyler;
 import org.knowm.xchart.style.Styler;
@@ -31,9 +30,8 @@ public class TestForIssue545 {
             .yAxisTitle("Rate")
             .build();
     setBubbleStyler(chart);
-    BubbleSeries bubbleSeries =
-        chart.addSeries(
-            "serieName", new double[] {data[0]}, new double[] {data[1]}, new double[] {data[2]});
+    chart.addSeries(
+        "serieName", new double[] {data[0]}, new double[] {data[1]}, new double[] {data[2]});
     //    bubbleSeries.setCustomToolTips(true);
     //    String tooltip =
     //        new DecimalFormat("#%").format(data[1]) + " (" + ((int) data[2]) + "/" + ((int)

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_1.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_1.java
@@ -15,7 +15,6 @@ import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
 import org.knowm.xchart.internal.chartpart.Chart;
-import org.knowm.xchart.internal.series.Series;
 import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.Styler.LegendPosition;
@@ -28,23 +27,22 @@ public class TestForIssue54_1 {
 
   public static void main(String[] args) {
 
-    List<Chart> charts = new ArrayList<Chart>();
+    List<Chart<?, ?>> charts = new ArrayList<>();
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("Default axis");
       charts.add(chart);
     }
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("sin(x) on second axis with title");
-      Series series = (Series) chart.getSeriesMap().get("y=sin(x)");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("y=sin(x)").setYAxisGroup(1);
       chart.setYAxisGroupTitle(1, "sin(x)");
       charts.add(chart);
     }
 
     {
-      Chart chart = getAreaChart();
+      XYChart chart = getAreaChart();
       chart.setTitle("Default axis");
       charts.add(chart);
     }
@@ -56,57 +54,51 @@ public class TestForIssue54_1 {
     //      charts.add(chart);
     //    }
     {
-      Chart chart = getAreaChart();
+      XYChart chart = getAreaChart();
       chart.setTitle("all different axis, b & c axis on right");
-      Series series = (Series) chart.getSeriesMap().get("b");
-      series.setYAxisGroup(1);
-      series = (Series) chart.getSeriesMap().get("c");
-      series.setYAxisGroup(2);
+      chart.getSeriesMap().get("b").setYAxisGroup(1);
+      chart.getSeriesMap().get("c").setYAxisGroup(2);
       chart.getStyler().setYAxisGroupPosition(1, Styler.YAxisPosition.Right);
       chart.getStyler().setYAxisGroupPosition(2, Styler.YAxisPosition.Right);
       charts.add(chart);
     }
 
     {
-      Chart chart = getCaregoryChart();
+      CategoryChart chart = getCaregoryChart();
       chart.setTitle("Default axis");
       charts.add(chart);
     }
     {
-      Chart chart = getCaregoryChart();
+      CategoryChart chart = getCaregoryChart();
       chart.setTitle("b on second axis, b on right");
-      Series series = (Series) chart.getSeriesMap().get("b");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("b").setYAxisGroup(1);
       chart.getStyler().setYAxisGroupPosition(1, Styler.YAxisPosition.Right);
       charts.add(chart);
     }
 
     {
-      Chart chart = getCategoryLineChart();
+      CategoryChart chart = getCategoryLineChart();
       chart.setTitle("Default axis");
       charts.add(chart);
     }
     {
-      Chart chart = getCategoryLineChart();
+      CategoryChart chart = getCategoryLineChart();
       chart.setTitle("b&d on second axis");
-      Series series = (Series) chart.getSeriesMap().get("b");
-      series.setYAxisGroup(1);
-      series = (Series) chart.getSeriesMap().get("d");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("b").setYAxisGroup(1);
+      chart.getSeriesMap().get("d").setYAxisGroup(1);
       chart.getStyler().setYAxisGroupPosition(1, Styler.YAxisPosition.Right);
       charts.add(chart);
     }
 
     {
-      Chart chart = getBubleChart();
+      BubbleChart chart = getBubleChart();
       chart.setTitle("Default axis");
       charts.add(chart);
     }
     {
-      Chart chart = getBubleChart();
+      BubbleChart chart = getBubleChart();
       chart.setTitle("b on second axis");
-      Series series = (Series) chart.getSeriesMap().get("b");
-      series.setYAxisGroup(1);
+      chart.getSeriesMap().get("b").setYAxisGroup(1);
       charts.add(chart);
     }
 
@@ -114,20 +106,20 @@ public class TestForIssue54_1 {
     // charts.clear();
     // charts.add(chart);
     {
-      Chart chart = getLineChart();
+      XYChart chart = getLineChart();
       chart.setTitle("Default axis on right");
       chart.getStyler().setYAxisGroupPosition(0, Styler.YAxisPosition.Right);
       charts.add(chart);
     }
 
-    SwingWrapper wrapper = new SwingWrapper(charts);
+    SwingWrapper<Chart<?, ?>> wrapper = new SwingWrapper<>(charts);
     wrapper.displayChartMatrix();
     for (int i = 0; i < charts.size(); i++) {
       wrapper.getXChartPanel(i).setToolTipsEnabled(true);
     }
   }
 
-  static Chart getLineChart() {
+  static XYChart getLineChart() {
     XYChart chart =
         new XYChartBuilder().width(WIDTH).height(HEIGHT).xAxisTitle("X").yAxisTitle("Y").build();
 
@@ -154,7 +146,7 @@ public class TestForIssue54_1 {
     return chart;
   }
 
-  static Chart getAreaChart() {
+  static XYChart getAreaChart() {
 
     // Create Chart
     XYChart chart =
@@ -295,7 +287,7 @@ public class TestForIssue54_1 {
   }
   public static XYChart getChart() {
 
-    return (XYChart) getLineChart();
+    return getLineChart();
   }
 
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_2.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue54_2.java
@@ -5,8 +5,6 @@ import java.util.List;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
-import org.knowm.xchart.internal.chartpart.Chart;
-import org.knowm.xchart.internal.series.Series;
 import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.Styler.YAxisPosition;
 
@@ -18,20 +16,19 @@ public class TestForIssue54_2 {
 
   public static void main(String[] args) {
 
-    Chart chart = getLineChart();
+    XYChart chart = getLineChart();
     chart.setTitle("sin(x) on second axis with title");
-    Series series = (Series) chart.getSeriesMap().get("y=sin(x)");
-    series.setYAxisGroup(1);
+    chart.getSeriesMap().get("y=sin(x)").setYAxisGroup(1);
     chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Left);
     chart.getStyler().setYAxisGroupPosition(0, YAxisPosition.Right);
     chart.setYAxisGroupTitle(1, "sin(x)");
 
-    SwingWrapper sw = new SwingWrapper(chart);
+    SwingWrapper<XYChart> sw = new SwingWrapper<>(chart);
     sw.displayChart();
     sw.getXChartPanel().setToolTipsEnabled(true);
   }
 
-  static Chart getLineChart() {
+  static XYChart getLineChart() {
 
     XYChart chart =
         new XYChartBuilder().width(WIDTH).height(HEIGHT).xAxisTitle("X").yAxisTitle("Y").build();
@@ -60,7 +57,7 @@ public class TestForIssue54_2 {
   }
   public static XYChart getChart() {
 
-    return (XYChart) getLineChart();
+    return getLineChart();
   }
 
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue582.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue582.java
@@ -11,7 +11,7 @@ public class TestForIssue582 {
   public static void main(String[] args) throws ParseException {
 
     XYChart chart = getXYChart();
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 
   public static XYChart getXYChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue593.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue593.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
-import org.knowm.xchart.XYSeries;
 
 /**
  * Demonstrates the fix for issue #593 — cursor dataPointList memory leak in live XYCharts.

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue617.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue617.java
@@ -12,7 +12,7 @@ public class TestForIssue617 {
   public static void main(String[] args) throws ParseException {
 
     CategoryChart chart = getCategoryChart();
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 
   public static CategoryChart getCategoryChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue628.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue628.java
@@ -11,7 +11,7 @@ public class TestForIssue628 {
   public static void main(String[] args) throws ParseException {
 
     XYChart chart = getCategoryChart();
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 
   public static XYChart getCategoryChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue653.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue653.java
@@ -12,7 +12,7 @@ public class TestForIssue653 {
   public static void main(String[] args) throws ParseException {
 
     CategoryChart chart = getCategoryChart();
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 
   public static CategoryChart getCategoryChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue707.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue707.java
@@ -11,7 +11,7 @@ public class TestForIssue707 {
   public static void main(String[] args) throws ParseException {
 
     CategoryChart chart = getCategoryChart();
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 
   public static CategoryChart getCategoryChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue826.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue826.java
@@ -12,7 +12,7 @@ public class TestForIssue826 {
   public static void main(String[] args) throws ParseException {
 
     CategoryChart chart = getChart();
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 
   public static CategoryChart getChart() {

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue83.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue83.java
@@ -1,10 +1,9 @@
 package org.knowm.xchart.standalone.issues;
 
-import java.io.IOException;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
-import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.Styler.LegendPosition;
+import org.knowm.xchart.style.XYStyler;
 import org.knowm.xchart.style.lines.SeriesLines;
 
 public class TestForIssue83 {
@@ -13,7 +12,7 @@ public class TestForIssue83 {
 
 
     final XYChart chart = new XYChart(500, 580);
-    final Styler styleManager = chart.getStyler();
+    final XYStyler styleManager = chart.getStyler();
     styleManager.setLegendPosition(LegendPosition.InsideNW);
     styleManager.setLegendVisible(false);
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue98.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue98.java
@@ -1,6 +1,5 @@
 package org.knowm.xchart.standalone.issues;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import org.knowm.xchart.SwingWrapper;

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/readme/IntermediateExample.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/readme/IntermediateExample.java
@@ -39,7 +39,7 @@ public class IntermediateExample {
         chart.addSeries("Gaussian Blob 2", getGaussian(1000, 1, 10), getGaussian(1000, 0, 5));
     series.setMarker(SeriesMarkers.DIAMOND);
 
-    new SwingWrapper(chart).displayChart();
+    new SwingWrapper<>(chart).displayChart();
   }
 
   private static List<Double> getGaussian(int number, double mean, double std) {

--- a/xchart-site/src/main/java/org/knowm/xchart/site/GenerateSite.java
+++ b/xchart-site/src/main/java/org/knowm/xchart/site/GenerateSite.java
@@ -416,7 +416,6 @@ public class GenerateSite {
 
   // ── Package scanning ─────────────────────────────────────────────────────────
 
-  @SuppressWarnings("unchecked")
   private List<Class<?>> scanPackage(String packageName) throws Exception {
     List<Class<?>> classes = new ArrayList<>();
     String packagePath = packageName.replace('.', '/');

--- a/xchart/src/main/java/org/knowm/xchart/AnnotationImage.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationImage.java
@@ -28,7 +28,7 @@ public class AnnotationImage extends Annotation {
     this.y = y;
   }
 
-  public void init(Chart chart) {
+  public void init(Chart<?, ?> chart) {
 
     super.init(chart);
   }

--- a/xchart/src/main/java/org/knowm/xchart/AnnotationTextPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationTextPanel.java
@@ -39,7 +39,7 @@ public class AnnotationTextPanel extends Annotation {
     this.y = y;
   }
 
-  public void init(Chart chart) {
+  public void init(Chart<?, ?> chart) {
 
     super.init(chart);
   }

--- a/xchart/src/main/java/org/knowm/xchart/BitmapEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/BitmapEncoder.java
@@ -21,7 +21,7 @@ import javax.imageio.metadata.IIOInvalidTreeException;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.stream.FileImageOutputStream;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.IChart;
 
 /** A helper class with static methods for saving Charts as bitmaps */
 public final class BitmapEncoder {
@@ -62,8 +62,8 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @throws IOException
    */
-  public static <T extends Chart<?, ?>> void saveBitmap(
-      T chart, String fileName, BitmapFormat bitmapFormat) throws IOException {
+  public static void saveBitmap(
+      IChart chart, String fileName, BitmapFormat bitmapFormat) throws IOException {
 
     try (OutputStream out = new FileOutputStream(addFileExtension(fileName, bitmapFormat))) {
       saveBitmap(chart, out, bitmapFormat);
@@ -79,8 +79,8 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @throws IOException
    */
-  public static <T extends Chart<?, ?>> void saveBitmap(
-      T chart, OutputStream targetStream, BitmapFormat bitmapFormat) throws IOException {
+  public static void saveBitmap(
+      IChart chart, OutputStream targetStream, BitmapFormat bitmapFormat) throws IOException {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
     ImageIO.write(bufferedImage, bitmapFormat.toString().toLowerCase(), targetStream);
@@ -97,8 +97,8 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @throws IOException
    */
-  public static <T extends Chart<?, ?>> void saveBitmap(
-      List<T> charts,
+  public static void saveBitmap(
+      List<? extends IChart> charts,
       Integer rows,
       Integer cols,
       String fileName,
@@ -122,8 +122,8 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @throws IOException
    */
-  public static <T extends Chart<?, ?>> void saveBitmap(
-      List<T> charts,
+  public static void saveBitmap(
+      List<? extends IChart> charts,
       Integer rows,
       Integer cols,
       OutputStream targetStream,
@@ -131,7 +131,7 @@ public final class BitmapEncoder {
       throws IOException {
 
     List<BufferedImage> chartImages = new LinkedList<>();
-    for (T c : charts) chartImages.add(getBufferedImage(c));
+    for (IChart c : charts) chartImages.add(getBufferedImage(c));
 
     BufferedImage bufferedImage = mergeImages(chartImages, rows, cols);
     ImageIO.write(bufferedImage, bitmapFormat.toString().toLowerCase(), targetStream);
@@ -146,8 +146,8 @@ public final class BitmapEncoder {
    * @param DPI
    * @throws IOException
    */
-  public static <T extends Chart<?, ?>> void saveBitmapWithDPI(
-      T chart, String fileName, BitmapFormat bitmapFormat, int DPI) throws IOException {
+  public static void saveBitmapWithDPI(
+      IChart chart, String fileName, BitmapFormat bitmapFormat, int DPI) throws IOException {
 
     double scaleFactor = DPI / 72.0;
 
@@ -230,8 +230,8 @@ public final class BitmapEncoder {
    * @param quality - a float between 0 and 1 (1 = maximum quality)
    * @throws IOException
    */
-  public static <T extends Chart<?, ?>> void saveJPGWithQuality(
-      T chart, String fileName, float quality) throws IOException {
+  public static void saveJPGWithQuality(
+      IChart chart, String fileName, float quality) throws IOException {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
 
@@ -258,7 +258,7 @@ public final class BitmapEncoder {
    * @return a byte[] for a given chart
    * @throws IOException
    */
-  public static <T extends Chart<?, ?>> byte[] getBitmapBytes(T chart, BitmapFormat bitmapFormat)
+  public static byte[] getBitmapBytes(IChart chart, BitmapFormat bitmapFormat)
       throws IOException {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
@@ -273,7 +273,7 @@ public final class BitmapEncoder {
     return imageInBytes;
   }
 
-  public static <T extends Chart<?, ?>> BufferedImage getBufferedImage(T chart) {
+  public static BufferedImage getBufferedImage(IChart chart) {
 
     BufferedImage bufferedImage =
         new BufferedImage(chart.getWidth(), chart.getHeight(), BufferedImage.TYPE_INT_RGB);

--- a/xchart/src/main/java/org/knowm/xchart/PdfboxGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/PdfboxGraphicsEncoder.java
@@ -13,7 +13,7 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.IChart;
 
 /** A helper class with static methods for saving Charts as a PDF file */
 public class PdfboxGraphicsEncoder {
@@ -30,7 +30,7 @@ public class PdfboxGraphicsEncoder {
    * @param fileName file name path
    * @throws IOException
    */
-  public static void savePdfboxGraphics(Chart<?, ?> chart, String fileName) throws IOException {
+  public static void savePdfboxGraphics(IChart chart, String fileName) throws IOException {
 
     savePdfboxGraphics(chart, new File(addFileExtension(fileName)));
   }
@@ -42,7 +42,7 @@ public class PdfboxGraphicsEncoder {
    * @param file File
    * @throws IOException
    */
-  public static void savePdfboxGraphics(Chart<?, ?> chart, File file) throws IOException {
+  public static void savePdfboxGraphics(IChart chart, File file) throws IOException {
 
     savePdfboxGraphics(chart, new BufferedOutputStream(new FileOutputStream(file)));
   }
@@ -54,9 +54,9 @@ public class PdfboxGraphicsEncoder {
    * @param os OutputStream
    * @throws IOException
    */
-  public static void savePdfboxGraphics(Chart<?, ?> chart, OutputStream os) throws IOException {
+  public static void savePdfboxGraphics(IChart chart, OutputStream os) throws IOException {
 
-    List<Chart<?, ?>> charts = new ArrayList<>();
+    List<IChart> charts = new ArrayList<>();
     charts.add(chart);
     savePdfboxGraphics(charts, os);
   }
@@ -64,11 +64,11 @@ public class PdfboxGraphicsEncoder {
   /**
    * Write multiple charts to a file
    *
-   * @param charts List&lt;? extends Chart&lt;?, ?&gt;&gt;
+   * @param charts List&lt;? extends IChart&gt;
    * @param fileName file name path
    * @throws IOException
    */
-  public static void savePdfboxGraphics(List<? extends Chart<?, ?>> charts, String fileName)
+  public static void savePdfboxGraphics(List<? extends IChart> charts, String fileName)
       throws IOException {
 
     savePdfboxGraphics(charts, new File(addFileExtension(fileName)));
@@ -77,11 +77,11 @@ public class PdfboxGraphicsEncoder {
   /**
    * Write multiple charts to a file
    *
-   * @param charts List&lt;? extends Chart&lt;?, ?&gt;&gt;
+   * @param charts List&lt;? extends IChart&gt;
    * @param file File
    * @throws IOException
    */
-  public static void savePdfboxGraphics(List<? extends Chart<?, ?>> charts, File file)
+  public static void savePdfboxGraphics(List<? extends IChart> charts, File file)
       throws IOException {
 
     savePdfboxGraphics(charts, new BufferedOutputStream(new FileOutputStream(file)));
@@ -90,11 +90,11 @@ public class PdfboxGraphicsEncoder {
   /**
    * Write multiple charts to an OutputStream
    *
-   * @param charts List&lt;? extends Chart&lt;?, ?&gt;&gt;
+   * @param charts List&lt;? extends IChart&gt;
    * @param os OutputStream
    * @throws IOException
    */
-  public static void savePdfboxGraphics(List<? extends Chart<?, ?>> charts, OutputStream os)
+  public static void savePdfboxGraphics(List<? extends IChart> charts, OutputStream os)
       throws IOException {
 
     PDDocument document = new PDDocument();
@@ -103,7 +103,7 @@ public class PdfboxGraphicsEncoder {
     PDPageContentStream contentStream = null;
     PdfBoxGraphics2D pdfBoxGraphics2D = null;
     PDFormXObject xform = null;
-    for (Chart<?, ?> chart : charts) {
+    for (IChart chart : charts) {
       mediaBox = new PDRectangle(chart.getWidth(), chart.getHeight());
       page = new PDPage(mediaBox);
       // add page

--- a/xchart/src/main/java/org/knowm/xchart/PdfboxGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/PdfboxGraphicsEncoder.java
@@ -30,7 +30,7 @@ public class PdfboxGraphicsEncoder {
    * @param fileName file name path
    * @throws IOException
    */
-  public static void savePdfboxGraphics(Chart chart, String fileName) throws IOException {
+  public static void savePdfboxGraphics(Chart<?, ?> chart, String fileName) throws IOException {
 
     savePdfboxGraphics(chart, new File(addFileExtension(fileName)));
   }
@@ -42,7 +42,7 @@ public class PdfboxGraphicsEncoder {
    * @param file File
    * @throws IOException
    */
-  public static void savePdfboxGraphics(Chart chart, File file) throws IOException {
+  public static void savePdfboxGraphics(Chart<?, ?> chart, File file) throws IOException {
 
     savePdfboxGraphics(chart, new BufferedOutputStream(new FileOutputStream(file)));
   }
@@ -54,9 +54,9 @@ public class PdfboxGraphicsEncoder {
    * @param os OutputStream
    * @throws IOException
    */
-  public static void savePdfboxGraphics(Chart chart, OutputStream os) throws IOException {
+  public static void savePdfboxGraphics(Chart<?, ?> chart, OutputStream os) throws IOException {
 
-    List<Chart> charts = new ArrayList<>();
+    List<Chart<?, ?>> charts = new ArrayList<>();
     charts.add(chart);
     savePdfboxGraphics(charts, os);
   }
@@ -64,11 +64,11 @@ public class PdfboxGraphicsEncoder {
   /**
    * Write multiple charts to a file
    *
-   * @param charts List&lt;? extends Chart&gt;
+   * @param charts List&lt;? extends Chart&lt;?, ?&gt;&gt;
    * @param fileName file name path
    * @throws IOException
    */
-  public static void savePdfboxGraphics(List<? extends Chart> charts, String fileName)
+  public static void savePdfboxGraphics(List<? extends Chart<?, ?>> charts, String fileName)
       throws IOException {
 
     savePdfboxGraphics(charts, new File(addFileExtension(fileName)));
@@ -77,11 +77,11 @@ public class PdfboxGraphicsEncoder {
   /**
    * Write multiple charts to a file
    *
-   * @param charts List&lt;? extends Chart&gt;
+   * @param charts List&lt;? extends Chart&lt;?, ?&gt;&gt;
    * @param file File
    * @throws IOException
    */
-  public static void savePdfboxGraphics(List<? extends Chart> charts, File file)
+  public static void savePdfboxGraphics(List<? extends Chart<?, ?>> charts, File file)
       throws IOException {
 
     savePdfboxGraphics(charts, new BufferedOutputStream(new FileOutputStream(file)));
@@ -90,11 +90,11 @@ public class PdfboxGraphicsEncoder {
   /**
    * Write multiple charts to an OutputStream
    *
-   * @param charts List&lt;? extends Chart&gt;
+   * @param charts List&lt;? extends Chart&lt;?, ?&gt;&gt;
    * @param os OutputStream
    * @throws IOException
    */
-  public static void savePdfboxGraphics(List<? extends Chart> charts, OutputStream os)
+  public static void savePdfboxGraphics(List<? extends Chart<?, ?>> charts, OutputStream os)
       throws IOException {
 
     PDDocument document = new PDDocument();
@@ -103,7 +103,7 @@ public class PdfboxGraphicsEncoder {
     PDPageContentStream contentStream = null;
     PdfBoxGraphics2D pdfBoxGraphics2D = null;
     PDFormXObject xform = null;
-    for (Chart chart : charts) {
+    for (Chart<?, ?> chart : charts) {
       mediaBox = new PDRectangle(chart.getWidth(), chart.getHeight());
       page = new PDPage(mediaBox);
       // add page

--- a/xchart/src/main/java/org/knowm/xchart/SwingWrapper.java
+++ b/xchart/src/main/java/org/knowm/xchart/SwingWrapper.java
@@ -197,7 +197,7 @@ public class SwingWrapper<T extends Chart<?, ?>> {
    * @param isCentered
    * @return
    */
-  public SwingWrapper isCentered(boolean isCentered) {
+  public SwingWrapper<T> isCentered(boolean isCentered) {
     this.isCentered = isCentered;
     return this;
   }
@@ -208,7 +208,7 @@ public class SwingWrapper<T extends Chart<?, ?>> {
    * @param windowTitle
    * @return
    */
-  public SwingWrapper setTitle(String windowTitle) {
+  public SwingWrapper<T> setTitle(String windowTitle) {
     this.windowTitle = windowTitle;
     return this;
   }

--- a/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
@@ -20,7 +20,7 @@ public final class VectorGraphicsEncoder {
 
   /** Write a chart to a file. */
   public static void saveVectorGraphic(
-      Chart chart, String fileName, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
+      Chart<?, ?> chart, String fileName, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
     FileOutputStream file = new FileOutputStream(addFileExtension(fileName, vectorGraphicsFormat));
 
     try {
@@ -32,7 +32,7 @@ public final class VectorGraphicsEncoder {
 
   /** Write a chart to an OutputStream. */
   public static void saveVectorGraphic(
-      Chart chart, OutputStream os, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
+      Chart<?, ?> chart, OutputStream os, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
     final Processor p;
 
     switch (vectorGraphicsFormat) {
@@ -102,7 +102,7 @@ public final class VectorGraphicsEncoder {
       return null;
     }
 
-    public void savePdf(Chart chart, OutputStream os) throws IOException {
+    public void savePdf(Chart<?, ?> chart, OutputStream os) throws IOException {
 
       PdfboxGraphicsEncoder.savePdfboxGraphics(chart, os);
     }

--- a/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
@@ -10,7 +10,7 @@ import de.erichseifert.vectorgraphics2d.util.PageSize;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.IChart;
 
 /** A helper class with static methods for saving Charts as vectors */
 public final class VectorGraphicsEncoder {
@@ -20,7 +20,7 @@ public final class VectorGraphicsEncoder {
 
   /** Write a chart to a file. */
   public static void saveVectorGraphic(
-      Chart<?, ?> chart, String fileName, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
+      IChart chart, String fileName, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
     FileOutputStream file = new FileOutputStream(addFileExtension(fileName, vectorGraphicsFormat));
 
     try {
@@ -32,7 +32,7 @@ public final class VectorGraphicsEncoder {
 
   /** Write a chart to an OutputStream. */
   public static void saveVectorGraphic(
-      Chart<?, ?> chart, OutputStream os, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
+      IChart chart, OutputStream os, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
     final Processor p;
 
     switch (vectorGraphicsFormat) {
@@ -102,7 +102,7 @@ public final class VectorGraphicsEncoder {
       return null;
     }
 
-    public void savePdf(Chart<?, ?> chart, OutputStream os) throws IOException {
+    public void savePdf(IChart chart, OutputStream os) throws IOException {
 
       PdfboxGraphicsEncoder.savePdfboxGraphics(chart, os);
     }

--- a/xchart/src/main/java/org/knowm/xchart/internal/ChartBuilder.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/ChartBuilder.java
@@ -4,7 +4,7 @@ import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.style.Styler.ChartTheme;
 
 /** A "Builder" to make creating charts easier */
-public abstract class ChartBuilder<T extends ChartBuilder<?, ?>, C extends Chart> {
+public abstract class ChartBuilder<T extends ChartBuilder<?, ?>, C extends Chart<?, ?>> {
 
   public int width = 800;
   public int height = 600;
@@ -15,24 +15,28 @@ public abstract class ChartBuilder<T extends ChartBuilder<?, ?>, C extends Chart
   /** Constructor */
   protected ChartBuilder() {}
 
+  @SuppressWarnings("unchecked")
   public T width(int width) {
 
     this.width = width;
     return (T) this;
   }
 
+  @SuppressWarnings("unchecked")
   public T height(int height) {
 
     this.height = height;
     return (T) this;
   }
 
+  @SuppressWarnings("unchecked")
   public T title(String title) {
 
     this.title = title;
     return (T) this;
   }
 
+  @SuppressWarnings("unchecked")
   public T theme(ChartTheme chartTheme) {
 
     this.chartTheme = chartTheme;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Annotation.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Annotation.java
@@ -8,7 +8,7 @@ public abstract class Annotation implements ChartPart {
   protected boolean isVisible = true;
   protected boolean isValueInScreenSpace;
 
-  protected Chart chart;
+  protected Chart<?, ?> chart;
   protected Styler styler;
   protected Rectangle2D bounds;
 
@@ -16,7 +16,7 @@ public abstract class Annotation implements ChartPart {
     this.isValueInScreenSpace = isValueInScreenSpace;
   }
 
-  public void init(Chart chart) {
+  public void init(Chart<?, ?> chart) {
 
     this.chart = chart;
     this.styler = chart.getStyler();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -73,9 +73,7 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
     groupPainter.wireRelationships();
 
     // Left side
-    double leftStart =
-        groupPainter.paintLeft(
-            g, chartPadding, leftYAxisBounds, styler.getYAxisLeftWidthHint());
+    groupPainter.paintLeft(g, chartPadding, leftYAxisBounds, styler.getYAxisLeftWidthHint());
 
     // Right side
     double legendWidth = 0;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_.java
@@ -311,7 +311,6 @@ public abstract class AxisTickCalculator_ implements AxisTickCalculator {
         // This happens when the data values are almost the same but differ by a very tiny amount.
         // The solution for now is to create a single axis label and tick at the average value
         tickLabels.add(getAxisFormat().format(BigDecimal.valueOf((maxValue + minValue) / 2.0)));
-        double averageValue = (maxValue + minValue) / 2.0;
         tickLocations.add(workingSpace / 2.0);
         return;
       } else if (firstPositionAsDouble == Double.NEGATIVE_INFINITY) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTitle.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTitle.java
@@ -25,7 +25,7 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
    * @param chart the Chart
    * @param direction the Direction
    */
-  AxisTitle(Chart<ST, S> chart, Direction direction, Axis_ yAxis, int yIndex) {
+  AxisTitle(Chart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis, int yIndex) {
 
     this.chart = chart;
     this.direction = direction;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_.java
@@ -193,7 +193,7 @@ public abstract class Axis_<ST extends AxesChartStyler, S extends AxesChartSerie
    * Returns the (possibly empty) list of colocated slave axes registered on this master.
    * Non-Y axes always return an empty list.
    */
-  public List<? extends Axis_> getColocatedSlaves() {
+  public List<? extends Axis_<?, ?>> getColocatedSlaves() {
 
     return java.util.Collections.emptyList();
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
@@ -8,7 +8,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -27,7 +27,7 @@ public abstract class Chart<ST extends Styler, S extends Series> {
   /** Chart Parts */
   // TODO maybe move this to a secondary abstract class for inheritors with axes. Pie charts don't
   // have an axis for example
-  protected AxisPair axisPair;
+  protected AxisPair<?, ?> axisPair;
 
   protected Plot_<ST, S> plot;
   protected Legend_<ST, S> legend;
@@ -202,22 +202,22 @@ public abstract class Chart<ST extends Styler, S extends Series> {
     return plot;
   }
 
-  Axis_X getXAxis() {
+  Axis_X<?, ?> getXAxis() {
 
     return axisPair.getXAxis();
   }
 
-  Axis_Y getYAxis() {
+  Axis_Y<?, ?> getYAxis() {
 
     return axisPair.getYAxis();
   }
 
-  Axis_Y getYAxis(int yIndex) {
+  Axis_Y<?, ?> getYAxis(int yIndex) {
 
     return axisPair.getYAxis(yIndex);
   }
 
-  AxisPair getAxisPair() {
+  AxisPair<?, ?> getAxisPair() {
 
     return axisPair;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -17,7 +17,7 @@ import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.Styler;
 
 /** An XChart Chart */
-public abstract class Chart<ST extends Styler, S extends Series> {
+public abstract class Chart<ST extends Styler, S extends Series> implements IChart {
 
   protected final ST styler;
   protected final ChartTitle<ST, S> chartTitle;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ColocatedSlaveLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ColocatedSlaveLabels.java
@@ -79,7 +79,7 @@ class ColocatedSlaveLabels {
       double maxTickLabelWidth,
       Map<Double, TextLayout> masterLayouts) {
 
-    List<? extends Axis_> colocatedSlaves = yAxis.getColocatedSlaves();
+    List<? extends Axis_<?, ?>> colocatedSlaves = yAxis.getColocatedSlaves();
     if (colocatedSlaves.isEmpty()) {
       return;
     }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Cursor.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Cursor.java
@@ -29,7 +29,7 @@ public class Cursor extends MouseAdapter implements ChartPart {
   private final List<DataPoint> dataPointList = new ArrayList<>();
   private final List<DataPoint> matchingDataPointList = new ArrayList<>();
 
-  private final Chart chart;
+  private final Chart<?, ?> chart;
   private final XYStyler styler;
 
   private final Map<String, Series> seriesMap;
@@ -47,7 +47,7 @@ public class Cursor extends MouseAdapter implements ChartPart {
    *
    * @param chart
    */
-  public Cursor(Chart chart) {
+  public Cursor(Chart<?, ?> chart) {
 
     this.chart = chart;
     this.styler = (XYStyler) chart.getStyler();
@@ -55,7 +55,9 @@ public class Cursor extends MouseAdapter implements ChartPart {
     // clear lists
     dataPointList.clear();
 
-    this.seriesMap = chart.getSeriesMap();
+    @SuppressWarnings("unchecked")
+    Map<String, Series> tmp = (Map<String, Series>) (Map<?, ?>) chart.getSeriesMap();
+    this.seriesMap = tmp;
   }
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Cursor.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Cursor.java
@@ -29,7 +29,6 @@ public class Cursor extends MouseAdapter implements ChartPart {
   private final List<DataPoint> dataPointList = new ArrayList<>();
   private final List<DataPoint> matchingDataPointList = new ArrayList<>();
 
-  private final Chart<?, ?> chart;
   private final XYStyler styler;
 
   private final Map<String, Series> seriesMap;
@@ -49,7 +48,6 @@ public class Cursor extends MouseAdapter implements ChartPart {
    */
   public Cursor(Chart<?, ?> chart) {
 
-    this.chart = chart;
     this.styler = (XYStyler) chart.getStyler();
 
     // clear lists

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/IChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/IChart.java
@@ -1,0 +1,19 @@
+package org.knowm.xchart.internal.chartpart;
+
+import java.awt.Graphics2D;
+
+/**
+ * Minimal rendering contract for all XChart chart types. Use this type (instead of the generic
+ * {@code Chart<?,?>}) whenever code only needs to paint a chart or query its dimensions/title —
+ * e.g. bitmap/vector/PDF encoders.
+ */
+public interface IChart {
+
+  void paint(Graphics2D g, int width, int height);
+
+  int getWidth();
+
+  int getHeight();
+
+  String getTitle();
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_HorizontalBar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_HorizontalBar.java
@@ -10,8 +10,6 @@ import org.knowm.xchart.style.Styler;
 public class Legend_HorizontalBar<ST extends Styler, S extends HorizontalBarSeries>
     extends Legend_<ST, S> {
 
-  private final ST axesChartStyler;
-
   /**
    * Constructor
    *
@@ -20,7 +18,6 @@ public class Legend_HorizontalBar<ST extends Styler, S extends HorizontalBarSeri
   public Legend_HorizontalBar(Chart<ST, S> chart) {
 
     super(chart);
-    axesChartStyler = chart.getStyler();
   }
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -328,7 +328,4 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
       }
     }
   }
-
-  // line chart drawing logic
-  private void paintLine(Graphics2D g, S series) {}
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -55,7 +55,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
       if (!series.isEnabled()) {
         continue;
       }
-      Axis_Y yAxis = chart.getYAxis(series.getYAxisGroup());
+      Axis_Y<?, ?> yAxis = chart.getYAxis(series.getYAxisGroup());
       double yMin = yAxis.getMin();
       double yMax = yAxis.getMax();
       if (xyStyler.isYAxisLogarithmic()) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
@@ -27,7 +27,6 @@ public class ToolTips extends MouseAdapter implements ChartPart {
   private static final int MARGIN = 5;
   private static final int MOUSE_MARGIN = 20;
 
-  private final Chart<?, ?> chart;
   private final Styler styler;
   private final boolean alwaysVisible;
   private final ToolTipType toolTipType;
@@ -46,7 +45,6 @@ public class ToolTips extends MouseAdapter implements ChartPart {
    */
   public ToolTips(Chart<?, ?> chart, boolean alwaysVisible, ToolTipType toolTipType) {
 
-    this.chart = chart;
     this.styler = chart.getStyler();
     this.alwaysVisible = alwaysVisible;
     this.toolTipType = toolTipType;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
@@ -27,7 +27,7 @@ public class ToolTips extends MouseAdapter implements ChartPart {
   private static final int MARGIN = 5;
   private static final int MOUSE_MARGIN = 20;
 
-  private final Chart chart;
+  private final Chart<?, ?> chart;
   private final Styler styler;
   private final boolean alwaysVisible;
   private final ToolTipType toolTipType;
@@ -44,7 +44,7 @@ public class ToolTips extends MouseAdapter implements ChartPart {
    * @param alwaysVisible
    * @param toolTipType
    */
-  public ToolTips(Chart chart, boolean alwaysVisible, ToolTipType toolTipType) {
+  public ToolTips(Chart<?, ?> chart, boolean alwaysVisible, ToolTipType toolTipType) {
 
     this.chart = chart;
     this.styler = chart.getStyler();

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/Trapezoid.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/Trapezoid.java
@@ -6,7 +6,6 @@ public class Trapezoid extends Marker {
   @Override
   public void paint(Graphics2D g, double xOffset, double yOffset, int markerSize) {
     g.setStroke(stroke);
-    double halfSize = (double) markerSize / 2;
     Polygon polygon = new Polygon();
 
     for (int i = 1; i <= 4; i++) {

--- a/xchart/src/main/java/org/knowm/xchart/style/theme/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/theme/Theme.java
@@ -4,7 +4,6 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Font;
 import org.knowm.xchart.style.PieStyler.LabelType;
-import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.colors.ChartColor;
 import org.knowm.xchart.style.colors.SeriesColors;

--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue536Test.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue536Test.java
@@ -73,7 +73,7 @@ public class RegressionIssue536Test {
     XYSeries xyseries = chart.addSeries(series, x, y);
     xyseries.setMarker(SeriesMarkers.NONE);
     xyseries.setYAxisGroup(1);
-    byte[] bytes = BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
 
     List<String> tickLabels = chart.axisPair.getXAxis().getAxisTickCalculator().getTickLabels();
 

--- a/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue536.java
+++ b/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue536.java
@@ -25,6 +25,6 @@ public class RegressionTestIssue536 {
     XYSeries series = chart.addSeries("Series", times, values);
     series.setMarker(SeriesMarkers.NONE);
 
-    byte[] bytes = BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
   }
 }


### PR DESCRIPTION
## Motivation

The codebase had accumulated a significant number of IDE warnings: raw generic types, unused variables/fields, unused imports, and dead code. These add noise to the IDE, make it harder to spot real issues, and signal areas where the type system isn't being used to its full potential.

## What changed

**Core library (`xchart/src/`)**

- Introduced `IChart` -- a non-generic rendering interface (`paint`, `getWidth`, `getHeight`, `getTitle`) implemented by `Chart<ST,S>`. This eliminates the need for `Chart<?,?>` wildcards throughout the encoder APIs (`BitmapEncoder`, `VectorGraphicsEncoder`, `PdfboxGraphicsEncoder`), which now accept `IChart` / `List<? extends IChart>`.
- Fixed all raw type usages in the core: `Chart`, `AxisPair`, `Annotation`, `ChartBuilder`, `ColocatedSlaveLabels`, `PlotContent_XY`, `Axis_` -- all now properly parameterized with `<?,?>` or specific bounds.
- Removed unused fields: `Cursor.chart`, `ToolTips.chart`, `Legend_HorizontalBar.axesChartStyler`.
- Removed unused local variables: `AxisPair.leftStart`, `AxisTickCalculator_.averageValue`, `Trapezoid.halfSize`.
- Removed unused import in `Theme.java` and dead empty method in `PlotContent_OHLC`.
- Fixed unused variable assignments in `RegressionIssue536Test`.

**Demo (`xchart-demo/src/`)**

- Added diamond operator `<>` to all raw `SwingWrapper` constructor calls (15 sites) and typed variable declarations.
- Parameterized all raw `JComboBox`, `Class`, `Constructor`, and `HashMap` usages in `ChartStylePanel`.
- Parameterized raw `XChartPanel` field and method params in `ChartStylePanel` and `XChartStyleDemo`.
- Fixed `TestForIssue1`: `List<Chart>` -> `List<XYChart>`.
- Removed unused local variable assignments (series return values that were never read) across `BarChart11`, `BarChart12`, `DialChart02`, `LineChart08`, `TestForIssue390`, `TestForIssue545`.
- Removed unused imports across several standalone test files.

**Site (`xchart-site/src/`)**

- Removed a now-unnecessary `@SuppressWarnings("unchecked")` in `GenerateSite`.

## Notes

- `XChartPanel<T extends Chart<?,?>>` and `SwingWrapper<T extends Chart<?,?>>` deliberately retain their typed bounds -- they call `getStyler()`, `enableInteractionData()`, etc., which require the full `Chart` API rather than just `IChart`.
- No behavior changes; this is purely a compiler/IDE hygiene pass. All 44 xchart unit tests pass and the full `mvn clean verify` build is green.