### PR TITLE
Fix #658: rename tick-label formatter styler methods to proper Java case

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart06.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart06.java
@@ -62,7 +62,7 @@ public class DateChart06 implements ExampleChart<XYChart> {
 
     chart
         .getStyler()
-        .setyAxisTickLabelsFormattingFunction(x -> NumberWordConverter.convert(x.intValue()));
+        .setYAxisTickLabelsFormattingFunction(x -> NumberWordConverter.convert(x.intValue()));
 
     return chart;
   }

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart09.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/date/DateChart09.java
@@ -63,7 +63,7 @@ public class DateChart09 implements ExampleChart<XYChart> {
     DateTimeFormatter xTickFormatter = DateTimeFormatter.ofPattern("LLL");
     chart
         .getStyler()
-        .setxAxisTickLabelsFormattingFunction(
+        .setXAxisTickLabelsFormattingFunction(
             x -> startTime.plusDays(x.longValue()).format(xTickFormatter));
 
     // set custom cursor tool tip text

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue658.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue658.java
@@ -1,0 +1,58 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Map;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Demonstrates how to map specific X-axis tick positions to custom label strings using {@link
+ * org.knowm.xchart.style.AxesChartStyler#setXAxisTickLabelsFormattingFunction(java.util.function.Function)}.
+ *
+ * <p>Issue #658 asked whether a "tick location label map" API was available. The equivalent
+ * functionality is achieved via the formatting function: build a {@code Map<Double, String>} and
+ * pass a lookup lambda as the formatter. Tick values that are not in the map fall back to the
+ * default numeric format.
+ *
+ * <p>Expected result: X-axis shows "Mon"–"Fri" labels on the first five integer tick positions
+ * instead of raw numbers.
+ */
+public class TestForIssue658 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  public static XYChart getChart() {
+
+    double[] xData = new double[] {1, 2, 3, 4, 5};
+    double[] yData = new double[] {4, 5, 3, 8, 6};
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Issue #658 — custom X-axis tick labels via map")
+            .xAxisTitle("Day")
+            .yAxisTitle("Value")
+            .build();
+
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideSW);
+    chart.getStyler().setDefaultSeriesRenderStyle(XYSeries.XYSeriesRenderStyle.Line);
+
+    chart.addSeries("Sales", xData, yData);
+
+    Map<Double, String> dayLabels =
+        Map.of(1.0, "Mon", 2.0, "Tue", 3.0, "Wed", 4.0, "Thu", 5.0, "Fri");
+
+    chart
+        .getStyler()
+        .setXAxisTickLabelsFormattingFunction(
+            x -> dayLabels.getOrDefault(x, String.valueOf(x.intValue())));
+
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue792.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue792.java
@@ -5,7 +5,7 @@ import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XYChart;
 
 /**
- * Demonstrates the fix for issue #792 — {@code setxAxisTickLabelsFormattingFunction} dropping
+ * Demonstrates the fix for issue #792 — {@code setXAxisTickLabelsFormattingFunction} dropping
  * tick labels when the formatting function intentionally returns duplicate strings.
  *
  * <p>Before the fix: the internal {@code do-while} loop in {@code AxisTickCalculator_} kept
@@ -35,7 +35,7 @@ public class TestForIssue792 {
     // Hide every odd x tick label — previously this caused all but two ticks to disappear.
     chart
         .getStyler()
-        .setxAxisTickLabelsFormattingFunction(
+        .setXAxisTickLabelsFormattingFunction(
             x -> x.intValue() % 2 == 0 ? String.valueOf(x.intValue()) : " ");
 
     return chart;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxesChart.java
@@ -79,21 +79,25 @@ public abstract class AxesChart<ST extends AxesChartStyler, S extends AxesChartS
   }
 
   /**
-   * @Deprecated - use styler instead
+   * Sets a custom formatting function for X-axis tick labels. The function receives the raw tick
+   * value as a {@code Double} and returns the label string to display. This is a convenience
+   * shortcut for {@code chart.getStyler().setXAxisTickLabelsFormattingFunction(fn)}.
    *
-   * @param customFormattingFunction
+   * @param customFormattingFunction the formatting function; pass {@code null} to remove
    */
   public void setCustomXAxisTickLabelsFormatter(Function<Double, String> customFormattingFunction) {
-    styler.setxAxisTickLabelsFormattingFunction(customFormattingFunction);
+    styler.setXAxisTickLabelsFormattingFunction(customFormattingFunction);
   }
 
   /**
-   * @Deprecated - use styler instead
+   * Sets a custom formatting function for Y-axis tick labels. The function receives the raw tick
+   * value as a {@code Double} and returns the label string to display. This is a convenience
+   * shortcut for {@code chart.getStyler().setYAxisTickLabelsFormattingFunction(fn)}.
    *
-   * @param customFormattingFunction
+   * @param customFormattingFunction the formatting function; pass {@code null} to remove
    */
   public void setCustomYAxisTickLabelsFormatter(Function<Double, String> customFormattingFunction) {
-    styler.setyAxisTickLabelsFormattingFunction(customFormattingFunction);
+    styler.setYAxisTickLabelsFormattingFunction(customFormattingFunction);
   }
 
   Axis_X<ST, S> getXAxis() {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
@@ -217,10 +217,10 @@ public class Axis_X<ST extends AxesChartStyler, S extends AxesChartSeries> exten
       xData.addAll(uniqueXData);
     }
 
-    if (axesChartStyler.getxAxisTickLabelsFormattingFunction() != null) {
+    if (axesChartStyler.getXAxisTickLabelsFormattingFunction() != null) {
       if (!xData.isEmpty()) { // TODO why would this be empty?
         return new AxisTickCalculator_Callback(
-            axesChartStyler.getxAxisTickLabelsFormattingFunction(),
+            axesChartStyler.getXAxisTickLabelsFormattingFunction(),
             Axis_.Direction.X,
             workingSpace,
             min,
@@ -229,7 +229,7 @@ public class Axis_X<ST extends AxesChartStyler, S extends AxesChartSeries> exten
             axesChartStyler);
       }
       return new AxisTickCalculator_Callback(
-          axesChartStyler.getxAxisTickLabelsFormattingFunction(),
+          axesChartStyler.getXAxisTickLabelsFormattingFunction(),
           Axis_.Direction.X,
           workingSpace,
           min,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_Y.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_Y.java
@@ -303,10 +303,10 @@ public class Axis_Y<ST extends AxesChartStyler, S extends AxesChartSeries> exten
       yData.addAll(uniqueYData);
     }
 
-    if (axesChartStyler.getyAxisTickLabelsFormattingFunction() != null) {
+    if (axesChartStyler.getYAxisTickLabelsFormattingFunction() != null) {
       if (!yData.isEmpty()) {
         return new AxisTickCalculator_Callback(
-            axesChartStyler.getyAxisTickLabelsFormattingFunction(),
+            axesChartStyler.getYAxisTickLabelsFormattingFunction(),
             Axis_.Direction.Y,
             workingSpace,
             min,
@@ -315,7 +315,7 @@ public class Axis_Y<ST extends AxesChartStyler, S extends AxesChartSeries> exten
             axesChartStyler);
       }
       return new AxisTickCalculator_Callback(
-          axesChartStyler.getyAxisTickLabelsFormattingFunction(),
+          axesChartStyler.getYAxisTickLabelsFormattingFunction(),
           Axis_.Direction.Y,
           workingSpace,
           min,

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -793,24 +793,66 @@ public abstract class AxesChartStyler extends Styler {
     return this;
   }
 
-  public Function<Double, String> getxAxisTickLabelsFormattingFunction() {
+  public Function<Double, String> getXAxisTickLabelsFormattingFunction() {
+
     return xAxisTickLabelsFormattingFunction;
   }
 
-  public AxesChartStyler setxAxisTickLabelsFormattingFunction(
+  /**
+   * Sets a custom formatting function for X-axis tick labels. The function receives the raw tick
+   * value as a {@code Double} and returns the label string to display.
+   *
+   * @param xAxisTickLabelsFormattingFunction the formatting function; pass {@code null} to remove
+   */
+  public AxesChartStyler setXAxisTickLabelsFormattingFunction(
       Function<Double, String> xAxisTickLabelsFormattingFunction) {
+
     this.xAxisTickLabelsFormattingFunction = xAxisTickLabelsFormattingFunction;
     return this;
   }
 
-  public Function<Double, String> getyAxisTickLabelsFormattingFunction() {
+  /** @deprecated Use {@link #getXAxisTickLabelsFormattingFunction()} instead. */
+  @Deprecated
+  public Function<Double, String> getxAxisTickLabelsFormattingFunction() {
+    return getXAxisTickLabelsFormattingFunction();
+  }
+
+  /** @deprecated Use {@link #setXAxisTickLabelsFormattingFunction(Function)} instead. */
+  @Deprecated
+  public AxesChartStyler setxAxisTickLabelsFormattingFunction(
+      Function<Double, String> xAxisTickLabelsFormattingFunction) {
+    return setXAxisTickLabelsFormattingFunction(xAxisTickLabelsFormattingFunction);
+  }
+
+  public Function<Double, String> getYAxisTickLabelsFormattingFunction() {
+
     return yAxisTickLabelsFormattingFunction;
   }
 
-  public AxesChartStyler setyAxisTickLabelsFormattingFunction(
+  /**
+   * Sets a custom formatting function for Y-axis tick labels. The function receives the raw tick
+   * value as a {@code Double} and returns the label string to display.
+   *
+   * @param yAxisTickLabelsFormattingFunction the formatting function; pass {@code null} to remove
+   */
+  public AxesChartStyler setYAxisTickLabelsFormattingFunction(
       Function<Double, String> yAxisTickLabelsFormattingFunction) {
+
     this.yAxisTickLabelsFormattingFunction = yAxisTickLabelsFormattingFunction;
     return this;
+  }
+
+  /** @deprecated Use {@link #getYAxisTickLabelsFormattingFunction()} instead. */
+  @Deprecated
+  public Function<Double, String> getyAxisTickLabelsFormattingFunction() {
+    return getYAxisTickLabelsFormattingFunction();
+  }
+
+  /** @deprecated Use {@link #setYAxisTickLabelsFormattingFunction(Function)} instead. */
+  @Deprecated
+  public AxesChartStyler setyAxisTickLabelsFormattingFunction(
+      Function<Double, String> yAxisTickLabelsFormattingFunction) {
+    return setYAxisTickLabelsFormattingFunction(yAxisTickLabelsFormattingFunction);
   }
 
   // TickLabels and MarksColor colors for xAxis, yAxis, yAxisGroup ////////////////////////////////

--- a/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
@@ -18,7 +18,7 @@ public class XYChartTest {
     double[] xData = new double[] {0.0, 1.0, 2.0};
     double[] yData = new double[] {2.0, 1.0, 0.0};
     XYChart chart = QuickChart.getChart("Sample Chart", "X", "Y", "y(x)", xData, yData);
-    chart.getStyler().setyAxisTickLabelsFormattingFunction(yValue -> "1");
+    chart.getStyler().setYAxisTickLabelsFormattingFunction(yValue -> "1");
 
     DigestOutputStream output =
         new DigestOutputStream(new ByteArrayOutputStream(), MessageDigest.getInstance(digestType));

--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue792Test.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue792Test.java
@@ -20,7 +20,7 @@ public class RegressionIssue792Test {
     XYChart chart = QuickChart.getChart("Sample Chart", "X", "Y", "y(x)", null, yData);
     chart
         .getStyler()
-        .setxAxisTickLabelsFormattingFunction(
+        .setXAxisTickLabelsFormattingFunction(
             x -> x.intValue() % 2 == 0 ? String.valueOf(x.intValue()) : " ");
 
     // when


### PR DESCRIPTION
## Problem

Issue #658 asks whether a custom tick-label API exists. It does — but users couldn't find it because `setxAxisTickLabelsFormattingFunction` starts with a lowercase `x`, making it invisible in IDE autocompletion next to all the other `setX…` / `setY…` styler methods.

To make things worse, the nicer convenience methods `setCustomXAxisTickLabelsFormatter` / `setCustomYAxisTickLabelsFormatter` on `AxesChart` were marked `@Deprecated`, pushing users toward the hard-to-find styler methods.

## Changes

### `AxesChartStyler`
- Add `setXAxisTickLabelsFormattingFunction` / `getXAxisTickLabelsFormattingFunction` (uppercase X — proper Java convention)
- Add `setYAxisTickLabelsFormattingFunction` / `getYAxisTickLabelsFormattingFunction` (uppercase Y)
- Deprecate the old lowercase `setxAxis…` / `setyAxis…` variants; they now delegate to the new methods (no behaviour change)

### `AxesChart`
- Remove the erroneous `@Deprecated` tag from `setCustomXAxisTickLabelsFormatter` / `setCustomYAxisTickLabelsFormatter`
- Add proper Javadoc to both
- Update internal calls to the new styler method names

### Internal callers
- `Axis_X`, `Axis_Y` updated to call the new getter names

### Demos & tests
- All existing callsites updated to the new names
- `TestForIssue658.java` added — shows the map-to-label pattern (build a `Map<Double, String>` and pass a lookup lambda as the formatter)

## Usage after this fix

```java
// Via the chart convenience method (recommended)
chart.setCustomXAxisTickLabelsFormatter(x -> myLabels.getOrDefault(x, ""));

// Or directly via the styler
chart.getStyler().setXAxisTickLabelsFormattingFunction(x -> myLabels.getOrDefault(x, ""));
```

Closes #658