### PR TITLE
Fix #881: restore deprecated AnnotationType shims and fix outside label font color

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue881.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue881.java
@@ -1,0 +1,42 @@
+package org.knowm.xchart.standalone.issues;
+
+import org.knowm.xchart.PieChart;
+import org.knowm.xchart.PieChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.PieStyler.AnnotationType;
+
+/**
+ * Reproduces issue #881: AnnotationType and setAnnotationDistance removed since 3.8.1.
+ *
+ * <p>The deprecated shims {@code setAnnotationType(AnnotationType)} and {@code
+ * setAnnotationDistance(double)} are restored and delegate to the new API ({@code
+ * setLabelType(LabelType)} and {@code setLabelsDistance(double)}).
+ */
+public class TestForIssue881 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  @SuppressWarnings("deprecation")
+  public static PieChart getChart() {
+
+    PieChart chart =
+        new PieChartBuilder().width(600).height(500).title("Issue 881 - AnnotationType shim").build();
+
+    // Old API that broke after 3.8.1 — now restored as deprecated shims
+    chart.getStyler().setAnnotationType(AnnotationType.LabelAndPercentage);
+    chart.getStyler().setAnnotationDistance(1.15);
+    chart.getStyler().setForceAllLabelsVisible(true);
+    // When labelsDistance > 1.0, reduce plotContentSize to leave room for outside labels
+    chart.getStyler().setPlotContentSize(.7);
+
+    chart.addSeries("Java", 43);
+    chart.addSeries("Python", 30);
+    chart.addSeries("C++", 15);
+    chart.addSeries("Other", 12);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -364,7 +364,9 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
         // draw label
         if (pieStyler.isForceAllLabelsVisible() || labelWillFit) {
 
-          if (pieStyler.isLabelsFontColorAutomaticEnabled()) {
+          if (pieStyler.isLabelsFontColorAutomaticEnabled() && pieStyler.getLabelsDistance() <= 1.0) {
+            // Auto color only makes sense for inside labels where the slice fill is the background.
+            // Outside labels sit on the plot background, so use the configured label color.
             g.setColor(pieStyler.getLabelsFontColor(series.getFillColor()));
           } else {
             g.setColor(pieStyler.getLabelsFontColor());

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -374,9 +374,11 @@ public class PieStyler extends Styler {
   }
 
   /**
-   * @deprecated Use {@link LabelType} with {@link #setLabelType(LabelType)} instead. Mapping:
-   *     {@code Label} → {@link LabelType#Name}, {@code LabelAndPercentage} → {@link
-   *     LabelType#NameAndPercentage}, {@code LabelAndValue} → {@link LabelType#NameAndValue}.
+   * @deprecated Use {@link LabelType} with {@link #setLabelType(LabelType)} instead. Full mapping:
+   *     {@code Value} → {@link LabelType#Value}, {@code Percentage} → {@link
+   *     LabelType#Percentage}, {@code Label} → {@link LabelType#Name}, {@code LabelAndPercentage}
+   *     → {@link LabelType#NameAndPercentage}, {@code LabelAndValue} → {@link
+   *     LabelType#NameAndValue}.
    */
   @Deprecated
   public enum AnnotationType {

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -373,6 +373,56 @@ public class PieStyler extends Styler {
     NameAndValue
   }
 
+  /**
+   * @deprecated Use {@link LabelType} with {@link #setLabelType(LabelType)} instead. Mapping:
+   *     {@code Label} → {@link LabelType#Name}, {@code LabelAndPercentage} → {@link
+   *     LabelType#NameAndPercentage}, {@code LabelAndValue} → {@link LabelType#NameAndValue}.
+   */
+  @Deprecated
+  public enum AnnotationType {
+    Value,
+    Percentage,
+    Label,
+    LabelAndPercentage,
+    LabelAndValue
+  }
+
+  /**
+   * @deprecated Use {@link #setLabelType(LabelType)} instead.
+   * @param annotationType the old annotation type
+   */
+  @Deprecated
+  public PieStyler setAnnotationType(AnnotationType annotationType) {
+
+    if (annotationType == null) {
+      return setLabelType(null);
+    }
+    switch (annotationType) {
+      case Value:
+        return setLabelType(LabelType.Value);
+      case Percentage:
+        return setLabelType(LabelType.Percentage);
+      case Label:
+        return setLabelType(LabelType.Name);
+      case LabelAndPercentage:
+        return setLabelType(LabelType.NameAndPercentage);
+      case LabelAndValue:
+        return setLabelType(LabelType.NameAndValue);
+      default:
+        return setLabelType(null);
+    }
+  }
+
+  /**
+   * @deprecated Use {@link #setLabelsDistance(double)} instead.
+   * @param annotationDistance the distance from center (0 = center, 1 = edge, &gt;1 = outside)
+   */
+  @Deprecated
+  public PieStyler setAnnotationDistance(double annotationDistance) {
+
+    return setLabelsDistance(annotationDistance);
+  }
+
   public enum ClockwiseDirectionType {
     CLOCKWISE,
     COUNTER_CLOCKWISE


### PR DESCRIPTION
Closes #881

## Changes

### 1. `PieStyler` — deprecated compatibility shims
The 3.8.1 rename of `annotation*` → `label*` silently dropped `AnnotationType` and `setAnnotationDistance()`, breaking all code written against the old API without any migration path.

Restored as `@Deprecated` shims that delegate to the new API:

| Old | New |
|-----|-----|
| `setAnnotationType(AnnotationType.LabelAndPercentage)` | `setLabelType(LabelType.NameAndPercentage)` |
| `setAnnotationType(AnnotationType.Label)` | `setLabelType(LabelType.Name)` |
| `setAnnotationType(AnnotationType.LabelAndValue)` | `setLabelType(LabelType.NameAndValue)` |
| `setAnnotationDistance(d)` | `setLabelsDistance(d)` |

Old code now compiles again (with deprecation warnings pointing to the replacement API).

### 2. `PlotContent_Pie` — outside label font color bug
When `isLabelsFontColorAutomaticEnabled` is `true` and `labelsDistance > 1.0`, the auto font-color detection was passing the **slice fill color** as the background. This produced white text on a white plot background, making outside labels invisible.

Fix: auto-color detection is only applied for inside labels (`labelsDistance <= 1.0`). Outside labels always sit on the plot background so they use the configured `labelsFontColor`.

### 3. Demo
`TestForIssue881.java` — exercises the deprecated API end-to-end. Note: `setPlotContentSize(.7)` is required when using `labelsDistance > 1.0` (same pattern as the existing `PieChart03` example).