### PR TITLE
Fix #805: wrong value displayed in cursor label

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue805.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue805.java
@@ -1,0 +1,71 @@
+package org.knowm.xchart.standalone.issues;
+
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
+import org.knowm.xchart.style.Styler.ChartTheme;
+
+/**
+ * Demonstrates the fix for issue #805 — wrong value displayed in cursor label.
+ *
+ * <p>Before the fix:
+ *
+ * <ol>
+ *   <li>Moving the cursor between data points left stale Y-values in the tooltip because {@code
+ *       matchingDataPointList} was only cleared inside the {@code dataPoints.size() > 0} branch.
+ *   <li>When multiple data points of the same series shared the same X position, only one Y value
+ *       was kept (closest X wins), so the others were silently dropped.
+ * </ol>
+ *
+ * <p>After the fix:
+ *
+ * <ol>
+ *   <li>{@code calculateMatchingDataPoints()} always clears {@code matchingDataPointList} at the
+ *       start, so no stale values persist when the cursor is between data points.
+ *   <li>Multiple Y values for the same series at the same X are combined into a comma-separated
+ *       string (e.g. {@code "1.0, 2.0"}).
+ * </ol>
+ *
+ * <p>To observe: enable the cursor, hover the mouse across the chart, and confirm the tooltip
+ * always reflects only the current data under the cursor.
+ */
+public class TestForIssue805 {
+
+  public static void main(String[] args) {
+
+    SwingWrapper<XYChart> sw = new SwingWrapper<>(getChart());
+    sw.displayChart();
+    sw.getXChartPanel().setCursorEnabled(true);
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static XYChart getChart() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Issue #805 — Cursor label wrong value fix")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .theme(ChartTheme.Matlab)
+            .build();
+
+    chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Line);
+
+    // Series 1: standard ascending data
+    chart.addSeries(
+        "Series A",
+        new double[] {1.0, 2.0, 3.0, 4.0, 5.0},
+        new double[] {2.0, 4.5, 3.0, 6.0, 5.5});
+
+    // Series 2: overlaps Series A at some X values to exercise multi-series cursor
+    chart.addSeries(
+        "Series B",
+        new double[] {1.0, 2.0, 3.0, 4.0, 5.0},
+        new double[] {1.0, 2.0, 4.0, 3.5, 7.0});
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Cursor.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Cursor.java
@@ -12,7 +12,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.internal.series.MarkerSeries;
@@ -231,8 +231,13 @@ public class Cursor extends MouseAdapter implements ChartPart {
     }
   }
 
-  /** One DataPoint per series, keep the DataPoint closest to mouseX */
+  /**
+   * Per series, collect all DataPoints under the cursor and combine their Y values. When multiple
+   * points of the same series share the same X position, their Y values are joined with ", ".
+   */
   private void calculateMatchingDataPoints() {
+
+    matchingDataPointList.clear();
 
     List<DataPoint> dataPoints = new ArrayList<>();
     for (DataPoint dataPoint : dataPointList) {
@@ -244,20 +249,24 @@ public class Cursor extends MouseAdapter implements ChartPart {
     }
 
     if (dataPoints.size() > 0) {
-      Map<String, DataPoint> map = new HashMap<>();
-      String seriesName = "";
+      // Preserve series order using a LinkedHashMap; accumulate Y values per series.
+      Map<String, DataPoint> representativeMap = new LinkedHashMap<>();
+      Map<String, StringBuilder> yValuesMap = new LinkedHashMap<>();
       for (DataPoint dataPoint : dataPoints) {
-        seriesName = dataPoint.seriesName;
-        if (map.containsKey(seriesName)) {
-          if (Math.abs(dataPoint.x - mouseX) < Math.abs(map.get(seriesName).x - mouseX)) {
-            map.put(seriesName, dataPoint);
-          }
+        String seriesName = dataPoint.seriesName;
+        if (representativeMap.containsKey(seriesName)) {
+          yValuesMap.get(seriesName).append(", ").append(dataPoint.yValue);
         } else {
-          map.put(seriesName, dataPoint);
+          representativeMap.put(seriesName, dataPoint);
+          yValuesMap.put(seriesName, new StringBuilder(dataPoint.yValue));
         }
       }
-      matchingDataPointList.clear();
-      matchingDataPointList.addAll(map.values());
+      for (Map.Entry<String, DataPoint> entry : representativeMap.entrySet()) {
+        DataPoint dp = entry.getValue();
+        String combinedY = yValuesMap.get(entry.getKey()).toString();
+        matchingDataPointList.add(
+            new DataPoint(dp.x, dp.y, dp.xValue, combinedY, dp.seriesName));
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #805

## Problem

Two bugs in `Cursor.calculateMatchingDataPoints()`:

1. **Stale tooltip values** — `matchingDataPointList` was only cleared inside the `if (dataPoints.size() > 0)` branch. When the cursor moved to a position where no data points were nearby (but still inside the plot), the old tooltip kept showing from the previous cursor position.

2. **Missing Y values for same-series multi-point hits** — The `HashMap` deduplication kept only one `DataPoint` per series (the closest X), silently dropping other Y values at the same X position. This caused wrong/incomplete values in the cursor label when multiple points of the same series fell under the cursor.

## Fix

- `matchingDataPointList.clear()` is now called **unconditionally** at the start of `calculateMatchingDataPoints()`, so no stale values persist when the cursor is between data points.
- Replaced the `HashMap` closest-X logic with a `LinkedHashMap` that **accumulates all Y values** for each series and joins them with `", "`, so all values are visible in the cursor label (e.g. `"1.0, 2.0"`). Series insertion order is preserved.

## Demo

`TestForIssue805.java` — two overlapping series on an XY chart; enable the cursor and hover across the chart to verify correct labels.