### PR TITLE
Phase 4: Introduce AxesChart abstract class between Chart and axes-based chart types

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/AnnotationImage.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationImage.java
@@ -4,7 +4,7 @@ import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import org.knowm.xchart.internal.chartpart.Annotation;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 
 public class AnnotationImage extends Annotation {
 
@@ -28,7 +28,7 @@ public class AnnotationImage extends Annotation {
     this.y = y;
   }
 
-  public void init(Chart<?, ?> chart) {
+  public void init(AxesChart<?, ?> chart) {
 
     super.init(chart);
   }

--- a/xchart/src/main/java/org/knowm/xchart/AnnotationTextPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationTextPanel.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.knowm.xchart.internal.chartpart.Annotation;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 
 public class AnnotationTextPanel extends Annotation {
 
@@ -39,7 +39,7 @@ public class AnnotationTextPanel extends Annotation {
     this.y = y;
   }
 
-  public void init(Chart<?, ?> chart) {
+  public void init(AxesChart<?, ?> chart) {
 
     super.init(chart);
   }

--- a/xchart/src/main/java/org/knowm/xchart/BoxChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/BoxChart.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 import org.knowm.xchart.internal.chartpart.Legend_Marker;
 import org.knowm.xchart.internal.chartpart.Plot_Box;
 import org.knowm.xchart.internal.series.Series.DataType;
@@ -16,7 +16,7 @@ import org.knowm.xchart.style.BoxStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.theme.Theme;
 
-public class BoxChart extends Chart<BoxStyler, BoxSeries> {
+public class BoxChart extends AxesChart<BoxStyler, BoxSeries> {
 
   private final List<String> xData = new ArrayList<>();
 

--- a/xchart/src/main/java/org/knowm/xchart/BubbleChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/BubbleChart.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 import org.knowm.xchart.internal.chartpart.Legend_Bubble;
 import org.knowm.xchart.internal.chartpart.Plot_Bubble;
 import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyle;
@@ -14,7 +14,7 @@ import org.knowm.xchart.style.BubbleStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.theme.Theme;
 
-public class BubbleChart extends Chart<BubbleStyler, BubbleSeries> {
+public class BubbleChart extends AxesChart<BubbleStyler, BubbleSeries> {
 
   /**
    * Constructor - the default Chart Theme will be used (XChartTheme)

--- a/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 import org.knowm.xchart.internal.chartpart.Legend_Marker;
 import org.knowm.xchart.internal.chartpart.Plot_Category;
 import org.knowm.xchart.internal.series.Series.DataType;
@@ -18,7 +18,7 @@ import org.knowm.xchart.style.CategoryStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.theme.Theme;
 
-public class CategoryChart extends Chart<CategoryStyler, CategorySeries> {
+public class CategoryChart extends AxesChart<CategoryStyler, CategorySeries> {
 
   /**
    * Constructor - the default Chart Theme will be used (XChartTheme)

--- a/xchart/src/main/java/org/knowm/xchart/DialChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/DialChart.java
@@ -122,7 +122,6 @@ public class DialChart extends Chart<DialStyler, DialSeries> {
     plot.paint(g);
     chartTitle.paint(g);
     //    legend.paint(g); // no legend for dial charts
-    annotations.forEach(x -> x.paint(g));
     paintAlwaysVisibleToolTips(g);
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/HeatMapChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/HeatMapChart.java
@@ -5,14 +5,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.internal.chartpart.AxisPair;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 import org.knowm.xchart.internal.chartpart.Legend_HeatMap;
 import org.knowm.xchart.internal.chartpart.Plot_HeatMap;
 import org.knowm.xchart.style.HeatMapStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.theme.Theme;
 
-public class HeatMapChart extends Chart<HeatMapStyler, HeatMapSeries> {
+public class HeatMapChart extends AxesChart<HeatMapStyler, HeatMapSeries> {
 
   private HeatMapSeries heatMapSeries;
 

--- a/xchart/src/main/java/org/knowm/xchart/HorizontalBarChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/HorizontalBarChart.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 import org.knowm.xchart.internal.chartpart.Legend_HorizontalBar;
 import org.knowm.xchart.internal.chartpart.Plot_HorizontalBar;
 import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyle;
@@ -15,7 +15,7 @@ import org.knowm.xchart.style.HorizontalBarStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.theme.Theme;
 
-public class HorizontalBarChart extends Chart<HorizontalBarStyler, HorizontalBarSeries> {
+public class HorizontalBarChart extends AxesChart<HorizontalBarStyler, HorizontalBarSeries> {
 
   /**
    * Constructor - the default Chart Theme will be used (XChartTheme)

--- a/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.knowm.xchart.OHLCSeries.OHLCSeriesRenderStyle;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 import org.knowm.xchart.internal.chartpart.Legend_OHLC;
 import org.knowm.xchart.internal.chartpart.Plot_OHLC;
 import org.knowm.xchart.internal.series.Series.DataType;
@@ -20,7 +20,7 @@ import org.knowm.xchart.style.OHLCStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.theme.Theme;
 
-public class OHLCChart extends Chart<OHLCStyler, OHLCSeries> {
+public class OHLCChart extends AxesChart<OHLCStyler, OHLCSeries> {
 
   /**
    * Constructor - the default Chart Theme will be used (XChartTheme)

--- a/xchart/src/main/java/org/knowm/xchart/PieChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/PieChart.java
@@ -131,7 +131,6 @@ public class PieChart extends Chart<PieStyler, PieSeries> {
     plot.paint(g);
     chartTitle.paint(g);
     legend.paint(g);
-    annotations.forEach(x -> x.paint(g));
     paintAlwaysVisibleToolTips(g);
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/RadarChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/RadarChart.java
@@ -158,7 +158,6 @@ public class RadarChart extends Chart<RadarStyler, RadarSeries> {
     plot.paint(g);
     chartTitle.paint(g);
     legend.paint(g);
-    annotations.forEach(x -> x.paint(g));
     paintAlwaysVisibleToolTips(g);
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -33,11 +33,11 @@ import javax.swing.filechooser.FileFilter;
 
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
 import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.chartpart.ChartZoom;
 import org.knowm.xchart.internal.chartpart.Cursor;
 import org.knowm.xchart.internal.chartpart.ToolTips;
-import org.knowm.xchart.style.AxesChartStyler;
 
 /**
  * A Swing JPanel that contains a Chart
@@ -227,7 +227,7 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
       anyEnabled = true;
       @SuppressWarnings("unchecked")
       ChartZoom zoom =
-          new ChartZoom((Chart<? extends AxesChartStyler, ?>) chart, this, resetString);
+          new ChartZoom((AxesChart<?, ?>) chart, this, resetString);
       this.chartZoom = zoom;
       this.addMouseListener(zoom);
       this.addMouseMotionListener(zoom);

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
-import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.AxesChart;
 import org.knowm.xchart.internal.chartpart.Legend_Marker;
 import org.knowm.xchart.internal.chartpart.Plot_XY;
 import org.knowm.xchart.internal.series.Series.DataType;
@@ -17,7 +17,7 @@ import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.XYStyler;
 import org.knowm.xchart.style.theme.Theme;
 
-public class XYChart extends Chart<XYStyler, XYSeries> {
+public class XYChart extends AxesChart<XYStyler, XYSeries> {
 
   /**
    * Constructor - the default Chart Theme will be used (XChartTheme)

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Annotation.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Annotation.java
@@ -8,7 +8,7 @@ public abstract class Annotation implements ChartPart {
   protected boolean isVisible = true;
   protected boolean isValueInScreenSpace;
 
-  protected Chart<?, ?> chart;
+  protected AxesChart<?, ?> chart;
   protected Styler styler;
   protected Rectangle2D bounds;
 
@@ -16,7 +16,7 @@ public abstract class Annotation implements ChartPart {
     this.isValueInScreenSpace = isValueInScreenSpace;
   }
 
-  public void init(Chart<?, ?> chart) {
+  public void init(AxesChart<?, ?> chart) {
 
     this.chart = chart;
     this.styler = chart.getStyler();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxesChart.java
@@ -1,0 +1,172 @@
+package org.knowm.xchart.internal.chartpart;
+
+import java.text.DecimalFormat;
+import java.text.Format;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.knowm.xchart.internal.series.AxesChartSeries;
+import org.knowm.xchart.style.AxesChartStyler;
+
+/**
+ * Abstract base class for all chart types that have X and Y axes.
+ *
+ * <p>Sits between {@link Chart} and concrete axes-based charts (XYChart, CategoryChart, etc.),
+ * holding axis state and methods that are meaningless for non-axes charts (PieChart, DialChart,
+ * RadarChart).
+ */
+public abstract class AxesChart<ST extends AxesChartStyler, S extends AxesChartSeries>
+    extends Chart<ST, S> {
+
+  protected AxisPair<ST, S> axisPair;
+  protected final ArrayList<ChartPart> annotations = new ArrayList<>();
+
+  private String xAxisTitle = "";
+  private String yAxisTitle = "";
+  private final Map<Integer, String> yAxisGroupTitleMap = new HashMap<>();
+
+  /**
+   * Constructor
+   *
+   * @param width
+   * @param height
+   * @param styler
+   */
+  protected AxesChart(int width, int height, ST styler) {
+
+    super(width, height, styler);
+  }
+
+  public String getXAxisTitle() {
+
+    return xAxisTitle;
+  }
+
+  public void setXAxisTitle(String xAxisTitle) {
+
+    this.xAxisTitle = xAxisTitle;
+  }
+
+  public String getYAxisTitle() {
+
+    return yAxisTitle;
+  }
+
+  public void setYAxisTitle(String yAxisTitle) {
+
+    this.yAxisTitle = yAxisTitle;
+  }
+
+  public String getYAxisGroupTitle(int yAxisGroup) {
+
+    String title = yAxisGroupTitleMap.get(yAxisGroup);
+    if (title == null) {
+      return yAxisTitle;
+    }
+    return title;
+  }
+
+  public void setYAxisGroupTitle(int yAxisGroup, String yAxisTitle) {
+
+    yAxisGroupTitleMap.put(yAxisGroup, yAxisTitle);
+  }
+
+  public void addAnnotation(Annotation annotation) {
+
+    annotations.add(annotation);
+    annotation.init(this);
+  }
+
+  /**
+   * @Deprecated - use styler instead
+   *
+   * @param customFormattingFunction
+   */
+  public void setCustomXAxisTickLabelsFormatter(Function<Double, String> customFormattingFunction) {
+    styler.setxAxisTickLabelsFormattingFunction(customFormattingFunction);
+  }
+
+  /**
+   * @Deprecated - use styler instead
+   *
+   * @param customFormattingFunction
+   */
+  public void setCustomYAxisTickLabelsFormatter(Function<Double, String> customFormattingFunction) {
+    styler.setyAxisTickLabelsFormattingFunction(customFormattingFunction);
+  }
+
+  Axis_X<ST, S> getXAxis() {
+
+    return axisPair.getXAxis();
+  }
+
+  Axis_Y<ST, S> getYAxis() {
+
+    return axisPair.getYAxis();
+  }
+
+  Axis_Y<ST, S> getYAxis(int yIndex) {
+
+    return axisPair.getYAxis(yIndex);
+  }
+
+  AxisPair<ST, S> getAxisPair() {
+
+    return axisPair;
+  }
+
+  Format getXAxisFormat() {
+    return axisPair.getXAxis().getAxisTickCalculator().getAxisFormat();
+  }
+
+  Format getYAxisFormat() {
+    return axisPair.getYAxis().getAxisTickCalculator().getAxisFormat();
+  }
+
+  Format getYAxisFormat(String yAxisDecimalPattern) {
+    final Format format;
+    if (yAxisDecimalPattern != null) {
+      format = new DecimalFormat(yAxisDecimalPattern);
+    } else {
+      format = axisPair.getYAxis().getAxisTickCalculator().getAxisFormat();
+    }
+    return format;
+  }
+
+  public double getChartXFromCoordinate(int screenX) {
+
+    return axisPair.getXAxis().getChartValue(screenX);
+  }
+
+  public double getChartYFromCoordinate(int screenY) {
+
+    return axisPair.getYAxis().getChartValue(screenY);
+  }
+
+  public double getChartYFromCoordinate(int screenY, int yIndex) {
+
+    return axisPair.getYAxis(yIndex).getChartValue(screenY);
+  }
+
+  public double getScreenXFromChart(double xValue) {
+
+    return axisPair.getXAxis().getScreenValue(xValue);
+  }
+
+  public double getScreenYFromChart(double yValue) {
+
+    return axisPair.getYAxis().getScreenValue(yValue);
+  }
+
+  public double getScreenYFromChart(double yValue, int yIndex) {
+
+    return axisPair.getYAxis(yIndex).getScreenValue(yValue);
+  }
+
+  public double getYAxisLeftWidth() {
+
+    java.awt.geom.Rectangle2D.Double bounds = getAxisPair().getLeftYAxisBounds();
+    return bounds.width + bounds.x;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -17,7 +17,7 @@ import org.knowm.xchart.style.Styler.LegendPosition;
 
 public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> implements ChartPart {
 
-  private final Chart<ST, S> chart;
+  private final AxesChart<ST, S> chart;
 
   private final Axis_X<ST, S> xAxis;
   private final Axis_Y<ST, S> yAxis;
@@ -42,7 +42,7 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
    *
    * @param chart
    */
-  public AxisPair(Chart<ST, S> chart) {
+  public AxisPair(AxesChart<ST, S> chart) {
 
     this.chart = chart;
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTick.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTick.java
@@ -9,7 +9,7 @@ import org.knowm.xchart.style.AxesChartStyler;
 /** An axis tick */
 public class AxisTick<ST extends AxesChartStyler, S extends AxesChartSeries> implements ChartPart {
 
-  private final Chart<ST, S> chart;
+  private final AxesChart<ST, S> chart;
   private final Direction direction;
 
   /** the axisticklabels */
@@ -27,7 +27,7 @@ public class AxisTick<ST extends AxesChartStyler, S extends AxesChartSeries> imp
    * @param direction
    * @param yAxis
    */
-  AxisTick(Chart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis) {
+  AxisTick(AxesChart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis) {
 
     this.chart = chart;
     this.direction = direction;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
@@ -18,7 +18,7 @@ import org.knowm.xchart.style.Styler.YAxisPosition;
 public class AxisTickLabels<ST extends AxesChartStyler, S extends AxesChartSeries>
     implements ChartPart {
 
-  private final Chart<ST, S> chart;
+  private final AxesChart<ST, S> chart;
   private final Direction direction;
   private final Axis_<?, ?> yAxis;
   private final ColocatedSlaveLabels colocatedSlaveLabels;
@@ -30,7 +30,7 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends AxesChartSerie
    * @param chart
    * @param direction
    */
-  AxisTickLabels(Chart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis) {
+  AxisTickLabels(AxesChart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis) {
 
     this.chart = chart;
     this.direction = direction;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickMarks.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickMarks.java
@@ -12,7 +12,7 @@ import org.knowm.xchart.style.Styler.YAxisPosition;
 public class AxisTickMarks<ST extends AxesChartStyler, S extends AxesChartSeries>
     implements ChartPart {
 
-  private final Chart<ST, S> chart;
+  private final AxesChart<ST, S> chart;
   private final Direction direction;
   private final Axis_<?, ?> yAxis;
   private Rectangle2D bounds;
@@ -23,7 +23,7 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends AxesChartSeries
    * @param chart
    * @param direction
    */
-  AxisTickMarks(Chart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis) {
+  AxisTickMarks(AxesChart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis) {
 
     this.chart = chart;
     this.direction = direction;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTitle.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTitle.java
@@ -6,14 +6,14 @@ import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import org.knowm.xchart.internal.chartpart.Axis_.Direction;
-import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.internal.series.AxesChartSeries;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.Styler.YAxisPosition;
 
 /** AxisTitle */
-public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements ChartPart {
+public class AxisTitle<ST extends AxesChartStyler, S extends AxesChartSeries> implements ChartPart {
 
-  private final Chart<ST, S> chart;
+  private final AxesChart<ST, S> chart;
   private final Direction direction;
   private final Axis_<?, ?> yAxis;
   private final int yIndex;
@@ -25,7 +25,7 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
    * @param chart the Chart
    * @param direction the Direction
    */
-  AxisTitle(Chart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis, int yIndex) {
+  AxisTitle(AxesChart<ST, S> chart, Direction direction, Axis_<?, ?> yAxis, int yIndex) {
 
     this.chart = chart;
     this.direction = direction;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_.java
@@ -13,7 +13,7 @@ import org.knowm.xchart.style.AxesChartStyler;
 public abstract class Axis_<ST extends AxesChartStyler, S extends AxesChartSeries>
     implements ChartPart {
 
-  final Chart<ST, S> chart;
+  final AxesChart<ST, S> chart;
   final Rectangle2D.Double bounds;
   final ST axesChartStyler;
 
@@ -35,7 +35,7 @@ public abstract class Axis_<ST extends AxesChartStyler, S extends AxesChartSerie
   double min;
   double max;
 
-  Axis_(Chart<ST, S> chart, int index) {
+  Axis_(AxesChart<ST, S> chart, int index) {
 
     this.chart = chart;
     this.axesChartStyler = chart.getStyler();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
@@ -35,7 +35,7 @@ import org.knowm.xchart.style.XYStyler;
 /** X-Axis. */
 public class Axis_X<ST extends AxesChartStyler, S extends AxesChartSeries> extends Axis_<ST, S> {
 
-  Axis_X(Chart<ST, S> chart) {
+  Axis_X(AxesChart<ST, S> chart) {
 
     super(chart, 0);
     axisTitle = new AxisTitle<>(chart, Axis_.Direction.X, null, 0);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_Y.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_Y.java
@@ -54,7 +54,7 @@ public class Axis_Y<ST extends AxesChartStyler, S extends AxesChartSeries> exten
    */
   private final List<Axis_Y<?, ?>> colocatedSlaves = new ArrayList<>();
 
-  Axis_Y(Chart<ST, S> chart, int index) {
+  Axis_Y(AxesChart<ST, S> chart, int index) {
 
     super(chart, index);
     axisTitle = new AxisTitle<>(chart, Axis_.Direction.Y, this, index);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -4,18 +4,12 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.geom.Rectangle2D;
-import java.text.DecimalFormat;
-import java.text.Format;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.function.Function;
 import org.knowm.xchart.ToolTipType;
 import org.knowm.xchart.internal.series.Series;
-import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.Styler;
 
 /** An XChart Chart */
@@ -24,13 +18,8 @@ public abstract class Chart<ST extends Styler, S extends Series> implements ICha
   protected final ST styler;
   protected final ChartTitle<ST, S> chartTitle;
   protected final Map<String, S> seriesMap = new LinkedHashMap<>();
-  protected final ArrayList<ChartPart> annotations = new ArrayList<>();
 
   /** Chart Parts */
-  // TODO maybe move this to a secondary abstract class for inheritors with axes. Pie charts don't
-  // have an axis for example
-  protected AxisPair<?, ?> axisPair;
-
   protected Plot_<ST, S> plot;
   protected Legend_<ST, S> legend;
 
@@ -39,13 +28,6 @@ public abstract class Chart<ST extends Styler, S extends Series> implements ICha
 
   private int height;
   private String title = "";
-  // TODO maybe move these to a secondary abstract class for inheritors with axes. Pie charts don't
-  // have an axis for example
-  private String xAxisTitle = "";
-  private String yAxisTitle = "";
-
-  // TODO Does this belong here for all chart types?
-  private final Map<Integer, String> yAxisGroupTitleMap = new HashMap<>();
 
   /**
    * Constructor
@@ -60,7 +42,6 @@ public abstract class Chart<ST extends Styler, S extends Series> implements ICha
     this.height = height;
     this.styler = styler;
 
-    // TODO move this out??
     this.chartTitle = new ChartTitle<ST, S>(this);
   }
 
@@ -126,68 +107,6 @@ public abstract class Chart<ST extends Styler, S extends Series> implements ICha
     this.title = title;
   }
 
-  public String getXAxisTitle() {
-
-    return xAxisTitle;
-  }
-
-  public void setXAxisTitle(String xAxisTitle) {
-
-    this.xAxisTitle = xAxisTitle;
-  }
-
-  public String getYAxisTitle() {
-
-    // TODO just call the getYAxisGroupTitle method passing in the 0th index
-    return yAxisTitle;
-  }
-
-  public void setYAxisTitle(String yAxisTitle) {
-
-    this.yAxisTitle = yAxisTitle;
-  }
-
-  // TODO these related methods don't make sense for all chart types
-  public String getYAxisGroupTitle(int yAxisGroup) {
-
-    String title = yAxisGroupTitleMap.get(yAxisGroup);
-    if (title == null) {
-      return yAxisTitle;
-    }
-    return title;
-  }
-
-  public void setYAxisGroupTitle(int yAxisGroup, String yAxisTitle) {
-
-    yAxisGroupTitleMap.put(yAxisGroup, yAxisTitle);
-  }
-
-  public void addAnnotation(Annotation annotation) {
-
-    annotations.add(annotation);
-    annotation.init(this);
-  }
-
-  /**
-   * @Deprecated - use styler instead
-   *
-   * @param customFormattingFunction
-   */
-  public void setCustomXAxisTickLabelsFormatter(Function<Double, String> customFormattingFunction) {
-    AxesChartStyler axesChartStyler = (AxesChartStyler) (styler);
-    axesChartStyler.setxAxisTickLabelsFormattingFunction(customFormattingFunction);
-  }
-
-  /**
-   * @Deprecated - use styler instead
-   *
-   * @param customFormattingFunction
-   */
-  public void setCustomYAxisTickLabelsFormatter(Function<Double, String> customFormattingFunction) {
-    AxesChartStyler axesChartStyler = (AxesChartStyler) (styler);
-    axesChartStyler.setyAxisTickLabelsFormattingFunction(customFormattingFunction);
-  }
-
   /** Chart Parts Getters */
   ChartTitle<ST, S> getChartTitle() {
 
@@ -202,105 +121,6 @@ public abstract class Chart<ST extends Styler, S extends Series> implements ICha
   Plot_<ST, S> getPlot() {
 
     return plot;
-  }
-
-  Axis_X<?, ?> getXAxis() {
-
-    return axisPair.getXAxis();
-  }
-
-  Axis_Y<?, ?> getYAxis() {
-
-    return axisPair.getYAxis();
-  }
-
-  Axis_Y<?, ?> getYAxis(int yIndex) {
-
-    return axisPair.getYAxis(yIndex);
-  }
-
-  AxisPair<?, ?> getAxisPair() {
-
-    return axisPair;
-  }
-
-  Format getXAxisFormat() {
-    return axisPair.getXAxis().getAxisTickCalculator().getAxisFormat();
-  }
-
-  Format getYAxisFormat() {
-    return axisPair.getYAxis().getAxisTickCalculator().getAxisFormat();
-  }
-
-  // TODO investigate this
-  Format getYAxisFormat(String yAxisDecimalPattern) {
-    final Format format;
-    if (yAxisDecimalPattern != null) {
-      format = new DecimalFormat(yAxisDecimalPattern);
-    } else {
-      format = axisPair.getYAxis().getAxisTickCalculator().getAxisFormat();
-    }
-    return format;
-  }
-
-  public double getChartXFromCoordinate(int screenX) {
-
-    if (axisPair == null) {
-      return Double.NaN;
-    }
-    return axisPair.getXAxis().getChartValue(screenX);
-  }
-
-  public double getChartYFromCoordinate(int screenY) {
-
-    if (axisPair == null) {
-      return Double.NaN;
-    }
-    return axisPair.getYAxis().getChartValue(screenY);
-  }
-
-  public double getChartYFromCoordinate(int screenY, int yIndex) {
-
-    if (axisPair == null) {
-      return Double.NaN;
-    }
-    return axisPair.getYAxis(yIndex).getChartValue(screenY);
-  }
-
-  public double getScreenXFromChart(double xValue) {
-
-    if (axisPair == null) {
-      return Double.NaN;
-    }
-    return axisPair.getXAxis().getScreenValue(xValue);
-  }
-
-  public double getScreenYFromChart(double yValue) {
-
-    if (axisPair == null) {
-      return Double.NaN;
-    }
-    return axisPair.getYAxis().getScreenValue(yValue);
-  }
-
-  public double getScreenYFromChart(double yValue, int yIndex) {
-
-    if (axisPair == null) {
-      return Double.NaN;
-    }
-    return axisPair.getYAxis(yIndex).getScreenValue(yValue);
-  }
-
-  //  ArrayList<ChartPart> getAnnotations() {
-  //
-  //    return annotations;
-  //  }
-
-  // TODO remove public
-  public double getYAxisLeftWidth() {
-
-    java.awt.geom.Rectangle2D.Double bounds = getAxisPair().getLeftYAxisBounds();
-    return bounds.width + bounds.x;
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
@@ -11,12 +11,11 @@ import java.awt.geom.Rectangle2D;
 import org.knowm.xchart.OHLCSeries;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.internal.series.AxesChartSeriesNumerical;
-import org.knowm.xchart.style.AxesChartStyler;
 
 public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener {
 
   protected final XChartPanel<?> xChartPanel;
-  protected final Chart<? extends AxesChartStyler, ?> chart;
+  protected final AxesChart<?, ?> chart;
   protected Rectangle bounds;
 
   protected final ChartButton resetButton;
@@ -32,7 +31,7 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
    * @param resetString
    */
   public ChartZoom(
-      Chart<? extends AxesChartStyler, ?> chart,
+      AxesChart<?, ?> chart,
       XChartPanel<?> xChartPanel,
       String resetString) {
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
@@ -18,6 +18,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
     extends PlotContent_<ST, S> {
 
   private final ST boxPlotStyler;
+  private final AxesChart<ST, S> axesChart;
   private double yMax;
   private double yMin;
   private double xLeftMargin;
@@ -26,9 +27,10 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
   private double xOffset;
   private double yOffset;
 
-  PlotContent_Box(Chart<ST, S> chart) {
+  PlotContent_Box(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     boxPlotStyler = chart.getStyler();
   }
 
@@ -63,8 +65,8 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
         continue;
       }
 
-      yMin = chart.getYAxis(series.getYAxisGroup()).getMin();
-      yMax = chart.getYAxis(series.getYAxisGroup()).getMax();
+      yMin = axesChart.getYAxis(series.getYAxisGroup()).getMin();
+      yMax = axesChart.getYAxis(series.getYAxisGroup()).getMax();
 
       if (boxPlotStyler.isYAxisLogarithmic()) {
         yMin = Math.log10(yMin);
@@ -122,7 +124,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
                 series.getName()
                     + ":"
                     + System.lineSeparator()
-                    + chart.getYAxisFormat().format(yOrig));
+                    + axesChart.getYAxisFormat().format(yOrig));
           }
         } else if (chart.getStyler().getShowWithinAreaPoint()) {
 
@@ -137,7 +139,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
                 series.getName()
                     + ":"
                     + System.lineSeparator()
-                    + chart.getYAxisFormat().format(yOrig));
+                    + axesChart.getYAxisFormat().format(yOrig));
           }
         }
       }
@@ -255,19 +257,19 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
               + ":"
               + System.lineSeparator()
               + "upper: "
-              + chart.getYAxisFormat().format(boxPlotData.upper)
+              + axesChart.getYAxisFormat().format(boxPlotData.upper)
               + System.lineSeparator()
               + "q3: "
-              + chart.getYAxisFormat().format(boxPlotData.q3)
+              + axesChart.getYAxisFormat().format(boxPlotData.q3)
               + System.lineSeparator()
               + "median: "
-              + chart.getYAxisFormat().format(boxPlotData.median)
+              + axesChart.getYAxisFormat().format(boxPlotData.median)
               + System.lineSeparator()
               + "q1: "
-              + chart.getYAxisFormat().format(boxPlotData.q1)
+              + axesChart.getYAxisFormat().format(boxPlotData.q1)
               + System.lineSeparator()
               + "lower: "
-              + chart.getYAxisFormat().format(boxPlotData.lower));
+              + axesChart.getYAxisFormat().format(boxPlotData.lower));
     }
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
@@ -11,15 +11,17 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
     extends PlotContent_<ST, S> {
 
   private final ST stylerBubble;
+  private final AxesChart<ST, S> axesChart;
 
   /**
    * Constructor
    *
    * @param chart
    */
-  PlotContent_Bubble(Chart<ST, S> chart) {
+  PlotContent_Bubble(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     stylerBubble = chart.getStyler();
   }
 
@@ -34,8 +36,8 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
     double yTickSpace = stylerBubble.getPlotContentSize() * getBounds().getHeight();
     double yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
 
-    double xMin = chart.getXAxis().getMin();
-    double xMax = chart.getXAxis().getMax();
+    double xMin = axesChart.getXAxis().getMin();
+    double xMax = axesChart.getXAxis().getMax();
 
     // logarithmic
     if (stylerBubble.isXAxisLogarithmic()) {
@@ -50,8 +52,8 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
         continue;
       }
 
-      double yMin = chart.getYAxis(series.getYAxisGroup()).getMin();
-      double yMax = chart.getYAxis(series.getYAxisGroup()).getMax();
+      double yMin = axesChart.getYAxis(series.getYAxisGroup()).getMin();
+      double yMax = axesChart.getYAxis(series.getYAxisGroup()).getMax();
       if (stylerBubble.isYAxisLogarithmic()) {
         yMin = Math.log10(yMin);
         yMax = Math.log10(yMax);
@@ -137,8 +139,8 @@ public class PlotContent_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
                 xOffset,
                 yOffset,
                 0,
-                chart.getXAxisFormat().format(x),
-                chart.getYAxisFormat().format(yOrig));
+                axesChart.getXAxisFormat().format(x),
+                axesChart.getYAxisFormat().format(yOrig));
           }
         }
       }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -24,15 +24,17 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
     extends PlotContent_<ST, S> {
 
   private final ST stylerCategory;
+  private final AxesChart<ST, S> axesChart;
 
   /**
    * Constructor
    *
    * @param chart
    */
-  PlotContent_Category_Bar(Chart<ST, S> chart) {
+  PlotContent_Category_Bar(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     this.stylerCategory = chart.getStyler();
   }
 
@@ -50,8 +52,8 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
     // System.out.println("gridStep: " + gridStep);
 
     // Y-Axis
-    double yMin = chart.getYAxis().getMin();
-    double yMax = chart.getYAxis().getMax();
+    double yMin = axesChart.getYAxis().getMin();
+    double yMax = axesChart.getYAxis().getMax();
 
     // figure out the general form of the chart
     final int chartForm; // 1=positive, -1=negative, 0=span
@@ -82,8 +84,8 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
         continue;
       }
 
-      yMin = chart.getYAxis(series.getYAxisGroup()).getMin();
-      yMax = chart.getYAxis(series.getYAxisGroup()).getMax();
+      yMin = axesChart.getYAxis(series.getYAxisGroup()).getMin();
+      yMax = axesChart.getYAxis(series.getYAxisGroup()).getMax();
       if (stylerCategory.isYAxisLogarithmic()) {
         yMin = Math.log10(yMin);
         yMax = Math.log10(yMax);
@@ -532,8 +534,8 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
               xOffset,
               yPoint,
               barWidth,
-              chart.getXAxisFormat().format(nextCat),
-              chart.getYAxisFormat().format(yOrig));
+              axesChart.getXAxisFormat().format(nextCat),
+              axesChart.getYAxisFormat().format(yOrig));
         }
       }
 
@@ -625,7 +627,7 @@ public class PlotContent_Category_Bar<ST extends CategoryStyler, S extends Categ
       boolean isTotalAnnotations,
       Color seriesColor) {
 
-    String numberAsString = chart.getYAxisFormat().format(next);
+    String numberAsString = axesChart.getYAxisFormat().format(next);
 
     TextLayout textLayout =
         new TextLayout(

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
@@ -17,6 +17,7 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
     extends PlotContent_<ST, S> {
 
   private final ST heatMapStyler;
+  private final AxesChart<ST, S> axesChart;
   private final DecimalFormat df = new DecimalFormat("");
 
   /**
@@ -24,9 +25,10 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
    *
    * @param chart
    */
-  PlotContent_HeatMap(Chart<ST, S> chart) {
+  PlotContent_HeatMap(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     heatMapStyler = chart.getStyler();
   }
 
@@ -103,9 +105,9 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
             0,
             series.getName()
                 + ": "
-                + chart.getXAxisFormat().format(xData.get(x))
+                + axesChart.getXAxisFormat().format(xData.get(x))
                 + ", "
-                + chart.getYAxisFormat().format(yData.get(y))
+                + axesChart.getYAxisFormat().format(yData.get(y))
                 + ", "
                 + df.format(numbers[2]));
       }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HorizontalBar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HorizontalBar.java
@@ -14,15 +14,17 @@ public class PlotContent_HorizontalBar<
     extends PlotContent_<ST, S> {
 
   private final ST styler;
+  private final AxesChart<ST, S> axesChart;
 
   /**
    * Constructor
    *
    * @param chart
    */
-  PlotContent_HorizontalBar(Chart<ST, S> chart) {
+  PlotContent_HorizontalBar(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     this.styler = chart.getStyler();
   }
 
@@ -40,8 +42,8 @@ public class PlotContent_HorizontalBar<
     // System.out.println("gridStep: " + gridStep);
 
     // Y-Axis
-    double xMin = chart.getXAxis().getMin();
-    double xMax = chart.getXAxis().getMax();
+    double xMin = axesChart.getXAxis().getMin();
+    double xMax = axesChart.getXAxis().getMax();
 
     // figure out the general form of the chart
     final int chartForm; // 1=positive, -1=negative, 0=span
@@ -69,8 +71,8 @@ public class PlotContent_HorizontalBar<
         continue;
       }
 
-      xMin = chart.getXAxis().getMin();
-      xMax = chart.getXAxis().getMax();
+      xMin = axesChart.getXAxis().getMin();
+      xMax = axesChart.getXAxis().getMax();
       if (styler.isXAxisLogarithmic()) {
         xMin = Math.log10(xMin);
         xMax = Math.log10(xMax);
@@ -187,8 +189,8 @@ public class PlotContent_HorizontalBar<
               xPoint,
               yOffset,
               barHeight,
-              chart.getXAxisFormat().format(xOrig),
-              chart.getYAxisFormat().format(nextCat));
+              axesChart.getXAxisFormat().format(xOrig),
+              axesChart.getYAxisFormat().format(nextCat));
         }
       }
 
@@ -205,7 +207,7 @@ public class PlotContent_HorizontalBar<
       double barHeight,
       Color seriesColor) {
 
-    String numberAsString = chart.getXAxisFormat().format(next);
+    String numberAsString = axesChart.getXAxisFormat().format(next);
 
     TextLayout textLayout =
         new TextLayout(

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_OHLC.java
@@ -15,15 +15,17 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
     extends PlotContent_<ST, S> {
 
   private final ST ohlcStyler;
+  private final AxesChart<ST, S> axesChart;
 
   /**
    * Constructor
    *
    * @param chart
    */
-  PlotContent_OHLC(Chart<ST, S> chart) {
+  PlotContent_OHLC(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     ohlcStyler = chart.getStyler();
   }
 
@@ -38,8 +40,8 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
     double yTickSpace = ohlcStyler.getPlotContentSize() * getBounds().getHeight();
     double yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
 
-    double xMin = chart.getXAxis().getMin();
-    double xMax = chart.getXAxis().getMax();
+    double xMin = axesChart.getXAxis().getMin();
+    double xMax = axesChart.getXAxis().getMax();
 
     // get ymax and ymin later because it depends on what yaxisgroup it belongs to.
     double yMin;
@@ -62,8 +64,8 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
         continue;
       }
 
-      yMin = chart.getYAxis(series.getYAxisGroup()).getMin();
-      yMax = chart.getYAxis(series.getYAxisGroup()).getMax();
+      yMin = axesChart.getYAxis(series.getYAxisGroup()).getMin();
+      yMax = axesChart.getYAxis(series.getYAxisGroup()).getMax();
       if (ohlcStyler.isYAxisLogarithmic()) {
         yMin = Math.log10(yMin);
         yMax = Math.log10(yMax);
@@ -143,8 +145,8 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
             interactionData.addToolTip(
                 xOffset,
                 yOffset,
-                chart.getXAxisFormat().format(x),
-                chart.getYAxisFormat(series.getYAxisDecimalPattern()).format(yOrig));
+                axesChart.getXAxisFormat().format(x),
+                axesChart.getYAxisFormat(series.getYAxisDecimalPattern()).format(yOrig));
           }
         }
       } else {
@@ -304,24 +306,24 @@ public class PlotContent_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
 
             StringBuilder sb = new StringBuilder();
             if (series.getVolumeData() != null) {
-              sb.append(chart.getXAxisFormat().format(x));
+              sb.append(axesChart.getXAxisFormat().format(x));
               sb.append(System.lineSeparator()).append("Volume: " + series.getVolumeData()[i]);
               sb.append(System.lineSeparator()).append(" ").append(System.lineSeparator());
             }
-            sb.append(chart.getXAxisFormat().format(x));
+            sb.append(axesChart.getXAxisFormat().format(x));
             sb.append(System.lineSeparator()).append(series.getName()).append(":");
             sb.append(System.lineSeparator())
                 .append("open: ")
-                .append(chart.getYAxisFormat().format(openOrig));
+                .append(axesChart.getYAxisFormat().format(openOrig));
             sb.append(System.lineSeparator())
                 .append("close: ")
-                .append(chart.getYAxisFormat().format(closeOrig));
+                .append(axesChart.getYAxisFormat().format(closeOrig));
             sb.append(System.lineSeparator())
                 .append("low: ")
-                .append(chart.getYAxisFormat().format(lowOrig));
+                .append(axesChart.getYAxisFormat().format(lowOrig));
             sb.append(System.lineSeparator())
                 .append("high: ")
-                .append(chart.getYAxisFormat().format(highOrig));
+                .append(axesChart.getYAxisFormat().format(highOrig));
             interactionData.addToolTip(toolTipArea, xOffset, highOffset, 0, sb.toString());
           }
         }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -14,15 +14,17 @@ import org.knowm.xchart.style.lines.SeriesLines;
 public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends PlotContent_<ST, S> {
 
   private final ST xyStyler;
+  private final AxesChart<ST, S> axesChart;
 
   /**
    * Constructor
    *
    * @param chart
    */
-  PlotContent_XY(Chart<ST, S> chart) {
+  PlotContent_XY(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     xyStyler = chart.getStyler();
   }
 
@@ -37,8 +39,8 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
     double yTickSpace = xyStyler.getPlotContentSize() * getBounds().getHeight();
     double yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
 
-    double xMin = chart.getXAxis().getMin();
-    double xMax = chart.getXAxis().getMax();
+    double xMin = axesChart.getXAxis().getMin();
+    double xMax = axesChart.getXAxis().getMax();
 
     Line2D.Double line = new Line2D.Double();
 
@@ -55,7 +57,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
       if (!series.isEnabled()) {
         continue;
       }
-      Axis_Y<?, ?> yAxis = chart.getYAxis(series.getYAxisGroup());
+      Axis_Y<?, ?> yAxis = axesChart.getYAxis(series.getYAxisGroup());
       double yMin = yAxis.getMin();
       double yMax = yAxis.getMax();
       if (xyStyler.isYAxisLogarithmic()) {
@@ -302,20 +304,20 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
           interactionData.addToolTip(
               xOffset,
               yOffset,
-              chart.getXAxisFormat().format(x),
-              chart.getYAxisFormat(series.getYAxisDecimalPattern()).format(yOrig));
+              axesChart.getXAxisFormat().format(x),
+              axesChart.getYAxisFormat(series.getYAxisDecimalPattern()).format(yOrig));
         }
 
         if (interactionData != null) {
           Format xFormat;
           Format yFormat;
           if (xyStyler.getCustomCursorXDataFormattingFunction() == null) {
-            xFormat = chart.getXAxisFormat();
+            xFormat = axesChart.getXAxisFormat();
           } else {
             xFormat = new Formatter_Custom(xyStyler.getCustomCursorXDataFormattingFunction());
           }
           if (xyStyler.getCustomCursorYDataFormattingFunction() == null) {
-            yFormat = chart.getYAxisFormat(series.getYAxisDecimalPattern());
+            yFormat = axesChart.getYAxisFormat(series.getYAxisDecimalPattern());
           } else {
             yFormat = new Formatter_Custom(xyStyler.getCustomCursorYDataFormattingFunction());
           }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_AxesChart.java
@@ -6,23 +6,25 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.util.List;
 
-import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.internal.series.AxesChartSeries;
 import org.knowm.xchart.style.AxesChartStyler;
 
 /** Draws the plot background, the plot border and the horizontal and vertical grid lines */
-public class PlotSurface_AxesChart<ST extends AxesChartStyler, S extends Series>
+public class PlotSurface_AxesChart<ST extends AxesChartStyler, S extends AxesChartSeries>
     extends PlotSurface_<ST, S> {
 
   private final ST stylerAxesChart;
+  private final AxesChart<ST, S> axesChart;
 
   /**
    * Constructor
    *
    * @param chart
    */
-  PlotSurface_AxesChart(Chart<ST, S> chart) {
+  PlotSurface_AxesChart(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     this.stylerAxesChart = chart.getStyler();
   }
 
@@ -43,7 +45,7 @@ public class PlotSurface_AxesChart<ST extends AxesChartStyler, S extends Series>
     if (stylerAxesChart.isPlotGridHorizontalLinesVisible()) {
 
       List<Double> yAxisTickLocations =
-          chart.getAxisPair().getLeftGridlineMasterAxis().getAxisTickCalculator().getTickLocations();
+          axesChart.getAxisPair().getLeftGridlineMasterAxis().getAxisTickCalculator().getTickLocations();
       for (Double yAxisTickLocation : yAxisTickLocations) {
         double yOffset = bounds.getY() + bounds.getHeight() - yAxisTickLocation;
 
@@ -73,7 +75,7 @@ public class PlotSurface_AxesChart<ST extends AxesChartStyler, S extends Series>
 
       // draw left side
       List<Double> yAxisTickLocations =
-          chart.getAxisPair().getLeftGridlineMasterAxis().getAxisTickCalculator().getTickLocations();
+          axesChart.getAxisPair().getLeftGridlineMasterAxis().getAxisTickCalculator().getTickLocations();
       for (Double yAxisTickLocation : yAxisTickLocations) {
         double yOffset = bounds.getY() + bounds.getHeight() - yAxisTickLocation;
 
@@ -94,7 +96,7 @@ public class PlotSurface_AxesChart<ST extends AxesChartStyler, S extends Series>
 
       // draw right side
       yAxisTickLocations =
-          chart
+          axesChart
               .getAxisPair()
               .getRightGridlineMasterAxis()
               .getAxisTickCalculator()
@@ -123,7 +125,7 @@ public class PlotSurface_AxesChart<ST extends AxesChartStyler, S extends Series>
     if (stylerAxesChart.isPlotGridVerticalLinesVisible()
         || stylerAxesChart.isPlotTicksMarksVisible()) {
 
-      List<Double> xAxisTickLocations = chart.getXAxis().getAxisTickCalculator().getTickLocations();
+      List<Double> xAxisTickLocations = axesChart.getXAxis().getAxisTickCalculator().getTickLocations();
       for (Double xAxisTickLocation : xAxisTickLocations) {
 
         double tickLocation = xAxisTickLocation;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_AxesChart.java
@@ -2,27 +2,31 @@ package org.knowm.xchart.internal.chartpart;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
-import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.internal.series.AxesChartSeries;
 import org.knowm.xchart.style.AxesChartStyler;
 
-public class Plot_AxesChart<ST extends AxesChartStyler, S extends Series> extends Plot_<ST, S> {
+public class Plot_AxesChart<ST extends AxesChartStyler, S extends AxesChartSeries>
+    extends Plot_<ST, S> {
+
+  private final AxesChart<ST, S> axesChart;
 
   /**
    * Constructor
    *
    * @param chart
    */
-  Plot_AxesChart(Chart<ST, S> chart) {
+  Plot_AxesChart(AxesChart<ST, S> chart) {
 
     super(chart);
+    this.axesChart = chart;
     this.plotSurface = new PlotSurface_AxesChart<ST, S>(chart);
   }
 
   @Override
   public void paint(Graphics2D g) {
 
-    Rectangle2D yAxisBounds = chart.getAxisPair().getLeftYAxisBounds();
-    Rectangle2D xAxisBounds = chart.getXAxis().getBounds();
+    Rectangle2D yAxisBounds = axesChart.getAxisPair().getLeftYAxisBounds();
+    Rectangle2D xAxisBounds = axesChart.getXAxis().getBounds();
 
     // calculate bounds
     double xOffset = xAxisBounds.getX();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Box.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Box.java
@@ -5,7 +5,7 @@ import org.knowm.xchart.style.BoxStyler;
 
 public class Plot_Box<ST extends BoxStyler, S extends BoxSeries> extends Plot_AxesChart<ST, S> {
 
-  public Plot_Box(Chart<ST, S> chart) {
+  public Plot_Box(AxesChart<ST, S> chart) {
 
     super(chart);
     this.plotContent = new PlotContent_Box<ST, S>(chart);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Bubble.java
@@ -11,7 +11,7 @@ public class Plot_Bubble<ST extends BubbleStyler, S extends BubbleSeries>
    *
    * @param chart
    */
-  public Plot_Bubble(Chart<ST, S> chart) {
+  public Plot_Bubble(AxesChart<ST, S> chart) {
 
     super(chart);
     this.plotContent = new PlotContent_Bubble<ST, S>(chart);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Category.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Category.java
@@ -11,7 +11,7 @@ public class Plot_Category<ST extends CategoryStyler, S extends CategorySeries>
    *
    * @param chart
    */
-  public Plot_Category(Chart<ST, S> chart) {
+  public Plot_Category(AxesChart<ST, S> chart) {
 
     super(chart);
     this.plotContent = new PlotContent_Category_Bar<ST, S>(chart);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_HeatMap.java
@@ -11,7 +11,7 @@ public class Plot_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeries>
    *
    * @param chart
    */
-  public Plot_HeatMap(Chart<ST, S> chart) {
+  public Plot_HeatMap(AxesChart<ST, S> chart) {
 
     super(chart);
     this.plotContent = new PlotContent_HeatMap<ST, S>(chart);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_HorizontalBar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_HorizontalBar.java
@@ -11,7 +11,7 @@ public class Plot_HorizontalBar<ST extends HorizontalBarStyler, S extends Horizo
    *
    * @param chart
    */
-  public Plot_HorizontalBar(Chart<ST, S> chart) {
+  public Plot_HorizontalBar(AxesChart<ST, S> chart) {
 
     super(chart);
     this.plotContent = new PlotContent_HorizontalBar<ST, S>(chart);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_OHLC.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_OHLC.java
@@ -11,7 +11,7 @@ public class Plot_OHLC<ST extends AxesChartStyler, S extends OHLCSeries>
    *
    * @param chart
    */
-  public Plot_OHLC(Chart<ST, S> chart) {
+  public Plot_OHLC(AxesChart<ST, S> chart) {
 
     super(chart);
     this.plotContent = new PlotContent_OHLC<ST, S>(chart);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_XY.java
@@ -10,7 +10,7 @@ public class Plot_XY<ST extends XYStyler, S extends XYSeries> extends Plot_AxesC
    *
    * @param chart
    */
-  public Plot_XY(Chart<ST, S> chart) {
+  public Plot_XY(AxesChart<ST, S> chart) {
 
     super(chart);
     this.plotContent = new PlotContent_XY<ST, S>(chart);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/YAxisGroupPainter.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/YAxisGroupPainter.java
@@ -23,7 +23,7 @@ import org.knowm.xchart.style.Styler.YAxisPosition;
  */
 class YAxisGroupPainter<ST extends AxesChartStyler, S extends AxesChartSeries> {
 
-  private final Chart<ST, S> chart;
+  private final AxesChart<ST, S> chart;
   private final TreeMap<Integer, Axis_Y<ST, S>> yAxisMap;
 
   // Results populated by paintLeft() / paintRight()
@@ -35,7 +35,7 @@ class YAxisGroupPainter<ST extends AxesChartStyler, S extends AxesChartSeries> {
   /** The adjusted x position used as the left origin; set during paintLeft(). */
   private double leftStartUsed;
 
-  YAxisGroupPainter(Chart<ST, S> chart, TreeMap<Integer, Axis_Y<ST, S>> yAxisMap) {
+  YAxisGroupPainter(AxesChart<ST, S> chart, TreeMap<Integer, Axis_Y<ST, S>> yAxisMap) {
 
     this.chart = chart;
     this.yAxisMap = yAxisMap;


### PR DESCRIPTION
## Summary

Implements Phase 4 of the XChart refactor plan: introduce `AxesChart<ST extends AxesChartStyler, S extends AxesChartSeries>` as a new abstract class that sits between `Chart` and the 7 axes-based chart types.

## Problem

`Chart.java` (the base of every chart type) previously held axis-specific state that only makes sense for charts with axes:
- Fields: `axisPair`, `annotations`, `xAxisTitle`, `yAxisTitle`, `yAxisGroupTitleMap`
- 8+ axis methods each guarded by `if (axisPair == null)` null guards
- 4 TODO comments acknowledging the design problem

`PieChart`, `RadarChart`, and `DialChart` inherited all of this and never used it.

## New Hierarchy

```
Chart<ST extends Styler, S extends Series>
  │
  ├── AxesChart<ST extends AxesChartStyler, S extends AxesChartSeries>  ← NEW
  │     ├── XYChart
  │     ├── CategoryChart
  │     ├── BubbleChart
  │     ├── BoxChart
  │     ├── HeatMapChart
  │     ├── HorizontalBarChart
  │     └── OHLCChart
  │
  ├── PieChart        ← extends Chart directly (unchanged)
  ├── RadarChart      ← extends Chart directly (unchanged)
  └── DialChart       ← extends Chart directly (unchanged)
```

## Changes

### New file
- `AxesChart.java` — abstract class holding all axis state and methods moved from `Chart`

### Modified files
- **`Chart.java`** — stripped of all axis fields/methods; notably smaller
- **7 axes chart types** — `extends Chart<ST,S>` → `extends AxesChart<ST,S>`
- **`AnnotationImage`, `AnnotationTextPanel`** — `init()` parameter updated to `AxesChart<?,?>`
- **`PieChart`, `DialChart`, `RadarChart`** — removed `annotations.forEach()` call (these chart types don't support axis-based annotations)
- **All axis rendering classes** (`AxisPair`, `Axis_`, `Axis_X`, `Axis_Y`, `AxisTitle`, `AxisTick`, etc.) — `Chart<ST,S>` → `AxesChart<ST,S>`
- **All `PlotContent_*` axes classes** — added `axesChart` typed field, replaced axis method calls
- **`Plot_AxesChart`, `PlotSurface_AxesChart`** — tightened generic bounds to `AxesChartSeries`
- **`ChartZoom`** — `Chart<? extends AxesChartStyler, ?>` → `AxesChart<?,?>`
- **`XChartPanel`** — cast updated for `ChartZoom` construction

## Verification

- ✅ `mvn test -pl xchart` — 73 tests, 0 failures
- ✅ `mvn fmt:check -pl xchart` — no formatting violations