### PR TITLE
Move locale to base Styler; fix locale-aware number formatting in PieChart

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
@@ -25,7 +25,6 @@ import org.knowm.xchart.style.Styler;
  * uses this to reset the zoom function. When it is clicked it fires its actionPerformed action and
  * whoever is listening to it can react to it.
  */
-// TODO tie this to the styler properties
 public class ChartButton extends MouseAdapter implements ChartPart {
 
   private final Styler styler;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -6,6 +6,7 @@ import java.awt.font.TextLayout;
 import java.awt.geom.*;
 import java.awt.geom.Arc2D.Double;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Map;
 import org.knowm.xchart.PieSeries;
 import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
@@ -17,7 +18,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
     extends PlotContent_<ST, S> {
 
   private final ST pieStyler;
-  private final DecimalFormat df = new DecimalFormat("#.0");
+  private final DecimalFormat df;
 
   /**
    * Constructor
@@ -28,6 +29,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
 
     super(chart);
     pieStyler = chart.getStyler();
+    df = new DecimalFormat("#.0", new DecimalFormatSymbols(pieStyler.getLocale()));
   }
 
   // TODO get rid of this

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -6,7 +6,6 @@ import java.awt.Font;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Function;
@@ -54,7 +53,6 @@ public abstract class AxesChartStyler extends Styler {
   private boolean isErrorBarsColorSeriesColor;
 
   // Formatting ////////////////////////////////
-  private Locale locale;
   private TimeZone timezone;
   private String datePattern;
   private String xAxisDecimalPattern;
@@ -138,7 +136,6 @@ public abstract class AxesChartStyler extends Styler {
     this.isErrorBarsColorSeriesColor = theme.isErrorBarsColorSeriesColor();
 
     // Formatting ////////////////////////////////
-    this.locale = Locale.getDefault();
     this.timezone = TimeZone.getDefault();
     this.datePattern = null; // if not null, this override pattern will be used
     this.xAxisDecimalPattern = null;
@@ -693,22 +690,6 @@ public abstract class AxesChartStyler extends Styler {
   }
 
   // Formatting ////////////////////////////////
-
-  public Locale getLocale() {
-
-    return locale;
-  }
-
-  /**
-   * Set the locale to use for rendering the chart
-   *
-   * @param locale - the locale to use when formatting Strings and dates for the axis tick labels
-   */
-  public AxesChartStyler setLocale(Locale locale) {
-
-    this.locale = locale;
-    return this;
-  }
 
   public TimeZone getTimezone() {
 

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -4,6 +4,7 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Font;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.knowm.xchart.ToolTipType;
@@ -89,6 +90,7 @@ public abstract class Styler {
   private boolean antiAlias = true;
   private boolean textAntiAlias = true;
   private String decimalPattern;
+  private Locale locale;
   // TODO I don't think this should be in styler directly?
   private final HashMap<Integer, YAxisPosition> yAxisAlignmentMap = new HashMap<>();
   private int yAxisLeftWidthHint;
@@ -173,6 +175,7 @@ public abstract class Styler {
 
     // Formatting
     decimalPattern = null;
+    locale = Locale.getDefault();
 
     // Line, Scatter, Area, Radar Charts ///////////////////////////////
     this.markerSize = theme.getMarkerSize();
@@ -845,6 +848,22 @@ public abstract class Styler {
   public Styler setDecimalPattern(String decimalPattern) {
 
     this.decimalPattern = decimalPattern;
+    return this;
+  }
+
+  public Locale getLocale() {
+
+    return locale;
+  }
+
+  /**
+   * Set the locale to use for number and date formatting on the chart
+   *
+   * @param locale the locale to use
+   */
+  public Styler setLocale(Locale locale) {
+
+    this.locale = locale;
     return this;
   }
 


### PR DESCRIPTION
Previously, `locale` lived only in `AxesChartStyler`, making it inaccessible to `PieStyler` (which extends `Styler` directly). This meant pie slice labels and tooltips always used the system default locale for decimal separators -- no way to override for non-English locales.

**What changed:**

- `locale` field, `getLocale()`, and `setLocale()` moved from `AxesChartStyler` up to the base `Styler` class. All chart types now inherit locale support.
- `PlotContent_Pie` constructs its `DecimalFormat` using `DecimalFormatSymbols` derived from `pieStyler.getLocale()`, so labels like percentages and values respect the configured locale.
- Removed a stale `// TODO tie this to the styler properties` comment from `ChartButton` (Swing component -- deliberately not styled via `Styler`).

Users can now do:
```java
pieChart.getStyler().setLocale(Locale.GERMAN);
```
...and get comma decimal separators in pie labels.

Closes #868