### PR TITLE
Fix #686: truncate long legend series names with ellipsis

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue686.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue686.java
@@ -1,0 +1,38 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Arrays;
+import java.util.List;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+
+/**
+ * Demonstrates that a very long series name is truncated in the legend rather than breaking the
+ * chart layout.
+ *
+ * @see <a href="https://github.com/knowm/XChart/issues/686">Issue #686</a>
+ */
+public class TestForIssue686 {
+
+  public static void main(String[] args) {
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  public static XYChart getChart() {
+    XYChart chart =
+        new XYChartBuilder()
+            .width(600)
+            .height(400)
+            .title("Issue 686 - Long Series Name")
+            .build();
+
+    List<Double> xData = Arrays.asList(1.0, 2.0, 3.0, 4.0, 5.0);
+    List<Double> yData = Arrays.asList(2.0, 4.0, 3.0, 5.0, 4.0);
+
+    String veryLongName =
+        "This is an extremely long series name that used to break the chart layout by pushing the plot area to zero width";
+    chart.addSeries(veryLongName, xData, yData);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_.java
@@ -17,6 +17,7 @@ public abstract class Legend_<ST extends Styler, S extends Series> implements Ch
   static final int BOX_OUTLINE_WIDTH = 5;
   private static final int LEGEND_MARGIN = 6;
   private static final int MULTI_LINE_SPACE = 3;
+  private static final double MAX_LEGEND_TEXT_WIDTH_RATIO = 0.45;
   final Chart<ST, S> chart;
   double xOffset = 0;
   double yOffset = 0;
@@ -290,22 +291,22 @@ public abstract class Legend_<ST extends Styler, S extends Series> implements Ch
     // FontMetrics fontMetrics = g.getFontMetrics(getChartPainter().getstyler().getLegendFont());
     // float fontDescent = fontMetrics.getDescent();
 
+    double maxTextWidth = chart.getWidth() * MAX_LEGEND_TEXT_WIDTH_RATIO;
+    FontRenderContext frc = new FontRenderContext(null, true, false);
     String lines[] = series.getLabel().split("\\n");
     Map<String, Rectangle2D> seriesTextBounds =
         new LinkedHashMap<String, Rectangle2D>(lines.length);
     for (String line : lines) {
       TextLayout textLayout =
-          new TextLayout(
-              line, chart.getStyler().getLegendFont(), new FontRenderContext(null, true, false));
+          new TextLayout(line, chart.getStyler().getLegendFont(), frc);
       Shape shape = textLayout.getOutline(null);
       Rectangle2D bounds = shape.getBounds2D();
-      // System.out.println(tl.getAscent());
-      // System.out.println(tl.getDescent());
-      // System.out.println(tl.getBounds());
-      // seriesTextBounds.put(line, new Rectangle2D.Double(bounds.getX(), bounds.getY(),
-      // bounds.getWidth(), bounds.getHeight() - tl.getDescent()));
-      // seriesTextBounds.put(line, new Rectangle2D.Double(bounds.getX(), bounds.getY(),
-      // bounds.getWidth(), tl.getAscent()));
+      if (bounds.getWidth() > maxTextWidth) {
+        line = truncateLabel(line, frc, maxTextWidth);
+        textLayout = new TextLayout(line, chart.getStyler().getLegendFont(), frc);
+        shape = textLayout.getOutline(null);
+        bounds = shape.getBounds2D();
+      }
       seriesTextBounds.put(line, bounds);
     }
     return seriesTextBounds;
@@ -380,5 +381,20 @@ public abstract class Legend_<ST extends Styler, S extends Series> implements Ch
       return getBoundsHintHorizontal(); // Actually, the only information contained in this bounds
       // is the width and height.
     }
+  }
+
+  private String truncateLabel(String text, FontRenderContext frc, double maxWidth) {
+    String ellipsis = "…";
+    StringBuilder sb = new StringBuilder(text);
+    while (sb.length() > 0) {
+      TextLayout tl =
+          new TextLayout(
+              sb.toString() + ellipsis, chart.getStyler().getLegendFont(), frc);
+      if (tl.getOutline(null).getBounds2D().getWidth() <= maxWidth) {
+        return sb.toString() + ellipsis;
+      }
+      sb.deleteCharAt(sb.length() - 1);
+    }
+    return ellipsis;
   }
 }


### PR DESCRIPTION
## Problem
When a series name is very long, the legend width grows to exceed the chart width, pushing the plot area to zero (or negative) width. The chart content disappears entirely — both in the Swing display and in exported bitmaps.

## Fix
In `Legend_.java`, `getSeriesTextBounds()` now computes a max text width of 45% of the chart width. If a label line exceeds that, a new `truncateLabel()` helper trims characters from the right and appends `…` until it fits.

## Demo
`TestForIssue686.java` in `standalone/issues/` shows a series with a very long name rendered correctly with a truncated legend entry.

Fixes #686