### PR TITLE
Eliminate boxing in AxesChartSeriesCategory: store yData/extraValues as double[]

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue879.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue879.java
@@ -1,55 +1,90 @@
 package org.knowm.xchart.standalone.issues;
 
-import org.knowm.xchart.CategoryChart;
-import org.knowm.xchart.CategoryChartBuilder;
-import org.knowm.xchart.SwingWrapper;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.style.Styler;
 
 /**
- * Demonstrates memory-efficient primitive-array usage for CategoryChart (issue #879).
+ * Demonstrates memory-efficient primitive-array usage for XYChart (issue #879).
  *
  * <p>The root cause of the perceived high memory usage in issue #879 was two-fold:
  *
  * <ol>
  *   <li>JDK 8's Parallel GC is less aggressive at reclaiming heap than JDK 21's G1GC. Adding
  *       {@code -XX:+UseG1GC} on JDK 8 restores comparable behaviour. This is not an XChart bug.
- *   <li>Passing {@code double[]} / {@code int[]} to {@link CategoryChart#addSeries} previously
- *       boxed every value into a {@code List<Double>}, consuming ~3× more memory per element (24
- *       bytes vs 8 bytes for a primitive double). This has been fixed: the data is now stored
- *       internally as {@code double[]}, eliminating the boxing overhead on both the add and update
- *       paths.
+ *   <li>Passing {@code double[]} / {@code int[]} to {@link
+ *       org.knowm.xchart.CategoryChart#addSeries} previously boxed every value into a {@code
+ *       List<Double>}, consuming ~3× more memory per element (24 bytes vs 8 bytes for a primitive
+ *       double). This has been fixed: data is now stored internally as {@code double[]}.
  * </ol>
+ *
+ * <p>Click "Add New Data" repeatedly while monitoring heap usage with VisualVM to verify behaviour.
  */
 public class TestForIssue879 {
 
+  public static final int NUM_DATA_POINTS = 18_000;
+
   public static void main(String[] args) {
 
-    new SwingWrapper<>(getChart()).displayChart();
+    double[] xData = new double[NUM_DATA_POINTS];
+    double[] yData = new double[NUM_DATA_POINTS];
+
+    long timestamp = System.currentTimeMillis();
+    for (int i = 0; i < NUM_DATA_POINTS; i++) {
+      xData[i] = timestamp + i;
+      yData[i] = Math.random() * 100;
+    }
+
+    XYChart chart = getChart(xData, yData);
+    XChartPanel<XYChart> chartPanel = new XChartPanel<>(chart);
+
+    JButton button = new JButton("Add New Data");
+    button.addActionListener(
+        e -> {
+          Color randomColor =
+              new Color(
+                  (int) (Math.random() * 255),
+                  (int) (Math.random() * 255),
+                  (int) (Math.random() * 255));
+          chart.getSeriesMap().get("mockData").setMarkerColor(randomColor);
+          chart.getSeriesMap().get("mockData").setLineColor(randomColor);
+          chart.getSeriesMap().get("mockData").setFillColor(randomColor);
+          SwingUtilities.invokeLater(
+              () -> {
+                chart.updateXYSeries("mockData", xData, yData, null);
+                chartPanel.repaint();
+              });
+        });
+
+    JFrame frame = new JFrame("Issue #879 — XYChart memory test");
+    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    frame.setLayout(new BorderLayout());
+    frame.add(button, BorderLayout.SOUTH);
+    frame.add(chartPanel, BorderLayout.CENTER);
+    frame.pack();
+    frame.setVisible(true);
   }
 
   /** Constructs and returns the chart without launching a window (headless-safe). */
-  public static CategoryChart getChart() {
+  public static XYChart getChart(double[] xData, double[] yData) {
 
-    int numPoints = 18_000;
-    double[] xData = new double[numPoints];
-    double[] yData = new double[numPoints];
-    for (int i = 0; i < numPoints; i++) {
-      xData[i] = i;
-      yData[i] = Math.sin(i * 0.001) * 100;
-    }
-
-    CategoryChart chart =
-        new CategoryChartBuilder()
+    XYChart chart =
+        new XYChartBuilder()
             .width(800)
             .height(600)
-            .title("Issue #879 — CategoryChart with 18 000 points (double[] path, no boxing)")
-            .xAxisTitle("Index")
+            .title("Issue #879 — XYChart with 18 000 points (double[] path, no boxing)")
+            .xAxisTitle("Time (ms)")
             .yAxisTitle("Value")
             .theme(Styler.ChartTheme.GGPlot2)
             .build();
 
-    // double[] passed directly — stored as primitive double[] internally, no boxing
-    chart.addSeries("series1", xData, yData);
+    chart.addSeries("mockData", xData, yData);
 
     return chart;
   }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue879.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue879.java
@@ -8,6 +8,7 @@ import javax.swing.SwingUtilities;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries;
 import org.knowm.xchart.style.Styler;
 
 /**
@@ -42,6 +43,7 @@ public class TestForIssue879 {
     }
 
     XYChart chart = getChart(xData, yData);
+    XYSeries series = (XYSeries) chart.getSeriesCollection().iterator().next();
     XChartPanel<XYChart> chartPanel = new XChartPanel<>(chart);
 
     JButton button = new JButton("Add New Data");
@@ -52,9 +54,9 @@ public class TestForIssue879 {
                   (int) (Math.random() * 255),
                   (int) (Math.random() * 255),
                   (int) (Math.random() * 255));
-          chart.getSeriesMap().get("mockData").setMarkerColor(randomColor);
-          chart.getSeriesMap().get("mockData").setLineColor(randomColor);
-          chart.getSeriesMap().get("mockData").setFillColor(randomColor);
+          series.setMarkerColor(randomColor);
+          series.setLineColor(randomColor);
+          series.setFillColor(randomColor);
           SwingUtilities.invokeLater(
               () -> {
                 chart.updateXYSeries("mockData", xData, yData, null);

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue879.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue879.java
@@ -1,0 +1,56 @@
+package org.knowm.xchart.standalone.issues;
+
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Demonstrates memory-efficient primitive-array usage for CategoryChart (issue #879).
+ *
+ * <p>The root cause of the perceived high memory usage in issue #879 was two-fold:
+ *
+ * <ol>
+ *   <li>JDK 8's Parallel GC is less aggressive at reclaiming heap than JDK 21's G1GC. Adding
+ *       {@code -XX:+UseG1GC} on JDK 8 restores comparable behaviour. This is not an XChart bug.
+ *   <li>Passing {@code double[]} / {@code int[]} to {@link CategoryChart#addSeries} previously
+ *       boxed every value into a {@code List<Double>}, consuming ~3× more memory per element (24
+ *       bytes vs 8 bytes for a primitive double). This has been fixed: the data is now stored
+ *       internally as {@code double[]}, eliminating the boxing overhead on both the add and update
+ *       paths.
+ * </ol>
+ */
+public class TestForIssue879 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static CategoryChart getChart() {
+
+    int numPoints = 18_000;
+    double[] xData = new double[numPoints];
+    double[] yData = new double[numPoints];
+    for (int i = 0; i < numPoints; i++) {
+      xData[i] = i;
+      yData[i] = Math.sin(i * 0.001) * 100;
+    }
+
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Issue #879 — CategoryChart with 18 000 points (double[] path, no boxing)")
+            .xAxisTitle("Index")
+            .yAxisTitle("Value")
+            .theme(Styler.ChartTheme.GGPlot2)
+            .build();
+
+    // double[] passed directly — stored as primitive double[] internally, no boxing
+    chart.addSeries("series1", xData, yData);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/BoxChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/BoxChart.java
@@ -54,12 +54,18 @@ public class BoxChart extends AxesChart<BoxStyler, BoxSeries> {
 
   public BoxSeries addSeries(String seriesName, int[] yData) {
 
-    return addSeries(seriesName, Utils.getNumberListFromIntArray(yData));
+    double[] doubles = new double[yData.length];
+    for (int i = 0; i < yData.length; i++) doubles[i] = yData[i];
+    return addSeries(seriesName, doubles);
   }
 
   public BoxSeries addSeries(String seriesName, double[] yData) {
 
-    return addSeries(seriesName, Utils.getNumberListFromDoubleArray(yData));
+    sanityCheckYData(yData);
+    xData.add(seriesName);
+    BoxSeries series = new BoxSeries(seriesName, xData, yData, null, DataType.String);
+    seriesMap.put(seriesName, series);
+    return series;
   }
 
   public BoxSeries addSeries(String seriesName, List<? extends Number> yData) {
@@ -97,14 +103,33 @@ public class BoxChart extends AxesChart<BoxStyler, BoxSeries> {
     }
   }
 
+  private void sanityCheckYData(double[] yData) {
+
+    if (yData == null) {
+      throw new IllegalArgumentException("Y-Axis data cannot be null !!!");
+    }
+    if (yData.length == 0) {
+      throw new IllegalArgumentException("Y-Axis data cannot be empty !!!");
+    }
+  }
+
   public BoxSeries updateBoxSeries(String seriesName, int[] newYData) {
 
-    return updateBoxSeries(seriesName, Utils.getNumberListFromIntArray(newYData));
+    double[] doubles = new double[newYData.length];
+    for (int i = 0; i < newYData.length; i++) doubles[i] = newYData[i];
+    return updateBoxSeries(seriesName, doubles);
   }
 
   public BoxSeries updateBoxSeries(String seriesName, double[] newYData) {
 
-    return updateBoxSeries(seriesName, Utils.getNumberListFromDoubleArray(newYData));
+    Map<String, BoxSeries> seriesMap = this.seriesMap;
+    BoxSeries series = seriesMap.get(seriesName);
+
+    if (series == null) {
+      throw new IllegalArgumentException("Series name > " + seriesName + " < not found !!!");
+    }
+    series.replaceData(newYData);
+    return series;
   }
 
   public BoxSeries updateBoxSeries(String seriesName, List<? extends Number> newYData) {

--- a/xchart/src/main/java/org/knowm/xchart/BoxSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/BoxSeries.java
@@ -16,6 +16,13 @@ public class BoxSeries extends AxesChartSeriesCategory {
     super(name, xData, yData, extraValues, xAxisDataType);
   }
 
+  /** Constructor — direct primitive-array path; avoids boxing entirely. */
+  public BoxSeries(
+      String name, List<?> xData, double[] yData, double[] extraValues, DataType xAxisDataType) {
+
+    super(name, xData, yData, extraValues, xAxisDataType);
+  }
+
   @Override
   public LegendRenderType getLegendRenderType() {
 
@@ -23,7 +30,7 @@ public class BoxSeries extends AxesChartSeriesCategory {
   }
 
   /**
-   * Replace the Y data for this box series, with validation.
+   * Replace the Y data for this box series via list, with validation.
    *
    * @param newYData the new Y data; must be non-null, non-empty, and contain no null values
    */
@@ -38,6 +45,23 @@ public class BoxSeries extends AxesChartSeriesCategory {
     }
     if (newYData.contains(null)) {
       throw new IllegalArgumentException("Y-Axis data cannot contain null !!!");
+    }
+    super.replaceData(newYData);
+  }
+
+  /**
+   * Replace the Y data for this box series via primitive array — avoids boxing entirely.
+   *
+   * @param newYData the new Y data; must be non-null and non-empty
+   */
+  @Override
+  public void replaceData(double[] newYData) {
+
+    if (newYData == null) {
+      throw new IllegalArgumentException("Y-Axis data cannot be null !!!");
+    }
+    if (newYData.length == 0) {
+      throw new IllegalArgumentException("Y-Axis data cannot be empty !!!");
     }
     super.replaceData(newYData);
   }

--- a/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
@@ -102,11 +102,21 @@ public class CategoryChart extends AxesChart<CategoryStyler, CategorySeries> {
   public CategorySeries addSeries(
       String seriesName, double[] xData, double[] yData, double[] errorBars) {
 
-    return addSeries(
-        seriesName,
-        Utils.getNumberListFromDoubleArray(xData),
-        Utils.getNumberListFromDoubleArray(yData),
-        Utils.getNumberListFromDoubleArray(errorBars));
+    List<?> xList = xData != null ? Utils.getNumberListFromDoubleArray(xData) : null;
+    if (xList != null) {
+      sanityCheck(seriesName, xList, yData, errorBars);
+      if (xList.size() != yData.length) {
+        throw new IllegalArgumentException("X and Y-Axis sizes are not the same!!!");
+      }
+    } else {
+      sanityCheck(seriesName, null, yData, errorBars);
+      xList = Utils.getGeneratedDataAsList(yData.length);
+    }
+    CategorySeries series =
+        new CategorySeries(seriesName, xList, yData, errorBars, DataType.Number);
+    seriesMap.put(seriesName, series);
+
+    return series;
   }
 
   /**
@@ -133,11 +143,28 @@ public class CategoryChart extends AxesChart<CategoryStyler, CategorySeries> {
    */
   public CategorySeries addSeries(String seriesName, int[] xData, int[] yData, int[] errorBars) {
 
-    return addSeries(
-        seriesName,
-        Utils.getNumberListFromIntArray(xData),
-        Utils.getNumberListFromIntArray(yData),
-        Utils.getNumberListFromIntArray(errorBars));
+    double[] yDoubles = new double[yData.length];
+    for (int i = 0; i < yData.length; i++) yDoubles[i] = yData[i];
+    double[] ebDoubles = null;
+    if (errorBars != null) {
+      ebDoubles = new double[errorBars.length];
+      for (int i = 0; i < errorBars.length; i++) ebDoubles[i] = errorBars[i];
+    }
+    List<?> xList = xData != null ? Utils.getNumberListFromIntArray(xData) : null;
+    if (xList != null) {
+      sanityCheck(seriesName, xList, yDoubles, ebDoubles);
+      if (xList.size() != yDoubles.length) {
+        throw new IllegalArgumentException("X and Y-Axis sizes are not the same!!!");
+      }
+    } else {
+      sanityCheck(seriesName, null, yDoubles, ebDoubles);
+      xList = Utils.getGeneratedDataAsList(yDoubles.length);
+    }
+    CategorySeries series =
+        new CategorySeries(seriesName, xList, yDoubles, ebDoubles, DataType.Number);
+    seriesMap.put(seriesName, series);
+
+    return series;
   }
 
   /**
@@ -256,11 +283,19 @@ public class CategoryChart extends AxesChart<CategoryStyler, CategorySeries> {
   public CategorySeries updateCategorySeries(
       String seriesName, double[] newXData, double[] newYData, double[] newErrorBarData) {
 
-    return updateCategorySeries(
-        seriesName,
-        Utils.getNumberListFromDoubleArray(newXData),
-        Utils.getNumberListFromDoubleArray(newYData),
-        Utils.getNumberListFromDoubleArray(newErrorBarData));
+    Map<String, CategorySeries> seriesMap = this.seriesMap;
+    CategorySeries series = seriesMap.get(seriesName);
+    if (series == null) {
+      throw new IllegalArgumentException("Series name >" + seriesName + "< not found!!!");
+    }
+    if (newXData == null) {
+      series.replaceData(Utils.getGeneratedDataAsList(newYData.length), newYData, newErrorBarData);
+    } else {
+      series.replaceData(
+          Utils.getNumberListFromDoubleArray(newXData), newYData, newErrorBarData);
+    }
+
+    return series;
   }
 
   ///////////////////////////////////////////////////
@@ -289,6 +324,28 @@ public class CategoryChart extends AxesChart<CategoryStyler, CategorySeries> {
       throw new IllegalArgumentException("X-Axis data cannot be empty!!!");
     }
     if (errorBars != null && errorBars.size() != yData.size()) {
+      throw new IllegalArgumentException("Error bars and Y-Axis sizes are not the same!!!");
+    }
+  }
+
+  private void sanityCheck(String seriesName, List<?> xData, double[] yData, double[] errorBars) {
+
+    if (seriesMap.containsKey(seriesName)) {
+      throw new IllegalArgumentException(
+          "Series name >"
+              + seriesName
+              + "< has already been used. Use unique names for each series!!!");
+    }
+    if (yData == null) {
+      throw new IllegalArgumentException("Y-Axis data cannot be null!!!");
+    }
+    if (yData.length == 0) {
+      throw new IllegalArgumentException("Y-Axis data cannot be empty!!!");
+    }
+    if (xData != null && xData.size() == 0) {
+      throw new IllegalArgumentException("X-Axis data cannot be empty!!!");
+    }
+    if (errorBars != null && errorBars.length != yData.length) {
       throw new IllegalArgumentException("Error bars and Y-Axis sizes are not the same!!!");
     }
   }

--- a/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
@@ -18,7 +18,7 @@ public class CategorySeries extends AxesChartSeriesCategory {
   private boolean smooth;
 
   /**
-   * Constructor
+   * Constructor — accepts Lists (yData/errorBars are converted to double[] internally).
    *
    * @param name
    * @param xData
@@ -31,6 +31,25 @@ public class CategorySeries extends AxesChartSeriesCategory {
       List<?> xData,
       List<? extends Number> yData,
       List<? extends Number> errorBars,
+      Series.DataType axisType) {
+
+    super(name, xData, yData, errorBars, axisType);
+  }
+
+  /**
+   * Constructor — direct primitive-array path; avoids boxing entirely.
+   *
+   * @param name
+   * @param xData
+   * @param yData
+   * @param errorBars
+   * @param axisType
+   */
+  public CategorySeries(
+      String name,
+      List<?> xData,
+      double[] yData,
+      double[] errorBars,
       Series.DataType axisType) {
 
     super(name, xData, yData, errorBars, axisType);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -2,7 +2,6 @@ package org.knowm.xchart.internal.chartpart;
 
 import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
-import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
 
@@ -308,20 +307,19 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
             }
 
             int categoryCounter = 0;
-            Iterator<? extends Number> yItr = axesChartSeriesCategory.getYData().iterator();
-            while (yItr.hasNext()) {
+            double[] yArr = axesChartSeriesCategory.getYData();
+            for (double next : yArr) {
 
-              Number next = yItr.next();
-              // skip when a value is null
-              if (next == null) {
+              // skip when a value is NaN (was null in the original list)
+              if (Double.isNaN(next)) {
                 categoryCounter++;
                 continue;
               }
 
-              if (next.doubleValue() > 0) {
-                accumulatedStackOffsetPos[categoryCounter] += next.doubleValue();
-              } else if (next.doubleValue() < 0) {
-                accumulatedStackOffsetNeg[categoryCounter] += next.doubleValue();
+              if (next > 0) {
+                accumulatedStackOffsetPos[categoryCounter] += next;
+              } else if (next < 0) {
+                accumulatedStackOffsetNeg[categoryCounter] += next;
               }
               categoryCounter++;
             }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_Y.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_Y.java
@@ -288,9 +288,8 @@ public class Axis_Y<ST extends AxesChartStyler, S extends AxesChartSeries> exten
       for (CategorySeries categorySeries :
           (Collection<CategorySeries>) (Collection<?>) chart.getSeriesMap().values()) {
         uniqueYData.addAll(
-            categorySeries.getYData().stream()
-                .filter(Objects::nonNull)
-                .mapToDouble(Number::doubleValue)
+            Arrays.stream(categorySeries.getYData())
+                .filter(v -> !Double.isNaN(v))
                 .boxed()
                 .collect(Collectors.toList()));
       }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/BoxPlotDataCalculator.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/BoxPlotDataCalculator.java
@@ -1,9 +1,7 @@
 package org.knowm.xchart.internal.chartpart;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.internal.series.AxesChartSeries;
@@ -22,43 +20,38 @@ public class BoxPlotDataCalculator<ST extends AxesChartStyler, S extends AxesCha
 
   public List<BoxPlotData> calculate(Map<String, S> seriesMap, ST boxPlotStyler) {
 
-    // Box plot data information for all series
     List<BoxPlotData> boxPlotDataList = new ArrayList<>();
-    BoxPlotData boxPlotData = null;
-    List<Double> data = null;
-    Collection<? extends Number> yData = null;
-    Iterator<? extends Number> yDataIterator = null;
-    Number next = null;
     for (S series : seriesMap.values()) {
       if (!series.isEnabled()) {
         continue;
       }
 
-      yData = ((AxesChartSeriesCategory) series).getYData();
-      yDataIterator = yData.iterator();
-      data = new ArrayList<>();
-      while (yDataIterator.hasNext()) {
-        next = yDataIterator.next();
-        if (next != null) {
-          data.add(next.doubleValue());
-        }
-      }
+      double[] yRaw = ((AxesChartSeriesCategory) series).getYData();
 
-      if (data.isEmpty()) {
+      // filter out NaN values (converted from null), then sort a copy
+      int count = 0;
+      for (double v : yRaw) {
+        if (!Double.isNaN(v)) count++;
+      }
+      if (count == 0) {
         boxPlotDataList.add(null);
         continue;
       }
-      Collections.sort(data);
-      boxPlotData = calculate(data, boxPlotStyler);
-      boxPlotDataList.add(boxPlotData);
+      double[] data = new double[count];
+      int idx = 0;
+      for (double v : yRaw) {
+        if (!Double.isNaN(v)) data[idx++] = v;
+      }
+      Arrays.sort(data);
+      boxPlotDataList.add(calculate(data, boxPlotStyler));
     }
     return boxPlotDataList;
   }
 
-  private BoxPlotData calculate(List<Double> data, ST boxPlotStyler) {
+  private BoxPlotData calculate(double[] data, ST boxPlotStyler) {
 
     BoxPlotData boxPlotData = new BoxPlotData();
-    int n = data.size();
+    int n = data.length;
     BoxplotCalCulationMethod boxplotCalCulationMethod =
         ((BoxStyler) boxPlotStyler).getBoxplotCalCulationMethod();
     double q1P = 0.0;
@@ -92,39 +85,39 @@ public class BoxPlotDataCalculator<ST extends AxesChartStyler, S extends AxesCha
 
     // Lower whisker, lower = Q1 - 1.5 * IQR
     boxPlotData.lower = boxPlotData.q1 - 1.5 * irq;
-    if (boxPlotData.lower < data.get(0)) {
-      boxPlotData.lower = data.get(0);
+    if (boxPlotData.lower < data[0]) {
+      boxPlotData.lower = data[0];
     }
 
     // Upper whisker, upper = Q3 + 1.5 * IQR
     boxPlotData.upper = boxPlotData.q3 + 1.5 * irq;
-    if (boxPlotData.upper > data.get(data.size() - 1)) {
-      boxPlotData.upper = data.get(data.size() - 1);
+    if (boxPlotData.upper > data[data.length - 1]) {
+      boxPlotData.upper = data[data.length - 1];
     }
     return boxPlotData;
   }
 
   private static double getQuartile(
-      List<Double> data, double qiP, BoxplotCalCulationMethod boxplotCalCulationMethod) {
+      double[] data, double qiP, BoxplotCalCulationMethod boxplotCalCulationMethod) {
 
     int previousItem = (int) Math.floor(qiP);
     int previousItem_index = previousItem == 0 ? 0 : previousItem - 1;
     int nextItem = (int) Math.ceil(qiP);
-    int nextItem_index = data.size() == 1 ? 0 : nextItem - 1;
+    int nextItem_index = data.length == 1 ? 0 : nextItem - 1;
     final double qi;
     if (BoxplotCalCulationMethod.NP == boxplotCalCulationMethod) {
       if (previousItem == nextItem) {
-        qi = (data.get(previousItem_index) + data.get(nextItem_index)) / 2;
+        qi = (data[previousItem_index] + data[nextItem_index]) / 2;
       } else {
-        qi = data.get(nextItem_index);
+        qi = data[nextItem_index];
       }
     } else {
       if (previousItem == nextItem) {
-        qi = data.get(previousItem_index);
+        qi = data[previousItem_index];
       } else {
         qi =
-            data.get(previousItem_index) * (nextItem - qiP)
-                + data.get(nextItem_index) * (qiP - previousItem);
+            data[previousItem_index] * (nextItem - qiP)
+                + data[nextItem_index] * (qiP - previousItem);
       }
     }
     return qi;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
@@ -7,8 +7,6 @@ import java.awt.Shape;
 import java.awt.geom.Area;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import org.knowm.xchart.BoxSeries;
 import org.knowm.xchart.internal.Utils;
@@ -73,13 +71,8 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
         yMax = Math.log10(yMax);
       }
       // data points
-      Collection<? extends Number> yData = series.getYData();
-      Iterator<? extends Number> yItr = yData.iterator();
-      while (yItr.hasNext()) {
-
-        Number next = yItr.next();
-
-        double yOrig = next.doubleValue();
+      double[] yArr = series.getYData();
+      for (double yOrig : yArr) {
         double y;
 
         if (boxPlotStyler.isYAxisLogarithmic()) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category.java
@@ -9,9 +9,7 @@ import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.knowm.xchart.CategorySeries;
@@ -91,13 +89,9 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
       // smooth curve path for Line render style
       Path2D.Double smoothPath = null;
 
-      Iterator<?> xItr = series.getXData().iterator();
-      Iterator<? extends Number> yItr = series.getYData().iterator();
-      Iterator<? extends Number> ebItr = null;
-      Collection<? extends Number> errorBars = series.getExtraValues();
-      if (errorBars != null) {
-        ebItr = errorBars.iterator();
-      }
+      List<?> xDataList = (List<?>) series.getXData();
+      double[] yArr = series.getYData();
+      double[] errorBars = series.getExtraValues();
 
       // Stepped bars are drawn in chunks rather than for each individual bar
       ArrayList<Point2D.Double> steppedPath = new ArrayList<>();
@@ -105,11 +99,11 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
       Path2D.Double path = null;
       int categoryCounter = 0;
 
-      while (yItr.hasNext()) {
+      for (int dataIndex = 0; dataIndex < yArr.length; dataIndex++) {
 
-        Number next = yItr.next();
-        // skip when a value is null
-        if (next == null) {
+        double next = yArr[dataIndex];
+        // skip when a value is NaN (was null in the original list)
+        if (Double.isNaN(next)) {
 
           if (smoothPath != null) {
             g.setColor(series.getLineColor());
@@ -123,9 +117,9 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
           categoryCounter++;
           continue;
         }
-        Object nextCat = xItr.next();
+        Object nextCat = xDataList.get(dataIndex);
 
-        double yOrig = next.doubleValue();
+        double yOrig = next;
         double y;
         if (stylerCategory.isYAxisLogarithmic()) {
           y = Math.log10(yOrig);
@@ -212,7 +206,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
 
         // Record the first series yOffset value, update totalYOffset value
         // when next is greater then 0
-        if (seriesCounter == 0 || next.doubleValue() > 0) {
+        if (seriesCounter == 0 || next > 0) {
           accumulatedStackOffsetTotalYOffset[categoryCounter] = yOffset;
         }
 
@@ -241,7 +235,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
                   xOffset,
                   gridStep,
                   seriesCounter,
-                  !yItr.hasNext(),
+                  dataIndex == yArr.length - 1,
                   steppedPath,
                   steppedReturnPath,
                   previousY);
@@ -280,7 +274,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
           // g.draw(path);
           // }
 
-          if (stylerCategory.isLabelsVisible() && next != null) {
+          if (stylerCategory.isLabelsVisible()) {
             drawLabels(
                 g,
                 next,
@@ -296,7 +290,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
               && stylerCategory.isShowStackSum()
               && stylerCategory.isStacked()
               && seriesCounter == (seriesMap.size() - 1)) {
-            Number totalNext =
+            double totalNext =
                 accumulatedStackOffsetPos[categoryCounter - 1]
                     - accumulatedStackOffsetNeg[categoryCounter - 1];
             double totalYOffset = accumulatedStackOffsetTotalYOffset[categoryCounter - 1];
@@ -415,7 +409,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
         // paint error bars
         if (errorBars != null) {
 
-          double eb = ebItr.next().doubleValue();
+          double eb = errorBars[dataIndex];
 
           // set error bar style
           if (stylerCategory.isErrorBarsColorSeriesColor()) {
@@ -676,7 +670,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
 
   private void drawLabels(
       Graphics2D g,
-      Number next,
+      double next,
       double xOffset,
       double yOffset,
       double zeroOffset,
@@ -711,7 +705,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
     if (showStackSum) {
       labelY = yOffset - 4;
     } else {
-      if (next.doubleValue() >= 0.0) {
+      if (next >= 0.0) {
         labelY =
             yOffset
                 + (zeroOffset - yOffset) * (1 - stylerCategory.getLabelsPosition())

--- a/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeriesCategory.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeriesCategory.java
@@ -5,28 +5,57 @@ import java.util.List;
 
 /**
  * A Series containing X and Y data to be plotted on a Chart with X and Y Axes. xData can be Number
- * or Date or String, hence a List<?>
+ * or Date or String, hence a List<?>. yData and extraValues are always numeric and stored as
+ * primitive double[] to avoid boxing overhead.
  */
 public abstract class AxesChartSeriesCategory extends MarkerSeries {
 
   List<?> xData; // can be Number or Date or String
 
-  List<? extends Number> yData;
+  double[] yData;
 
-  List<? extends Number> extraValues;
+  double[] extraValues;
 
   /**
-   * Constructor
+   * Constructor — accepts lists (List API path; yData and extraValues are converted to double[]
+   * internally, mapping null elements to Double.NaN).
    *
    * @param name
    * @param xData
    * @param yData
+   * @param extraValues
+   * @param xAxisDataType
    */
   public AxesChartSeriesCategory(
       String name,
       List<?> xData,
       List<? extends Number> yData,
       List<? extends Number> extraValues,
+      DataType xAxisDataType) {
+
+    super(name, xAxisDataType);
+
+    this.xData = xData;
+    this.yData = numberListToDoubleArray(yData);
+    this.extraValues = numberListToDoubleArray(extraValues);
+
+    calculateMinMax();
+  }
+
+  /**
+   * Constructor — direct primitive-array path; avoids boxing entirely.
+   *
+   * @param name
+   * @param xData
+   * @param yData
+   * @param extraValues
+   * @param xAxisDataType
+   */
+  public AxesChartSeriesCategory(
+      String name,
+      List<?> xData,
+      double[] yData,
+      double[] extraValues,
       DataType xAxisDataType) {
 
     super(name, xAxisDataType);
@@ -58,17 +87,51 @@ public abstract class AxesChartSeriesCategory extends MarkerSeries {
     }
 
     xData = newXData;
+    yData = numberListToDoubleArray(newYData);
+    extraValues = numberListToDoubleArray(newExtraValues);
+    calculateMinMax();
+  }
+
+  /**
+   * Direct primitive-array update path — avoids boxing entirely.
+   *
+   * @param newXData
+   * @param newYData
+   * @param newExtraValues
+   */
+  public void replaceData(List<?> newXData, double[] newYData, double[] newExtraValues) {
+
+    // Sanity check
+    if (newExtraValues != null && newExtraValues.length != newYData.length) {
+      throw new IllegalArgumentException("error bars and Y-Axis sizes are not the same!!!");
+    }
+    if (newXData.size() != newYData.length) {
+      throw new IllegalArgumentException("X and Y-Axis sizes are not the same!!!");
+    }
+
+    xData = newXData;
     yData = newYData;
     extraValues = newExtraValues;
     calculateMinMax();
   }
 
   /**
-   * For box plot, replace yData
+   * For box plot, replace yData via list (maps null → NaN).
    *
    * @param newYData Updated yData
    */
   public void replaceData(List<? extends Number> newYData) {
+
+    yData = numberListToDoubleArray(newYData);
+    calculateMinMax();
+  }
+
+  /**
+   * For box plot, replace yData via primitive array — avoids boxing entirely.
+   *
+   * @param newYData Updated yData
+   */
+  public void replaceData(double[] newYData) {
 
     yData = newYData;
     calculateMinMax();
@@ -85,7 +148,7 @@ public abstract class AxesChartSeriesCategory extends MarkerSeries {
     // yData
     double[] yMinMax;
     if (extraValues == null) {
-      yMinMax = SeriesMinMaxCalculator.findMinMax(yData, yAxisType);
+      yMinMax = SeriesMinMaxCalculator.findMinMax(yData);
     } else {
       yMinMax = SeriesMinMaxCalculator.findMinMaxWithErrorBars(yData, extraValues);
     }
@@ -98,13 +161,27 @@ public abstract class AxesChartSeriesCategory extends MarkerSeries {
     return xData;
   }
 
-  public Collection<? extends Number> getYData() {
+  public double[] getYData() {
 
     return yData;
   }
 
-  public Collection<? extends Number> getExtraValues() {
+  public double[] getExtraValues() {
 
     return extraValues;
+  }
+
+  /** Converts a {@code List<? extends Number>} to a {@code double[]}, mapping null → NaN. */
+  static double[] numberListToDoubleArray(List<? extends Number> list) {
+
+    if (list == null) {
+      return null;
+    }
+    double[] arr = new double[list.size()];
+    int i = 0;
+    for (Number n : list) {
+      arr[i++] = (n == null) ? Double.NaN : n.doubleValue();
+    }
+    return arr;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeriesNumerical.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/series/AxesChartSeriesNumerical.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 public abstract class AxesChartSeriesNumerical extends MarkerSeries {
 
   // full unfiltered data — retained so zoom can be reset to the original range
-  // TODO(zoom-memory): For large datasets, xData/yData/extraValues duplicate xDataAll/yDataAll/
+  // For large datasets, xData/yData/extraValues duplicate xDataAll/yDataAll/
   //   extraValuesAll for zoom filtering. A DataRange(startIndex, endIndex) abstraction could
   //   replace the duplicated arrays for the index-based zoom path (filterXByIndex). The
   //   value-based path (filterXByValue) is non-contiguous and would need a full index-mapping

--- a/xchart/src/test/java/org/knowm/xchart/CategoryChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/CategoryChartTest.java
@@ -141,8 +141,8 @@ public class CategoryChartTest {
         () ->
             assertThat(series.getXData())
                 .isEqualTo(Arrays.asList("Blue", "Red", "Green", "Yellow", "Orange")),
-        () -> assertThat(series.getYData()).isEqualTo(Arrays.asList(-40, 40.8, 20, 60, 60)),
-        () -> assertThat(series.getExtraValues()).isEqualTo(Arrays.asList(3, 3, 4, 3, 5)),
+        () -> assertThat(series.getYData()).containsExactly(-40.0, 40.8, 20.0, 60.0, 60.0),
+        () -> assertThat(series.getExtraValues()).containsExactly(3.0, 3.0, 4.0, 3.0, 5.0),
         () -> assertThat(series.getYData()).hasSize(5));
   }
 
@@ -193,7 +193,7 @@ public class CategoryChartTest {
         Arrays.asList(50, 10, -20, 40, 60),
         null);
 
-    assertThat(fruit.getYData()).isEqualTo(Arrays.asList(50, 10, -20, 40, 60));
+    assertThat(fruit.getYData()).containsExactly(50.0, 10.0, -20.0, 40.0, 60.0);
   }
 
   @Test
@@ -211,7 +211,7 @@ public class CategoryChartTest {
         Arrays.asList(-40, 30, 20, 60, 60),
         Arrays.asList(3, 1, 2, 1, 2));
 
-    assertThat(fruit.getExtraValues()).isEqualTo(Arrays.asList(3, 1, 2, 1, 2));
+    assertThat(fruit.getExtraValues()).containsExactly(3.0, 1.0, 2.0, 1.0, 2.0);
   }
 
   @Test


### PR DESCRIPTION
## Motivation

`AxesChartSeriesCategory` (and its subclasses `CategorySeries`, `BoxSeries`) stored `yData` and `extraValues` as `List<? extends Number>`, causing automatic boxing of every primitive value. For a caller passing `double[]` or `int[]`, each element was allocated as a `Double`/`Integer` object -- roughly 3x the memory of a primitive array and additional GC pressure on repeated updates.

For an 18,000-point chart updated frequently (the scenario in issue #879), the boxed list consumed ~432 KB vs ~144 KB for a `double[]`, and `BoxPlotDataCalculator` was re-boxing every element on every repaint.

## Approach

Changed the internal storage in `AxesChartSeriesCategory` from `List<? extends Number>` to `double[]`. All consumers were updated accordingly:

- **`AxesChartSeriesCategory`** -- core storage changed to `double[]`; added `double[]` constructor overloads alongside the existing `List` constructors (null list elements map to `Double.NaN` via a `numberListToDoubleArray()` helper for backward compatibility); `getYData()` / `getExtraValues()` now return `double[]`.
- **`CategoryChart` / `BoxChart`** -- added `addSeries(double[], ...)` and `updateXxxSeries(double[], ...)` overloads that bypass boxing entirely; `sanityCheck` overloads added for `double[]`.
- **`PlotContent_Category`** -- switched from dual-iterator loop to index-based array loop; null checks replaced with `Double.isNaN()`; `drawLabels()` parameter changed from `Number` to `double`.
- **`PlotContent_Box`** -- switched to for-each array loop; removed unused `Collection`/`Iterator` imports.
- **`BoxPlotDataCalculator`** -- completely rewritten to use `double[]` + `Arrays.sort()` instead of allocating a `List<Double>` and calling `Collections.sort()` on every repaint.
- **`Axis_Y` / `AxisPair`** -- updated min/max and stacked-bar accumulation loops to work with `double[]` directly.

## Notable details

- **API break**: `getYData()` return type changes from `Collection<? extends Number>` to `double[]`. This is intentional and acceptable under the 4.0.0-SNAPSHOT major version. The `List`-accepting public constructors and `addSeries`/`updateSeries` methods are fully preserved.
- **null -> NaN**: The legacy `List` path maps null elements to `Double.NaN` so rendering and min/max logic (already NaN-aware in `AxesChartSeriesNumerical`) handles them consistently.
- **`HorizontalBarSeries`** was intentionally left unchanged -- it has a different class hierarchy (`AxesChartSeries` directly, not `AxesChartSeriesCategory`) and its `yData` is `List<?>` which can hold `String` values. That is a separate concern.
- Demo class `TestForIssue879.java` added with the interactive "Add New Data" button from the original issue report, plus a headless-safe `getChart()` static method for unit testing.

All 73 existing tests pass; `mvn fmt:check` passes.