### PR TITLE
docs: XChart general refactor plan

### DIFF
--- a/.github/REFACTOR_PLAN.md
+++ b/.github/REFACTOR_PLAN.md
@@ -1,0 +1,162 @@
+# XChart General Refactor Plan
+
+## Problem Statement
+
+XChart has accumulated ~10 years of structural debt. A high-level code audit identified ~38 issues
+across architecture, generics, null handling, duplication, naming, and testability.
+This plan captures the major problem areas and proposes a prioritized refactor roadmap.
+
+---
+
+## Findings Summary
+
+### HIGH Severity
+
+**H1 — Axis fields in base `Chart` class (Liskov violation)**
+
+`Chart.java` contains `axisPair`, `xAxisTitle`, `yAxisTitle`, and `yAxisGroupTitleMap` even though
+PieChart, RadarChart, and DialChart have no axes. This forces defensive `axisPair != null` checks
+throughout the codebase and breaks LSP. A proper `AxesChart<ST, S>` abstract subclass should hold
+all axis-related state, and non-axes charts should extend `Chart` directly.
+
+**H2 — God-class Stylers**
+
+`Styler.java` (1013 lines, 100+ fields) and `AxesChartStyler.java` (1056 lines, 50+ more fields)
+are monolithic property bags. They handle chart-level, legend, tooltip, annotation, button, and
+axis styling all in one class. Adding any new styling property requires touching multiple files.
+Decompose into focused sub-stylers (e.g., `LegendStyler`, `TooltipStyler`, `AnnotationStyler`).
+
+**H3 — Massive `addSeries()` overload explosion**
+
+`XYChart` has ~15+ `addSeries()` overloads for every combination of `double[]`, `float[]`, `int[]`,
+`List<Number>`, `List<Date>`, etc. `CategoryChart` has ~12+. This is ~30% of chart code. A series
+builder / factory pattern would collapse this drastically.
+
+---
+
+### MEDIUM Severity
+
+**M1 — Deep inheritance chains in Series hierarchy**
+
+5-level deep chain:
+`Series → AxesChartSeries → MarkerSeries → AxesChartSeriesNumericalNoErrorBars → XYSeries`.
+Changes to any intermediate class ripple everywhere. Composition over inheritance should be
+explored.
+
+**M2 — Pervasive unchecked casts (`@SuppressWarnings("unchecked")`)**
+
+`Chart.java`, `ChartBuilder.java`, `Cursor.java`, `Axis_X.java`, `XChartPanel.java` all suppress
+unchecked cast warnings. This defeats the type system and risks runtime ClassCastExceptions.
+
+**M3 — Misleading class name: `AxesChartSeriesNumericalNoErrorBars`**
+
+Despite the name, this class contains `double[] extraValues` and `findMinMaxWithErrorBars()`.
+The class itself has a comment calling this out: "weird name of class."
+
+**M4 — Null used as sentinel for "use styler default"**
+
+`XYSeries.xySeriesRenderStyle = null` is an implicit contract meaning "inherit from styler."
+This is an invisible design contract that's easy to break. Use `Optional<>` or explicit delegation.
+
+**M5 — Duplicate data storage for zoom support**
+
+Series classes maintain both full data (`xDataAll`, `yDataAll`) and filtered/zoomed data
+(`xData`, `yData`). For large datasets this doubles memory. A view/range abstraction would be
+cleaner.
+
+**M6 — High cyclomatic complexity in rendering**
+
+`PlotContent_Category_Bar.java` is 680 lines with deeply nested conditionals for handling
+different series types, error bars, and styles. Should be decomposed.
+
+**M7 — Theme is mutable after chart creation**
+
+`setTheme()` can be called on a live Styler, potentially affecting multiple charts. Themes should
+be immutable value objects applied at construction time.
+
+**M8 — Calculation mixed with rendering in Series**
+
+Series classes mix data storage, min/max calculation, zoom filtering, and rendering hints. The
+calculation logic should be separated so it can be tested independently.
+
+**M9 — Unresolved TODO debt (23+ instances)**
+
+Documented architectural TODOs in `Chart.java` (axis fields), `Series.java`, `Styler.java`,
+`AxesChartSeriesNumericalNoErrorBars.java`, `ToolTips.java`, and `BoxChart.java`.
+
+**M10 — `getSeriesMap()` creates new unmodifiable wrapper on every call**
+
+Minor but avoidable per-call allocation; wrap once at mutation time.
+
+---
+
+### LOW Severity
+
+**L1 — Magic numbers scattered in rendering constants**
+
+`Legend_.java` has `BOX_SIZE=20`, `BOX_OUTLINE_WIDTH=5`, `LEGEND_MARGIN=6`, etc. inline.
+Should be named constants in a single location.
+
+**L2 — Typos in error messages**
+
+`BoxChart.java`: `"connot be null"`, `"connot be empyt"` → `"cannot be null"`,
+`"cannot be empty"`.
+
+**L3 — Commented-out code and orphaned `System.out.println`**
+
+Cleanup pass needed.
+
+**L4 — Inconsistent fluent setter coverage**
+
+Some series setters return `this`, others don't. Should be uniform.
+
+---
+
+## Proposed Refactor Phases
+
+### Phase 1 — Low-hanging fruit (no API breakage)
+
+- Fix typos in error messages (BoxChart and any others)
+- Remove commented-out code / dead `System.out.println`
+- Rename `AxesChartSeriesNumericalNoErrorBars` to something accurate
+- Collect all rendering magic numbers into named constants
+- Resolve straightforward TODOs
+
+### Phase 2 — Series & data layer
+
+- Rename series class hierarchy to accurate names
+- Introduce `Optional<SeriesRenderStyle>` instead of null sentinel
+- Separate min/max calculation from series data storage
+- Explore replacing duplicate zoom data with a view/range object
+
+### Phase 3 — Styler decomposition
+
+- Extract `LegendStyler`, `TooltipStyler`, `AnnotationStyler` sub-objects
+- Make `Theme` an immutable value type; remove `setTheme()` from Styler
+
+### Phase 4 — Chart class hierarchy (highest risk)
+
+- Introduce `AxesChart<ST extends AxesChartStyler, S extends AxesChartSeries>` between `Chart`
+  and the axes-based chart types
+- Move `axisPair`, axis titles, `yAxisGroupTitleMap` out of base `Chart`
+- Remove all defensive `axisPair != null` checks from base class
+
+### Phase 5 — `addSeries()` overload reduction (public API change)
+
+- Design a `SeriesBuilder` / factory that accepts data generically
+- Collapse the 15+ overloads per chart type
+- Requires a deprecation cycle before removing old overloads
+
+### Phase 6 — Rendering decomposition
+
+- Break up `PlotContent_Category_Bar` and similar large renderers
+- Separate data computation from `Graphics2D` drawing calls (aids testability)
+
+---
+
+## Risk Notes
+
+- **Phase 4** is the highest risk: `Chart` is the base of everything; all chart types must be
+  retested
+- **Phase 5** is a public API change — requires a deprecation cycle
+- **Phases 1–3** can be done incrementally without breaking anything public


