### PR TITLE
Implement #467: smooth curved lines for CategoryChart

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue467.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue467.java
@@ -29,9 +29,13 @@ public class TestForIssue467 {
             .yAxisTitle("Value")
             .build();
 
+    chart.getStyler().setOverlapped(true);
+    chart.getStyler().setAvailableSpaceFill(0.4);
+
     List<String> xData = Arrays.asList("Jan", "Feb", "Mar", "Apr", "May", "Jun");
     List<Integer> yData1 = Arrays.asList(4, 7, 3, 8, 5, 9);
     List<Integer> yData2 = Arrays.asList(2, 5, 6, 3, 7, 4);
+    List<Integer> yData3 = Arrays.asList(1, 3, 5, 2, 4, 6);
 
     CategorySeries series1 = chart.addSeries("Smooth", xData, yData1);
     series1.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
@@ -40,6 +44,9 @@ public class TestForIssue467 {
     CategorySeries series2 = chart.addSeries("Normal", xData, yData2);
     series2.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
     series2.setSmooth(false);
+
+    CategorySeries series3 = chart.addSeries("Bar", xData, yData3);
+    series3.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Bar);
 
     return chart;
   }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue467.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue467.java
@@ -1,0 +1,46 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Arrays;
+import java.util.List;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.SwingWrapper;
+
+/**
+ * Demonstrates smooth curved lines in a CategoryChart (string X-axis labels).
+ *
+ * @see <a href="https://github.com/knowm/XChart/issues/467">Issue #467</a>
+ */
+public class TestForIssue467 {
+
+  public static void main(String[] args) {
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  public static CategoryChart getChart() {
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Issue 467 - Smooth Lines in CategoryChart")
+            .xAxisTitle("Month")
+            .yAxisTitle("Value")
+            .build();
+
+    List<String> xData = Arrays.asList("Jan", "Feb", "Mar", "Apr", "May", "Jun");
+    List<Integer> yData1 = Arrays.asList(4, 7, 3, 8, 5, 9);
+    List<Integer> yData2 = Arrays.asList(2, 5, 6, 3, 7, 4);
+
+    CategorySeries series1 = chart.addSeries("Smooth", xData, yData1);
+    series1.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
+    series1.setSmooth(true);
+
+    CategorySeries series2 = chart.addSeries("Normal", xData, yData2);
+    series2.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
+    series2.setSmooth(false);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
@@ -13,6 +13,9 @@ public class CategorySeries extends AxesChartSeriesCategory {
 
   private CategorySeriesRenderStyle chartCategorySeriesRenderStyle = null;
 
+  // smooth curve
+  private boolean smooth;
+
   /**
    * Constructor
    *
@@ -50,6 +53,22 @@ public class CategorySeries extends AxesChartSeriesCategory {
 
   public CategorySeries setOverlapped(boolean overlapped) {
     isOverlapped = overlapped;
+    return this;
+  }
+
+  public boolean isSmooth() {
+
+    return smooth;
+  }
+
+  /**
+   * Sets whether the line/area series should be rendered with smooth cubic Bezier curves.
+   *
+   * @param smooth true for smooth curves, false for straight lines
+   */
+  public CategorySeries setSmooth(boolean smooth) {
+
+    this.smooth = smooth;
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -93,6 +93,9 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
       double previousX = -Double.MAX_VALUE;
       double previousY = -Double.MAX_VALUE;
 
+      // smooth curve path for Line render style
+      Path2D.Double smoothPath = null;
+
       Iterator<?> xItr = series.getXData().iterator();
       Iterator<? extends Number> yItr = series.getYData().iterator();
       Iterator<? extends Number> ebItr = null;
@@ -113,6 +116,12 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
         // skip when a value is null
         if (next == null) {
 
+          if (smoothPath != null) {
+            g.setColor(series.getLineColor());
+            g.setStroke(series.getLineStyle());
+            g.draw(smoothPath);
+            smoothPath = null;
+          }
           //          // for area charts
           //          closePath(g, path, previousX, getBounds(), yTopMargin);
           //          path = null;
@@ -398,9 +407,23 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
               if (previousX != -Double.MAX_VALUE && previousY != -Double.MAX_VALUE) {
                 g.setColor(series.getLineColor());
                 g.setStroke(series.getLineStyle());
-                Shape line =
-                    new Line2D.Double(previousX, previousY, xOffset + barWidth / 2, yOffset);
-                g.draw(line);
+                if (series.isSmooth()) {
+                  if (smoothPath == null) {
+                    smoothPath = new Path2D.Double();
+                    smoothPath.moveTo(previousX, previousY);
+                  }
+                  smoothPath.curveTo(
+                      (previousX + xOffset + barWidth / 2) / 2,
+                      previousY,
+                      (previousX + xOffset + barWidth / 2) / 2,
+                      yOffset,
+                      xOffset + barWidth / 2,
+                      yOffset);
+                } else {
+                  Shape line =
+                      new Line2D.Double(previousX, previousY, xOffset + barWidth / 2, yOffset);
+                  g.draw(line);
+                }
               }
             }
           }
@@ -418,7 +441,17 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
                 path.moveTo(previousX, yBottomOfArea);
                 path.lineTo(previousX, previousY);
               }
-              path.lineTo(xOffset + barWidth / 2, yOffset);
+              if (series.isSmooth()) {
+                path.curveTo(
+                    (previousX + xOffset + barWidth / 2) / 2,
+                    previousY,
+                    (previousX + xOffset + barWidth / 2) / 2,
+                    yOffset,
+                    xOffset + barWidth / 2,
+                    yOffset);
+              } else {
+                path.lineTo(xOffset + barWidth / 2, yOffset);
+              }
             }
             if (xOffset < previousX) {
               throw new RuntimeException("X-Data must be in ascending order for Area Charts!!!");
@@ -502,6 +535,14 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
               chart.getXAxisFormat().format(nextCat),
               chart.getYAxisFormat().format(yOrig));
         }
+      }
+
+      // flush smooth path for line series
+      if (smoothPath != null) {
+        g.setColor(series.getLineColor());
+        g.setStroke(series.getLineStyle());
+        g.draw(smoothPath);
+        smoothPath = null;
       }
 
       // close any open path for area charts


### PR DESCRIPTION
## Feature
Adds `setSmooth(true)` support to `CategorySeries`, enabling smooth cubic Bezier curves for `Line` and `Area` render styles in `CategoryChart` — the same behaviour already available in `XYChart`.

## Changes
- `CategorySeries`: added `smooth` field with `isSmooth()` / `setSmooth()` 
- `PlotContent_Category_Bar`: Line and Area paths use `curveTo` when `isSmooth()` is true, falling back to straight lines otherwise
- `TestForIssue467`: demo with two series — one smooth, one normal — over string X-axis labels

Closes #467