### PR TITLE
docs: update REFACTOR_PLAN.md with final refactor status

### DIFF
--- a/.github/REFACTOR_PLAN.md
+++ b/.github/REFACTOR_PLAN.md
@@ -31,7 +31,7 @@ It is kept for historical reference and to explain decisions made along the way.
 | Item | Notes |
 |------|-------|
 | Series inheritance chain | The chain is currently 5 levels deep. Could be explored in a future refactor, but requires careful analysis of downstream impact. |
-| Fluent setter uniformity | Some series setters return `this` for chaining; others do not. A minor polish item that can be addressed incrementally. |
+| Fluent setter uniformity | ✅ Done — all series setters now return `this` for chaining (PRs: `BubbleSeries`, `DialSeries`, `PieSeries`, `RadarSeries`, `XYSeries`). |
 | Zoom data duplication | `filterXByValue` operates on non-contiguous ranges. A clean `DataRange` abstraction would be the right fix but requires more invasive changes across the rendering pipeline. |
 
 ---

--- a/.github/REFACTOR_PLAN.md
+++ b/.github/REFACTOR_PLAN.md
@@ -1,0 +1,39 @@
+# XChart Refactor Plan — Final Status
+
+This document tracks the refactor initiative that ran across PRs #957–#961.
+It is kept for historical reference and to explain decisions made along the way.
+
+---
+
+## Completed Work
+
+| PR | Phase | Summary |
+|----|-------|---------|
+| [#957](https://github.com/knowm/XChart/pull/957) | Phase 1 — Clean-up | Fixed typos in `BoxChart`; removed dead code; renamed `AxesChartSeriesNumericalNoErrorBars` → `AxesChartSeriesNumerical` |
+| [#958](https://github.com/knowm/XChart/pull/958) | Phase 2 — Optional render style | Replaced null sentinels with `Optional<RenderStyle>` in all series classes; extracted `SeriesMinMaxCalculator` helper with unit tests |
+| [#959](https://github.com/knowm/XChart/pull/959) | Theme API | Added `.theme(Theme)` fluent method to `ChartBuilder`; deprecated `setTheme()` on all stylers; updated `ThemeChart04` demo |
+| [#960](https://github.com/knowm/XChart/pull/960) | Phase 4 — AxesChart abstraction | Introduced `AxesChart` abstract subclass; moved all axis state out of the base `Chart` class; removed all `axisPair == null` null guards; eliminated unchecked casts |
+| [#961](https://github.com/knowm/XChart/pull/961) | Phase 6 — PlotContent extraction | Renamed `PlotContent_Category_Bar` → `PlotContent_Category`; extracted `computeBarDimensions`, `processSteppedBarDataPoint`, `finalizeSteppedBar` from `doPaint()`; extracted `paintErrorBar()` from `PlotContent_XY` |
+
+---
+
+## Deliberately Skipped
+
+| Phase | Reason |
+|-------|--------|
+| Phase 3 — Styler decomposition | The monolithic styler is intentional. IDE autocomplete discoverability is a core UX feature of the library; sub-stylers would fragment that experience and make the API harder to discover. |
+| Phase 5 — `addSeries` overload reduction | The primitive array overloads (`double[]`, `float[]`, `int[]`) are deliberate convenience API. They lower the barrier to entry for new users and are not a problem to maintain. |
+
+---
+
+## Open Items (future work)
+
+| Item | Notes |
+|------|-------|
+| Series inheritance chain | The chain is currently 5 levels deep. Could be explored in a future refactor, but requires careful analysis of downstream impact. |
+| Fluent setter uniformity | Some series setters return `this` for chaining; others do not. A minor polish item that can be addressed incrementally. |
+| Zoom data duplication | `filterXByValue` operates on non-contiguous ranges. A clean `DataRange` abstraction would be the right fix but requires more invasive changes across the rendering pipeline. |
+
+---
+
+_Last updated: 2026-05-29_

--- a/xchart/src/main/java/org/knowm/xchart/BubbleSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/BubbleSeries.java
@@ -28,9 +28,10 @@ public class BubbleSeries extends NoMarkersSeries {
     return bubbleSeriesRenderStyle;
   }
 
-  public void setBubbleSeriesRenderStyle(BubbleSeriesRenderStyle bubbleSeriesRenderStyle) {
+  public BubbleSeries setBubbleSeriesRenderStyle(BubbleSeriesRenderStyle bubbleSeriesRenderStyle) {
 
     this.bubbleSeriesRenderStyle = Optional.ofNullable(bubbleSeriesRenderStyle);
+    return this;
   }
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/DialSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/DialSeries.java
@@ -24,9 +24,10 @@ public class DialSeries extends Series {
     return value;
   }
 
-  public void setValue(double value) {
+  public DialSeries setValue(double value) {
 
     this.value = value;
+    return this;
   }
 
   public String getLabel() {

--- a/xchart/src/main/java/org/knowm/xchart/PieSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/PieSeries.java
@@ -48,9 +48,10 @@ public class PieSeries extends Series {
     return value;
   }
 
-  public void setValue(Number value) {
+  public PieSeries setValue(Number value) {
 
     this.value = value;
+    return this;
   }
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/RadarSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/RadarSeries.java
@@ -44,9 +44,10 @@ public class RadarSeries extends MarkerSeries {
     return values;
   }
 
-  public void setValues(double[] values) {
+  public RadarSeries setValues(double[] values) {
 
     this.values = values;
+    return this;
   }
 
   public String[] getTooltipOverrides() {
@@ -153,8 +154,9 @@ public class RadarSeries extends MarkerSeries {
     return LegendRenderType.Line;
   }
 
-  public void setTooltipOverrides(String[] tooltipOverrides) {
+  public RadarSeries setTooltipOverrides(String[] tooltipOverrides) {
 
     this.tooltipOverrides = tooltipOverrides;
+    return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/XYSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYSeries.java
@@ -49,8 +49,9 @@ public class XYSeries extends AxesChartSeriesNumerical {
     return smooth;
   }
 
-  public void setSmooth(boolean smooth) {
+  public XYSeries setSmooth(boolean smooth) {
     this.smooth = smooth;
+    return this;
   }
 
   public enum XYSeriesRenderStyle implements RenderableSeries {


### PR DESCRIPTION
Adds `.github/REFACTOR_PLAN.md` documenting the outcome of the refactor initiative that ran across PRs #957–#961, and completes the "Fluent setter uniformity" open item.

### REFACTOR_PLAN.md
- **Completed** — PRs #957–#961 with a one-line summary of each phase
- **Deliberately skipped** — Phase 3 (Styler decomposition) and Phase 5 (`addSeries` overload reduction), with rationale for each decision
- **Open items** — Series inheritance depth, fluent setter uniformity (now done), and zoom data duplication

### Fluent setter uniformity
Six series setters that returned `void` have been updated to return `this` for method chaining:

| Class | Method |
|-------|--------|
| `BubbleSeries` | `setBubbleSeriesRenderStyle` |
| `DialSeries` | `setValue` |
| `PieSeries` | `setValue` |
| `RadarSeries` | `setValues` |
| `RadarSeries` | `setTooltipOverrides` |
| `XYSeries` | `setSmooth` |

All existing tests pass.