### PR TITLE
Add setChartTitleFontColor() for independent title text color control

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue706.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue706.java
@@ -1,0 +1,105 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.util.ArrayList;
+import java.util.List;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Demonstrates independent chart title font color control (issue #706).
+ *
+ * <p>Three charts are shown side by side:
+ *
+ * <ol>
+ *   <li>Default — title color follows chartFontColor (no override).
+ *   <li>Red title — setChartTitleFontColor(Color.RED) while body text stays dark.
+ *   <li>Custom color + larger font — orange title, bold 20pt, dark body text.
+ * </ol>
+ */
+public class TestForIssue706 {
+
+  public static XYChart getChartDefault() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .title("Default Title Color")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .width(400)
+            .height(350)
+            .build();
+
+    chart.addSeries("sin", xData(), sinData());
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideSW);
+    return chart;
+  }
+
+  public static XYChart getChartRedTitle() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .title("Red Title (Issue #706)")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .width(400)
+            .height(350)
+            .build();
+
+    chart.addSeries("sin", xData(), sinData());
+    chart.getStyler().setChartTitleFontColor(Color.RED);
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideSW);
+    return chart;
+  }
+
+  public static XYChart getChartOrangeTitle() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .title("Orange Bold Title")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .width(400)
+            .height(350)
+            .build();
+
+    chart.addSeries("sin", xData(), sinData());
+    chart
+        .getStyler()
+        .setChartTitleFontColor(new Color(220, 100, 0))
+        .setChartTitleFont(new Font("Arial", Font.BOLD, 20));
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideSW);
+    return chart;
+  }
+
+  public static void main(String[] args) {
+
+    List<XYChart> charts = new ArrayList<>();
+    charts.add(getChartDefault());
+    charts.add(getChartRedTitle());
+    charts.add(getChartOrangeTitle());
+
+    new SwingWrapper<>(charts).displayChartMatrix();
+  }
+
+  private static double[] xData() {
+
+    double[] x = new double[100];
+    for (int i = 0; i < 100; i++) {
+      x[i] = i * 2 * Math.PI / 99;
+    }
+    return x;
+  }
+
+  private static double[] sinData() {
+
+    double[] y = new double[100];
+    for (int i = 0; i < 100; i++) {
+      y[i] = Math.sin(i * 2 * Math.PI / 99);
+    }
+    return y;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartTitle.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartTitle.java
@@ -78,9 +78,9 @@ public class ChartTitle<ST extends Styler, S extends Series> implements ChartPar
     if (TexRenderer.isTeX(title)) {
       TexRenderer.render(
           g, title, xOffset, yOffset - textBounds.getHeight(),
-          chart.getStyler().getChartTitleFont(), chart.getStyler().getChartFontColor());
+          chart.getStyler().getChartTitleFont(), chart.getStyler().getChartTitleFontColor());
     } else {
-      g.setColor(chart.getStyler().getChartFontColor());
+      g.setColor(chart.getStyler().getChartTitleFontColor());
       FontRenderContext frc = g.getFontRenderContext();
       TextLayout textLayout =
           new TextLayout(title, chart.getStyler().getChartTitleFont(), frc);

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -34,6 +34,7 @@ public abstract class Styler {
 
   // Chart Title ///////////////////////////////
   private Font chartTitleFont;
+  private Color chartTitleFontColor;
   private boolean isChartTitleVisible;
   private boolean isChartTitleBoxVisible;
   private Color chartTitleBoxBackgroundColor;
@@ -297,6 +298,22 @@ public abstract class Styler {
   public Styler setChartTitleFont(Font chartTitleFont) {
 
     this.chartTitleFont = chartTitleFont;
+    return this;
+  }
+
+  public Color getChartTitleFontColor() {
+
+    return chartTitleFontColor != null ? chartTitleFontColor : chartFontColor;
+  }
+
+  /**
+   * Set the chart title font color. When not set, falls back to {@link #getChartFontColor()}.
+   *
+   * @param chartTitleFontColor the color to use for the chart title text
+   */
+  public Styler setChartTitleFontColor(Color chartTitleFontColor) {
+
+    this.chartTitleFontColor = chartTitleFontColor;
     return this;
   }
 

--- a/xchart/src/test/java/org/knowm/xchart/StylerChartTitleFontColorTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/StylerChartTitleFontColorTest.java
@@ -1,0 +1,46 @@
+package org.knowm.xchart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.knowm.xchart.style.Styler.ChartTheme.GGPlot2;
+
+import java.awt.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class StylerChartTitleFontColorTest {
+
+  private XYChart chart;
+
+  @BeforeEach
+  void setUp() {
+    chart = new XYChart(800, 600, GGPlot2);
+  }
+
+  @Test
+  void defaultFallsBackToChartFontColor() {
+    Color expected = chart.getStyler().getChartFontColor();
+    assertThat(chart.getStyler().getChartTitleFontColor()).isEqualTo(expected);
+  }
+
+  @Test
+  void setChartTitleFontColorOverridesChartFontColor() {
+    Color titleColor = Color.RED;
+    chart.getStyler().setChartTitleFontColor(titleColor);
+    assertThat(chart.getStyler().getChartTitleFontColor()).isEqualTo(titleColor);
+  }
+
+  @Test
+  void chartFontColorStillUnaffectedByTitleColorOverride() {
+    Color originalFontColor = chart.getStyler().getChartFontColor();
+    chart.getStyler().setChartTitleFontColor(Color.BLUE);
+    assertThat(chart.getStyler().getChartFontColor()).isEqualTo(originalFontColor);
+  }
+
+  @Test
+  void setChartTitleFontColorToNullFallsBackToChartFontColor() {
+    chart.getStyler().setChartTitleFontColor(Color.GREEN);
+    chart.getStyler().setChartTitleFontColor(null);
+    assertThat(chart.getStyler().getChartTitleFontColor())
+        .isEqualTo(chart.getStyler().getChartFontColor());
+  }
+}


### PR DESCRIPTION
## Motivation

There was no way to set the chart title font color independently -- `setChartFontColor()` controls the title, axes labels, and legend all at once. Issue #706 asks for finer-grained control over just the title text color, consistent with the per-axis color overrides already available (e.g. `setXAxisTitleColor()`).

## Approach

Added `chartTitleFontColor` to `Styler` as an optional override:

- `getChartTitleFontColor()` returns the override if set, otherwise falls back to `chartFontColor` -- fully backward compatible.
- `setChartTitleFontColor(Color)` is fluent and lives alongside the other chart title settings (`setChartTitleFont`, `setChartTitleBoxBackgroundColor`, etc.).
- `ChartTitle` now calls `getChartTitleFontColor()` instead of `getChartFontColor()` for both the regular text and TeX render paths.

## Usage

```java
chart.getStyler().setChartTitleFontColor(Color.RED);

// or combine with a custom font
chart.getStyler()
    .setChartTitleFontColor(new Color(220, 100, 0))
    .setChartTitleFont(new Font("Arial", Font.BOLD, 20));
```

## Testing

- 4 unit tests in `StylerChartTitleFontColorTest`: default fallback, override, isolation from `chartFontColor`, and reset-to-null fallback.
- Demo: `TestForIssue706` -- displays three charts side by side (default, red title, orange bold title) to visually verify the feature.