### PR TITLE
Fix HeatMap legend gradient asymmetry (issue #585) + cleanup

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue585.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue585.java
@@ -1,0 +1,121 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+import org.knowm.xchart.HeatMapChart;
+import org.knowm.xchart.HeatMapChartBuilder;
+import org.knowm.xchart.HeatMapSeries;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.Styler.LegendLayout;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+/**
+ * Demonstrates issue #585 — a symmetric colormap definition produces an asymmetric legend.
+ *
+ * <p>The gradient legend bar for the Vertical layout has its LinearGradientPaint "start" point
+ * placed {@code fontSize} pixels above the actual bottom of the rectangle. This leaves a strip at
+ * the bottom that is always clamped to {@code rangeColors[0]} (the min colour), making the
+ * min-colour area visually larger than the max-colour area even when the colormap and data range
+ * are perfectly symmetric.
+ *
+ * <p>Two windows open side by side — one for each LegendPosition — so the asymmetry is visible in
+ * both orientations. The colourmap intentionally goes blue → dark → blue to make the off-centre
+ * midpoint obvious.
+ */
+public class TestForIssue585 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChartVertical()).displayChart();
+    new SwingWrapper<>(getChartHorizontal()).displayChart();
+  }
+
+  /** Vertical legend — bug is visible here: blue band at the bottom is wider than at the top. */
+  public static HeatMapChart getChartVertical() {
+
+    HeatMapChart chart = buildChart("Issue #585 – Vertical legend (bug: asymmetric gradient)");
+    chart.getStyler().setLegendPosition(LegendPosition.OutsideE);
+    chart.getStyler().setLegendLayout(LegendLayout.Vertical);
+    chart.getStyler().setGradientColorColumnHeight(200);
+    return chart;
+  }
+
+  /** Horizontal legend — shown for comparison. */
+  public static HeatMapChart getChartHorizontal() {
+
+    HeatMapChart chart = buildChart("Issue #585 – Horizontal legend (for comparison)");
+    chart.getStyler().setLegendPosition(LegendPosition.OutsideS);
+    chart.getStyler().setLegendLayout(LegendLayout.Horizontal);
+    chart.getStyler().setGradientColorColumnHeight(200);
+    return chart;
+  }
+
+  public static HeatMapChart getChart() {
+
+    return getChartVertical();
+  }
+
+  private static HeatMapChart buildChart(String title) {
+
+    // 21-colour symmetric palette: full-blue → no-blue → full-blue
+    Color[] colors =
+        new Color[] {
+          new Color(0.0f, 0.5f, 1.0f),
+          new Color(0.0f, 0.5f, 0.9f),
+          new Color(0.0f, 0.5f, 0.8f),
+          new Color(0.0f, 0.5f, 0.7f),
+          new Color(0.0f, 0.5f, 0.6f),
+          new Color(0.0f, 0.5f, 0.5f),
+          new Color(0.0f, 0.5f, 0.4f),
+          new Color(0.0f, 0.5f, 0.3f),
+          new Color(0.0f, 0.5f, 0.2f),
+          new Color(0.0f, 0.5f, 0.1f),
+          new Color(0.0f, 0.5f, 0.0f), // middle — darkest
+          new Color(0.0f, 0.5f, 0.1f),
+          new Color(0.0f, 0.5f, 0.2f),
+          new Color(0.0f, 0.5f, 0.3f),
+          new Color(0.0f, 0.5f, 0.4f),
+          new Color(0.0f, 0.5f, 0.5f),
+          new Color(0.0f, 0.5f, 0.6f),
+          new Color(0.0f, 0.5f, 0.7f),
+          new Color(0.0f, 0.5f, 0.8f),
+          new Color(0.0f, 0.5f, 0.9f),
+          new Color(0.0f, 0.5f, 1.0f),
+        };
+
+    List<String> xData = new ArrayList<>();
+    List<String> yData = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      xData.add("X" + i);
+      yData.add("Y" + i);
+    }
+
+    // Data ranges symmetrically from -5 to +5
+    List<Number[]> heatData = new ArrayList<>();
+    double step = 10.0 / (xData.size() * yData.size() - 1);
+    int idx = 0;
+    for (int x = 0; x < xData.size(); x++) {
+      for (int y = 0; y < yData.size(); y++) {
+        heatData.add(new Number[] {x, y, -5.0 + step * idx});
+        idx++;
+      }
+    }
+
+    HeatMapChart chart =
+        new HeatMapChartBuilder().width(700).height(500).title(title).build();
+
+    HeatMapSeries series = chart.addSeries("heat", xData, yData, heatData);
+    series.setMin(-5.0);
+    series.setMax(5.0);
+
+    chart
+        .getStyler()
+        .setRangeColors(colors)
+        .setMin(-5.0)
+        .setMax(5.0)
+        .setLegendVisible(true);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/HeatMapSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/HeatMapSeries.java
@@ -48,7 +48,7 @@ public class HeatMapSeries extends AxesChartSeries {
   protected void calculateMinMax() {
 
     min = Double.MAX_VALUE;
-    max = Double.MIN_VALUE;
+    max = -Double.MAX_VALUE;
     Number number = null;
     for (Number[] numbers : heatData) {
       if (numbers == null) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_HeatMap.java
@@ -329,7 +329,12 @@ public class Legend_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeries>
     Rectangle2D rect = null;
     // paint gradient color Column
     if (chart.getStyler().getLegendLayout() == Styler.LegendLayout.Vertical) {
-      start = new Point2D.Double(startx, starty + chart.getStyler().getGradientColorColumnHeight());
+      start =
+          new Point2D.Double(
+              startx,
+              starty
+                  + chart.getStyler().getLegendFont().getSize()
+                  + chart.getStyler().getGradientColorColumnHeight());
       end = new Point2D.Double(startx, starty + chart.getStyler().getLegendFont().getSize());
       rect =
           new Rectangle2D.Double(

--- a/xchart/src/main/java/org/knowm/xchart/style/BoxStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/BoxStyler.java
@@ -12,10 +12,7 @@ public class BoxStyler extends AxesChartStyler {
     super.setAllStyles();
   }
 
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
+  @Override
   public void setTheme(Theme theme) {
 
     this.theme = theme;

--- a/xchart/src/main/java/org/knowm/xchart/style/BubbleStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/BubbleStyler.java
@@ -43,13 +43,4 @@ public class BubbleStyler extends AxesChartStyler {
    *
    * @param theme
    */
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public void setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/CategoryStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/CategoryStyler.java
@@ -259,13 +259,4 @@ public class CategoryStyler extends AxesChartStyler {
    *
    * @param theme
    */
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public void setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/DialStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/DialStyler.java
@@ -77,22 +77,6 @@ public class DialStyler extends Styler {
     labelsFont = theme.getBaseFont();
   }
 
-  /**
-   * Set the theme the styler should use
-   *
-   * @param theme
-   */
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public DialStyler setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-    return this;
-  }
-
   public boolean isCircular() {
 
     return isCircular;

--- a/xchart/src/main/java/org/knowm/xchart/style/HeatMapStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/HeatMapStyler.java
@@ -43,21 +43,6 @@ public class HeatMapStyler extends AxesChartStyler {
 
   private Function<Double, String> heatMapDecimalValueFormatter;
 
-  /**
-   * Set the theme the styler should use
-   *
-   * @param theme
-   */
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public void setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-  }
-
   @Override
   public void setAllStyles() {
 
@@ -127,8 +112,9 @@ public class HeatMapStyler extends AxesChartStyler {
         this.rangeColors = new Color[2];
         this.rangeColors[0] = rangeColors[0];
         this.rangeColors[1] = rangeColors[0];
+      } else {
+        this.rangeColors = rangeColors;
       }
-      this.rangeColors = rangeColors;
     } else {
       this.rangeColors = DEFAULT_RANGE_COLORS;
     }

--- a/xchart/src/main/java/org/knowm/xchart/style/HorizontalBarStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/HorizontalBarStyler.java
@@ -180,13 +180,4 @@ public class HorizontalBarStyler extends AxesChartStyler {
    *
    * @param theme
    */
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public void setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/OHLCStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/OHLCStyler.java
@@ -43,13 +43,4 @@ public class OHLCStyler extends AxesChartStyler {
    *
    * @param theme
    */
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public void setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -346,22 +346,6 @@ public class PieStyler extends Styler {
     return this;
   }
 
-  /**
-   * Set the theme the styler should use
-   *
-   * @param theme
-   */
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public PieStyler setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-    return this;
-  }
-
   public ClockwiseDirectionType getClockwiseDirectionType() {
     return clockwiseDirectionType;
   }

--- a/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
@@ -84,22 +84,6 @@ public class RadarStyler extends Styler {
     return this;
   }
 
-  /**
-   * Set the theme the styler should use
-   *
-   * @param theme
-   */
-  /**
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public RadarStyler setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-    return this;
-  }
-
   public int getMarkerSize() {
 
     return markerSize;

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -807,7 +807,7 @@ public abstract class Styler {
   /**
    * When true, all data-point labels are rendered into the chart image (visible in BitmapEncoder
    * output and Swing panels alike). This is a rendering/visual property; enable hover tooltips
-   * separately via {@link XChartPanel#setToolTipsEnabled(boolean)}.
+   * separately via {@link org.knowm.xchart.XChartPanel#setToolTipsEnabled(boolean)}.
    *
    * @param toolTipsAlwaysVisible true to render labels for every data point
    */
@@ -1028,5 +1028,17 @@ public abstract class Styler {
   public Theme getTheme() {
 
     return theme;
+  }
+
+  /**
+   * Sets the theme for this styler and re-applies all styles. Prefer constructing the chart via its
+   * builder ({@code .theme(Theme)}) over calling this method after construction.
+   *
+   * @param theme the theme to apply
+   */
+  public void setTheme(Theme theme) {
+
+    this.theme = theme;
+    setAllStyles();
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/XYStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/XYStyler.java
@@ -43,19 +43,6 @@ public class XYStyler extends AxesChartStyler {
     this.cursorBackgroundColor = theme.getCursorBackgroundColor();
   }
 
-  /**
-   * Set the theme the styler should use
-   *
-   * @param theme
-   * @deprecated Use the builder's {@code .theme(Theme)} method instead.
-   */
-  @Deprecated
-  public void setTheme(Theme theme) {
-
-    this.theme = theme;
-    setAllStyles();
-  }
-
   public XYSeriesRenderStyle getDefaultSeriesRenderStyle() {
 
     return xySeriesRenderStyle;


### PR DESCRIPTION
## Root cause

The HeatMap gradient legend bar was visually asymmetric even when the colormap and data range were perfectly symmetric. The `LinearGradientPaint` start point (fraction=0, min colour) was placed at `starty + gradientColumnHeight`, but the rectangle it filled extended `fontSize` pixels further down to `starty + fontSize + gradientColumnHeight`. That extra strip at the bottom was always clamped to `rangeColors[0]`, making the min-colour band appear disproportionately wide.

## Fixes

**`Legend_HeatMap`** - align the gradient `start` point to the actual bottom of the rectangle:
```
starty + legendFont.getSize() + gradientColorColumnHeight
```

**`HeatMapSeries`** - `calculateMinMax()` initialised `max = Double.MIN_VALUE` (~4.9E-324, not the minimum double). Changed to `-Double.MAX_VALUE` so datasets with all-negative values compute the correct max.

**`HeatMapStyler`** - `setRangeColors()` was missing an `else`, so the single-colour workaround array was immediately overwritten by the original 1-element array.

**`Styler` / all subclass stylers** - `setTheme(Theme)` was `@Deprecated` in each of the 10 concrete stylers, yet every chart's `(width, height, Theme)` constructor called it internally, producing deprecation warnings on every build. Fixed by promoting a single non-deprecated `setTheme(Theme)` to `Styler`, removing the redundant overrides from 9 subclasses, and converting `BoxStyler`'s override to a proper `@Override` (it has extra `boxplotCalCulationMethod` reset logic). Build is now warning-free.

**`Styler`** - fixed a broken Javadoc `{@link XChartPanel#setToolTipsEnabled(boolean)}` reference (class is in a different package; added fully-qualified name).

## Demo

`TestForIssue585` in `xchart-demo/.../standalone/issues/` opens two windows (vertical and horizontal legend) with a symmetric blue colormap over a -5 to +5 range, making the pre-fix asymmetry immediately obvious.

Closes #585