### PR TITLE
Fix #171: auto-skip crowded X-axis labels on CategoryChart

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue171.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue171.java
@@ -1,0 +1,64 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Demonstrates that x-axis labels no longer overlap when there are many categories.
+ *
+ * <p>Reproduces the 161-category histogram from issue #171. The default xAxisTickMarkSpacingHint
+ * now automatically skips labels on category charts so they don't overlap.
+ */
+public class TestForIssue171 {
+
+  public static void main(String[] args) {
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static CategoryChart getChart() {
+    int n = 80;
+    int nbRandomWalks = 1_000_000;
+    Random generator = new Random(42);
+
+    int[] histogramY = new int[2 * n + 1];
+    for (int j = 0; j < nbRandomWalks; j++) {
+      int delta = 0;
+      for (int i = 0; i < n; i++) {
+        delta += generator.nextInt(2) < 1 ? -1 : 1;
+      }
+      histogramY[delta + n] += 1;
+    }
+
+    List<Integer> xData = new ArrayList<>();
+    List<Integer> yData = new ArrayList<>();
+    for (int i = 0; i < 2 * n + 1; i++) {
+      xData.add(i - n);
+      yData.add(histogramY[i]);
+    }
+
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Random Walk Distribution (Issue #171)")
+            .xAxisTitle("delta")
+            .yAxisTitle("occurrences")
+            .build();
+
+    chart.getStyler().setChartTitleVisible(true);
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideNW);
+    chart.getStyler().setLegendVisible(false);
+    chart.getStyler().setDefaultSeriesRenderStyle(CategorySeries.CategorySeriesRenderStyle.Stick);
+
+    chart.addSeries("data", xData, yData);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Category.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Category.java
@@ -78,6 +78,13 @@ class AxisTickCalculator_Category extends AxisTickCalculator_ {
       firstPosition = 0;
     }
 
+    // When no explicit label count cap is set, respect the spacing hint to avoid overlap.
+    // Compute how many categories to skip so adjacent labels are at least spacingHint pixels apart.
+    int skipFactor = 1;
+    if (xAxisMaxLabelCount == 0 && gridStep < styler.getXAxisTickMarkSpacingHint()) {
+      skipFactor = (int) Math.ceil(styler.getXAxisTickMarkSpacingHint() / gridStep);
+    }
+
     // set up String formatters that may be encountered
     if (axisType == Series.DataType.String) {
       axisFormat = new Formatter_String();
@@ -96,16 +103,17 @@ class AxisTickCalculator_Category extends AxisTickCalculator_ {
     int counter = 0;
 
     for (Object category : categories) {
-      if (axisType == Series.DataType.String) {
-        tickLabels.add(category.toString());
-      } else if (axisType == Series.DataType.Number) {
-        tickLabels.add(axisFormat.format(new BigDecimal(category.toString()).doubleValue()));
-      } else if (axisType == Series.DataType.Date) {
-        tickLabels.add(axisFormat.format((((Date) category).getTime())));
+      if (counter % skipFactor == 0) {
+        if (axisType == Series.DataType.String) {
+          tickLabels.add(category.toString());
+        } else if (axisType == Series.DataType.Number) {
+          tickLabels.add(axisFormat.format(new BigDecimal(category.toString()).doubleValue()));
+        } else if (axisType == Series.DataType.Date) {
+          tickLabels.add(axisFormat.format((((Date) category).getTime())));
+        }
+        tickLocations.add(margin + firstPosition + gridStep * counter);
       }
-
-      double tickLabelPosition = margin + firstPosition + gridStep * counter++;
-      tickLocations.add(tickLabelPosition);
+      counter++;
     }
   }
 }

--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/AxisTickCalculatorCategoryTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/AxisTickCalculatorCategoryTest.java
@@ -59,4 +59,36 @@ public class AxisTickCalculatorCategoryTest {
     assertThat(calculator.tickLocations)
         .isEqualTo(Arrays.asList(105.0, 243.0, 381.0, 519.0, 657.0, 795.0));
   }
+
+  @Test
+  public void shouldAutoSkipLabelsWhenCrowded() {
+    // 20 categories in 200px: gridStep ≈ 8.5 px < default spacingHint (74 px)
+    // skipFactor = ceil(74 / 8.5) = 9 → labels at indices 0, 9, 18 → 3 labels
+    List<String> categories =
+        Arrays.asList(
+            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q",
+            "r", "s", "t");
+    CategoryStyler styler = new CategoryStyler();
+
+    AxisTickCalculator_Category calculator =
+        new AxisTickCalculator_Category(
+            Axis_.Direction.X, 200, categories, Series.DataType.String, styler);
+
+    assertThat(calculator.tickLabels.size()).isLessThan(categories.size());
+    assertThat(calculator.tickLabels.get(0)).isEqualTo("a");
+  }
+
+  @Test
+  public void shouldNotAutoSkipWhenSpacingHintIsDisabled() {
+    // Setting spacingHint to 0 disables auto-skip; all labels should appear
+    List<String> categories = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
+    CategoryStyler styler = new CategoryStyler();
+    styler.setXAxisTickMarkSpacingHint(0);
+
+    AxisTickCalculator_Category calculator =
+        new AxisTickCalculator_Category(
+            Axis_.Direction.X, 200, categories, Series.DataType.String, styler);
+
+    assertThat(calculator.tickLabels.size()).isEqualTo(categories.size());
+  }
 }


### PR DESCRIPTION
## Problem
When a `CategoryChart` has many categories (e.g. 161 values from -80 to 80), all X-axis labels are rendered and they overlap. The user's call to `setXAxisTickMarkSpacingHint()` had no effect because `AxisTickCalculator_Category` completely ignored that hint.

PR #344 added `setXAxisMaxLabelCount()` as a manual workaround, but the original complaint — that `setXAxisTickMarkSpacingHint` doesn't work — remained unresolved.

## Fix
`AxisTickCalculator_Category` now respects `xAxisTickMarkSpacingHint` (default 74 px). When no explicit `xAxisMaxLabelCount` is set and the per-tick pixel spacing is smaller than the hint, a `skipFactor` is computed:

```java
skipFactor = (int) Math.ceil(spacingHint / gridStep);
```

Only every `skipFactor`-th label is then rendered, eliminating overlap automatically — no user configuration required.

## Behaviour
| Scenario | Before | After |
|---|---|---|
| Many categories, default settings | All labels, overlapping | Auto-skipped, no overlap |
| Few categories, enough space | All labels shown | All labels shown (unchanged) |
| `setXAxisMaxLabelCount(N)` set | Manual cap respected | Manual cap respected (unchanged) |
| `setXAxisTickMarkSpacingHint(0)` | No effect | Disables auto-skip, shows all labels |

## Files changed
- `AxisTickCalculator_Category.java` — core fix
- `AxisTickCalculatorCategoryTest.java` — two new tests
- `TestForIssue171.java` — standalone demo reproducing the 161-category histogram

Fixes: #171