### PR DESCRIPTION
## Summary

Adds `.github/REFACTOR_PLAN.md` — a high-level audit and phased roadmap for a general structural refactor of the XChart library.

The codebase is ~10 years old and has accumulated significant architectural debt. This document captures ~38 identified issues and proposes a 6-phase plan to address them incrementally.

---

## Key Findings

### 🔴 High Priority
| # | Issue |
|---|-------|
| H1 | Axis-specific fields (`axisPair`, axis titles) in base `Chart` class — Liskov violation; non-axes charts (Pie, Radar, Dial) inherit state they can never use |
| H2 | God-class Stylers — `Styler.java` (1013 lines) and `AxesChartStyler.java` (1056 lines) handle legend, tooltip, annotation, button, axis styling all in one class |
| H3 | `addSeries()` overload explosion — ~15 overloads in XYChart, ~12 in CategoryChart for every `double[]`/`float[]`/`int[]`/`List<>` combination |

### 🟡 Medium Priority
- 5-level deep Series inheritance chain
- Pervasive `@SuppressWarnings("unchecked")` casts in 5+ core files
- `null` used as sentinel ("inherit from styler") — invisible contract
- Duplicate `xData`/`xDataAll` in every series for zoom support (2× memory)
- 23+ unresolved TODO comments, some flagging the H1 issue directly
- Mutable Theme — `setTheme()` callable after chart creation

### 🟢 Low Priority
- Magic numbers in rendering constants
- Typos: `"connot be null"`, `"connot be empyt"` in BoxChart
- Commented-out code / stray `System.out.println`
- Inconsistent fluent setter coverage

---

## Proposed Phases

| Phase | Scope | Risk |
|-------|-------|------|
| 1 | Low-hanging fruit: typos, dead code, magic numbers, straightforward TODOs | None |
| 2 | Series & data layer: rename classes, `Optional` for render style, zoom view | Low |
| 3 | Styler decomposition: extract `LegendStyler`, `TooltipStyler`, `AnnotationStyler`; immutable Theme | Medium |
| 4 | Chart hierarchy: introduce `AxesChart` abstract subclass, move axis state out of `Chart` | High |
| 5 | `addSeries()` API reduction via SeriesBuilder (deprecation cycle required) | High |
| 6 | Rendering decomposition: break up large PlotContent classes | Medium |

Phases 1–3 can be done incrementally with no public API breakage.