### PR TITLE
Fix BoxChart crashes with empty/single-value data (issues #890, #891)

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue890.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue890.java
@@ -1,0 +1,34 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Arrays;
+import org.knowm.xchart.BoxChart;
+import org.knowm.xchart.BoxChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+
+/**
+ * Reproducer for https://github.com/knowm/XChart/issues/890
+ *
+ * <p>Box chart gets stuck when only one yData value is provided.
+ */
+public class TestForIssue890 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static BoxChart getChart() {
+
+    BoxChart chart =
+        new BoxChartBuilder()
+            .title("Box plot – single data point (issue 890)")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .build();
+
+    chart.addSeries("test", Arrays.asList(1));
+
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue891.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue891.java
@@ -17,6 +17,7 @@ public class TestForIssue891 {
 
   public static void main(String[] args) {
 
+    demonstrateValidation();
     new SwingWrapper<>(getChart()).displayChart();
   }
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue891.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue891.java
@@ -1,0 +1,57 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.knowm.xchart.BoxChart;
+import org.knowm.xchart.BoxChartBuilder;
+import org.knowm.xchart.BoxSeries;
+import org.knowm.xchart.SwingWrapper;
+
+/**
+ * Reproducer for https://github.com/knowm/XChart/issues/891
+ *
+ * <p>Updating a BoxChart by setting the BoxSeries data to an empty list causes an
+ * IndexOutOfBoundsException.
+ */
+public class TestForIssue891 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static BoxChart getChart() {
+
+    BoxChart chart =
+        new BoxChartBuilder()
+            .title("Box plot – replace with valid data (issue 891)")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .build();
+
+    BoxSeries boxSeries = chart.addSeries("test", Arrays.asList(1, 2, 3));
+    // Replacing with valid data should work fine
+    boxSeries.replaceData(Arrays.asList(4, 5, 6));
+
+    return chart;
+  }
+
+  /**
+   * Demonstrates that replacing with empty data throws an IllegalArgumentException rather than an
+   * IndexOutOfBoundsException.
+   */
+  public static void demonstrateValidation() {
+
+    BoxChart chart =
+        new BoxChartBuilder().title("validation demo").xAxisTitle("X").yAxisTitle("Y").build();
+
+    BoxSeries boxSeries = chart.addSeries("test", Arrays.asList(1, 2));
+    try {
+      boxSeries.replaceData(Collections.emptyList());
+      System.out.println("ERROR: expected IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      System.out.println("OK: caught expected exception: " + e.getMessage());
+    }
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/BoxSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/BoxSeries.java
@@ -21,4 +21,24 @@ public class BoxSeries extends AxesChartSeriesCategory {
 
     return null;
   }
+
+  /**
+   * Replace the Y data for this box series, with validation.
+   *
+   * @param newYData the new Y data; must be non-null, non-empty, and contain no null values
+   */
+  @Override
+  public void replaceData(List<? extends Number> newYData) {
+
+    if (newYData == null) {
+      throw new IllegalArgumentException("Y-Axis data cannot be null !!!");
+    }
+    if (newYData.isEmpty()) {
+      throw new IllegalArgumentException("Y-Axis data cannot be empty !!!");
+    }
+    if (newYData.contains(null)) {
+      throw new IllegalArgumentException("Y-Axis data cannot contain null !!!");
+    }
+    super.replaceData(newYData);
+  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/BoxPlotDataCalculator.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/BoxPlotDataCalculator.java
@@ -44,6 +44,10 @@ public class BoxPlotDataCalculator<ST extends AxesChartStyler, S extends AxesCha
         }
       }
 
+      if (data.isEmpty()) {
+        boxPlotDataList.add(null);
+        continue;
+      }
       Collections.sort(data);
       boxPlotData = calculate(data, boxPlotStyler);
       boxPlotDataList.add(boxPlotData);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
@@ -57,6 +57,12 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
       }
       boxPlotCounter++;
       boxPlotData = boxPlotDataList.get(boxPlotCounter);
+
+      // skip series with no usable data (e.g. all nulls or empty after filtering)
+      if (boxPlotData == null) {
+        continue;
+      }
+
       yMin = chart.getYAxis(series.getYAxisGroup()).getMin();
       yMax = chart.getYAxis(series.getYAxisGroup()).getMax();
 
@@ -141,6 +147,11 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
   }
 
   private void drawBoxPlot(Graphics2D g, String seriesName, BoxPlotData boxPlotData) {
+
+    // when all data values are the same yMin == yMax; offsets would be NaN, so skip rendering
+    if (yMax == yMin) {
+      return;
+    }
 
     double q1YOffset =
         getBounds().getY()

--- a/xchart/src/test/java/org/knowm/xchart/BoxChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/BoxChartTest.java
@@ -1,0 +1,84 @@
+package org.knowm.xchart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BoxChartTest {
+
+  private BoxChart chart;
+
+  @BeforeEach
+  void setUp() {
+
+    chart = new BoxChartBuilder().title("test").xAxisTitle("X").yAxisTitle("Y").build();
+  }
+
+  // https://github.com/knowm/XChart/issues/891
+  @Test
+  void replaceDataWithEmptyListThrowsIllegalArgument() {
+
+    BoxSeries series = chart.addSeries("test", Arrays.asList(1, 2, 3));
+
+    assertThatThrownBy(() -> series.replaceData(Collections.emptyList()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("empty");
+  }
+
+  // https://github.com/knowm/XChart/issues/891
+  @Test
+  void replaceDataWithNullListThrowsIllegalArgument() {
+
+    BoxSeries series = chart.addSeries("test", Arrays.asList(1, 2, 3));
+
+    assertThatThrownBy(() -> series.replaceData((java.util.List<Number>) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null");
+  }
+
+  // https://github.com/knowm/XChart/issues/891
+  @Test
+  void replaceDataWithContainingNullThrowsIllegalArgument() {
+
+    BoxSeries series = chart.addSeries("test", Arrays.asList(1, 2, 3));
+
+    assertThatThrownBy(() -> series.replaceData(Arrays.asList(1, null, 3)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null");
+  }
+
+  // https://github.com/knowm/XChart/issues/891
+  @Test
+  void replaceDataWithValidListSucceeds() {
+
+    BoxSeries series = chart.addSeries("test", Arrays.asList(1, 2, 3));
+
+    assertAll(
+        () -> assertDoesNotThrow(() -> series.replaceData(Arrays.asList(4, 5, 6))),
+        () -> assertThat(series.getYData()).hasSize(3));
+  }
+
+  // https://github.com/knowm/XChart/issues/890
+  @Test
+  void addSeriesWithSingleDataPointDoesNotThrow() {
+
+    assertDoesNotThrow(() -> chart.addSeries("single", Arrays.asList(42)));
+  }
+
+  // https://github.com/knowm/XChart/issues/890
+  @Test
+  void chartWithSingleDataPointCanBeSaved() {
+
+    chart.addSeries("single", Arrays.asList(42));
+
+    java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+    assertDoesNotThrow(
+        () -> BitmapEncoder.saveBitmap(chart, out, BitmapEncoder.BitmapFormat.PNG));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two related BoxChart bugs reported by @hogan-deng.

---

### Issue #891 — `IndexOutOfBoundsException` when `replaceData` is called with an empty list

**Root cause:** `BoxSeries.replaceData(List)` is inherited from `AxesChartSeriesCategory` and bypasses `BoxChart.sanityCheckYData()`. Passing `Collections.emptyList()` goes through silently; during the next paint `BoxPlotDataCalculator.getQuartile()` then calls `data.get(0)` on an empty list → `IndexOutOfBoundsException` on the AWT-EventQueue thread.

**Fix:**
- Override `replaceData(List<? extends Number>)` in `BoxSeries` with the same null / empty / contains-null validation already present in `BoxChart.sanityCheckYData`.
- Add a defensive `null`-`BoxPlotData` guard in `PlotContent_Box.doPaint` for any series whose data list is empty after null-filtering.

---

### Issue #890 — Chart freezes (blank window, unresponsive close button) with a single data point

**Root cause:** When all data values are identical (`yMin == yMax`), the per-offset calculation in `drawBoxPlot` divides by `(yMax - yMin) == 0`, producing `NaN` coordinates for every shape. Rendering shapes with NaN coordinates hangs the AWT Event Dispatch Thread.

**Fix:**
- Return early from `drawBoxPlot` when `yMax == yMin` (the axis tick calculator already handles this case by emitting a single centred tick label; the box itself simply cannot be drawn).

---

### Changes

| File | Change |
|------|--------|
| `BoxSeries.java` | Override `replaceData` with validation |
| `PlotContent_Box.java` | Guard against null `BoxPlotData`; skip `drawBoxPlot` when `yMax == yMin` |
| `BoxPlotDataCalculator.java` | Skip series with empty filtered data (return `null` entry) |
| `BoxChartTest.java` | New test class covering both issues |
| `TestForIssue890.java` | Standalone demo |
| `TestForIssue891.java` | Standalone demo |

Closes #890
Closes #891