### PR TITLE
Fix #799: empty-string custom tick labels crash TextLayout

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue799.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue799.java
@@ -1,0 +1,57 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries;
+
+/**
+ * Reproducer for GitHub issue #799: BitmapEncoder hang / crash when a custom Y-axis tick label
+ * formatter returns empty strings for unmapped values.
+ *
+ * <p>The formatter maps only a subset of Y values to human-readable labels and returns {@code ""}
+ * for everything else. Before the fix this caused either an infinite loop in the tick calculator
+ * (older code) or an {@code IllegalArgumentException} from {@code TextLayout} (newer code). Both
+ * are now resolved: empty labels are silently skipped during rendering, just like {@code null}.
+ */
+public class TestForIssue799 {
+
+  public static void main(String[] args) {
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static XYChart getChart() {
+    XYChart chart =
+        new XYChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Issue 799 – Custom Y-axis formatter with empty labels")
+            .xAxisTitle("X")
+            .yAxisTitle("Y (scaled)")
+            .build();
+
+    double[] xData = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    double[] yData = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+    XYSeries series = chart.addSeries("data", xData, yData);
+    series.setXYSeriesRenderStyle(XYSeries.XYSeriesRenderStyle.Scatter);
+
+    // Only a few Y values have a mapped label; the rest intentionally return ""
+    Map<Double, Double> yLabelMap = new HashMap<>();
+    yLabelMap.put(10.0, 0.01);
+    yLabelMap.put(30.0, 0.03);
+    yLabelMap.put(50.0, 0.05);
+    yLabelMap.put(70.0, 0.07);
+    yLabelMap.put(100.0, 0.10);
+
+    chart.setCustomYAxisTickLabelsFormatter(
+        yValue -> {
+          Double label = yLabelMap.get(yValue);
+          return label == null ? "" : label.toString();
+        });
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
@@ -75,6 +75,7 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends AxesChartSerie
         double flippedTickLocation = yOffset + height - tickLocation;
 
         if (tickLabel != null
+            && !tickLabel.isEmpty()
             && flippedTickLocation > yOffset
             && flippedTickLocation < yOffset + height) { // some are null for logarithmic axes
           Rectangle2D tickLabelBounds;
@@ -186,8 +187,9 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends AxesChartSerie
         double tickLocation = chart.getXAxis().getAxisTickCalculator().getTickLocations().get(i);
         double shiftedTickLocation = xOffset + tickLocation;
 
-        // discard null and out of bounds labels
+        // discard null, empty, and out of bounds labels
         if (tickLabel != null
+            && !tickLabel.isEmpty()
             && shiftedTickLocation > xOffset
             && shiftedTickLocation < xOffset + width) {
           // some are null for logarithmic axes
@@ -218,8 +220,9 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends AxesChartSerie
         double tickLocation = chart.getXAxis().getAxisTickCalculator().getTickLocations().get(i);
         double shiftedTickLocation = xOffset + tickLocation;
 
-        // discard null and out of bounds labels
+        // discard null, empty, and out of bounds labels
         if (tickLabel != null
+            && !tickLabel.isEmpty()
             && shiftedTickLocation > xOffset
             && shiftedTickLocation < xOffset + width) { // some are null for logarithmic axes
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ColocatedSlaveLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ColocatedSlaveLabels.java
@@ -109,6 +109,7 @@ class ColocatedSlaveLabels {
         double flippedTickLocation = yOffset + height - tickLocation;
 
         if (label != null
+            && !label.isEmpty()
             && flippedTickLocation > yOffset
             && flippedTickLocation < yOffset + height) {
           TextLayout layout = new TextLayout(label, styler.getAxisTickLabelsFont(), frc);

--- a/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
@@ -1,29 +1,68 @@
 package org.knowm.xchart;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import java.io.ByteArrayOutputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
-import org.junit.jupiter.api.Disabled;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
 
 public class XYChartTest {
   private static final String digestType = "md5";
 
-  // https://github.com/knowm/XChart/issues/799
-  @Disabled // because the issue is not fixed yet
-  public void issue799() throws Exception {
-    // given
+  // https://github.com/knowm/XChart/issues/799 — all-duplicate labels must not loop forever
+  @Test
+  public void yAxisFormatterAllDuplicateLabelsDoesNotHang() throws Exception {
     double[] xData = new double[] {0.0, 1.0, 2.0};
     double[] yData = new double[] {2.0, 1.0, 0.0};
     XYChart chart = QuickChart.getChart("Sample Chart", "X", "Y", "y(x)", xData, yData);
     chart.getStyler().setyAxisTickLabelsFormattingFunction(yValue -> "1");
 
-    // when
     DigestOutputStream output =
         new DigestOutputStream(new ByteArrayOutputStream(), MessageDigest.getInstance(digestType));
-    BitmapEncoder.saveBitmap(chart, output, BitmapEncoder.BitmapFormat.PNG);
+    assertThatCode(() -> BitmapEncoder.saveBitmap(chart, output, BitmapEncoder.BitmapFormat.PNG))
+        .doesNotThrowAnyException();
     output.close();
+  }
 
-    // test
-    // finishes
+  // https://github.com/knowm/XChart/issues/799 — empty-string labels must not crash TextLayout
+  @Test
+  public void yAxisFormatterEmptyStringLabelsDoesNotCrash() throws Exception {
+    double[] xData = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+    double[] yData = {10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0};
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+    chart.addSeries("test", xData, yData);
+
+    Map<Double, Double> yLabelMap = new HashMap<>();
+    yLabelMap.put(10.0, 0.01);
+    yLabelMap.put(50.0, 0.05);
+    chart.setCustomYAxisTickLabelsFormatter(
+        yValue -> {
+          Double yLabel = yLabelMap.get(yValue);
+          return yLabel == null ? "" : yLabel.toString();
+        });
+
+    assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
+        .doesNotThrowAnyException();
+  }
+
+  // X-axis variant: empty-string labels from a custom X-axis formatter must not crash TextLayout
+  @Test
+  public void xAxisFormatterEmptyStringLabelsDoesNotCrash() throws Exception {
+    double[] xData = {1.0, 2.0, 3.0, 4.0, 5.0};
+    double[] yData = {10.0, 20.0, 30.0, 40.0, 50.0};
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+    chart.addSeries("test", xData, yData);
+
+    Map<Double, String> xLabelMap = new HashMap<>();
+    xLabelMap.put(1.0, "A");
+    xLabelMap.put(3.0, "C");
+    chart.setCustomXAxisTickLabelsFormatter(
+        xValue -> xLabelMap.getOrDefault(xValue, ""));
+
+    assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
+        .doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
## Problem

When a custom Y-axis (or X-axis) tick label formatter returns `""` to suppress a label, `AxisTickLabels.paint()` passed the empty string directly to the `TextLayout` constructor, which throws `IllegalArgumentException: Zero length string passed to TextLayout constructor`.

Reproducer:
```java
chart.setCustomYAxisTickLabelsFormatter(yValue -> {
    Double label = myMap.get(yValue);
    return label == null ? "" : label.toString(); // "" for unmapped values
});
BitmapEncoder.saveBitmap(chart, "output.png", BitmapEncoder.BitmapFormat.PNG); // crashes
```

## Root Cause

`AxisTickLabels.paint()` checked `tickLabel != null` before passing labels to `TextLayout`, but did not check for empty strings. `TextLayout` accepts `null` but throws on `""`.

`ColocatedSlaveLabels.paint()` had the same gap (its sibling method `maxSlaveWidth()` already guarded for `!isEmpty()` correctly).

## Fix

Treat `""` the same as `null` — silently skip rendering. No label text is drawn; tick marks remain visible (consistent with the existing `null`/log-axis behaviour and the documented `" "` hide-label workaround from #792).

**Files changed:**
- `AxisTickLabels.java` — add `!tickLabel.isEmpty()` to the Y-axis guard and both X-axis guards
- `ColocatedSlaveLabels.java` — add `!label.isEmpty()` to `paint()` to match the existing guard in `maxSlaveWidth()`
- `XYChartTest.java` — replace `@Disabled` stub with three `@Test` regressions: all-duplicate labels, Y-axis empty labels, X-axis empty labels
- `TestForIssue799.java` — headless-safe demo class

Closes #799