### PR TITLE
Fix #834: custom tick formatter breaks logarithmic axis

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue834.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue834.java
@@ -1,0 +1,54 @@
+package org.knowm.xchart.standalone.issues;
+
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+
+/**
+ * Verifies that a custom Y-axis tick label formatter works correctly with a logarithmic Y-axis.
+ *
+ * <p>Before the fix, setting a custom formatter disabled logarithmic scaling entirely and the
+ * formatter received linearly-spaced values (0, 1e8, 2e8 …) instead of the expected powers of ten
+ * (1, 10, 100, … 1e8).
+ */
+public class TestForIssue834 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  public static XYChart getChart() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(720)
+            .height(480)
+            .title("Issue 834 – custom formatter + logarithmic Y-axis")
+            .xAxisTitle("Count")
+            .yAxisTitle("Energy")
+            .build();
+
+    chart.getStyler().setYAxisLogarithmic(true);
+    chart.setCustomYAxisTickLabelsFormatter(TestForIssue834::formatEnergy);
+
+    double[] xValues = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    double[] yValues = new double[] {1, 10, 100, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8};
+    chart.addSeries("main", xValues, yValues);
+
+    return chart;
+  }
+
+  private static String formatEnergy(Double value) {
+
+    if (value < 1e3) {
+      return String.format("%.0f nJ", value);
+    } else if (value < 1e6) {
+      return String.format("%.2f µJ", value / 1e3);
+    } else if (value < 1e9) {
+      return String.format("%.2f mJ", value / 1e6);
+    } else {
+      return String.format("%.2f J", value / 1e9);
+    }
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue834.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue834.java
@@ -18,6 +18,7 @@ public class TestForIssue834 {
     new SwingWrapper<>(getChart()).displayChart();
   }
 
+  /** Constructs and returns the chart without launching a window (headless-safe). */
   public static XYChart getChart() {
 
     XYChart chart =

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Logarithmic.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Logarithmic.java
@@ -1,6 +1,7 @@
 package org.knowm.xchart.internal.chartpart;
 
 import java.math.BigDecimal;
+import java.util.function.Function;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.Axis_.Direction;
 import org.knowm.xchart.style.AxesChartStyler;
@@ -59,12 +60,63 @@ class AxisTickCalculator_Logarithmic extends AxisTickCalculator_ {
     calculate();
   }
 
+  /**
+   * Constructor with a custom label formatting callback. Tick positions are still computed
+   * logarithmically; only the label text is produced by the supplied function.
+   *
+   * @param axisDirection
+   * @param workingSpace
+   * @param minValue
+   * @param maxValue
+   * @param styler
+   * @param customFormattingFunction
+   */
+  public AxisTickCalculator_Logarithmic(
+      Direction axisDirection,
+      double workingSpace,
+      double minValue,
+      double maxValue,
+      AxesChartStyler styler,
+      Function<Double, String> customFormattingFunction) {
+
+    super(axisDirection, workingSpace, minValue, maxValue, styler);
+    formatterLogNumber = new Formatter_LogNumber(styler, axisDirection);
+    axisFormat = new Formatter_Custom(customFormattingFunction);
+    calculate();
+  }
+
+  /**
+   * Constructor with a custom label formatting callback for a specific Y-axis index.
+   *
+   * @param axisDirection
+   * @param workingSpace
+   * @param minValue
+   * @param maxValue
+   * @param styler
+   * @param yIndex
+   * @param customFormattingFunction
+   */
+  public AxisTickCalculator_Logarithmic(
+      Direction axisDirection,
+      double workingSpace,
+      double minValue,
+      double maxValue,
+      AxesChartStyler styler,
+      int yIndex,
+      Function<Double, String> customFormattingFunction) {
+
+    super(axisDirection, workingSpace, minValue, maxValue, styler);
+    formatterLogNumber = new Formatter_LogNumber(styler, axisDirection, yIndex);
+    axisFormat = new Formatter_Custom(customFormattingFunction);
+    calculate();
+  }
+
   @Override
   protected void calculate() {
 
     // a check if all axis data are the exact same values
     if (minValue == maxValue) {
-      tickLabels.add(formatterLogNumber.format(BigDecimal.valueOf(maxValue).doubleValue()));
+      tickLabels.add(axisFormat.format(BigDecimal.valueOf(maxValue).doubleValue()));
       tickLocations.add(workingSpace / 2.0);
       return;
     }
@@ -137,7 +189,7 @@ class AxisTickCalculator_Logarithmic extends AxisTickCalculator_ {
 
         // only add labels for the decades
         if (!axisDecadeOnly || j == 1 || j == 10) {
-          tickLabels.add(formatterLogNumber.format(tickValue));
+          tickLabels.add(axisFormat.format(tickValue));
         } else {
           tickLabels.add(null);
         }
@@ -155,9 +207,9 @@ class AxisTickCalculator_Logarithmic extends AxisTickCalculator_ {
       firstPosition = 2;
     }
     if (tickLocations.size() <= 1) {
-      tickLabels.add(formatterLogNumber.format(minValue));
+      tickLabels.add(axisFormat.format(minValue));
       tickLocations.add(margin);
-      tickLabels.add(formatterLogNumber.format(maxValue));
+      tickLabels.add(axisFormat.format(maxValue));
       tickLocations.add(margin + tickSpace);
     }
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
@@ -217,7 +217,18 @@ public class Axis_X<ST extends AxesChartStyler, S extends AxesChartSeries> exten
       xData.addAll(uniqueXData);
     }
 
-    if (axesChartStyler.getXAxisTickLabelsFormattingFunction() != null) {
+    if (axesChartStyler.getXAxisTickLabelsFormattingFunction() != null
+        && axesChartStyler.isXAxisLogarithmic()) {
+
+      return new AxisTickCalculator_Logarithmic(
+          Axis_.Direction.X,
+          workingSpace,
+          min,
+          max,
+          axesChartStyler,
+          axesChartStyler.getXAxisTickLabelsFormattingFunction());
+
+    } else if (axesChartStyler.getXAxisTickLabelsFormattingFunction() != null) {
       if (!xData.isEmpty()) { // TODO why would this be empty?
         return new AxisTickCalculator_Callback(
             axesChartStyler.getXAxisTickLabelsFormattingFunction(),

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
@@ -218,7 +218,8 @@ public class Axis_X<ST extends AxesChartStyler, S extends AxesChartSeries> exten
     }
 
     if (axesChartStyler.getXAxisTickLabelsFormattingFunction() != null
-        && axesChartStyler.isXAxisLogarithmic()) {
+        && axesChartStyler.isXAxisLogarithmic()
+        && getDataType() != DataType.Date) {
 
       return new AxisTickCalculator_Logarithmic(
           Axis_.Direction.X,

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_Y.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_Y.java
@@ -303,7 +303,20 @@ public class Axis_Y<ST extends AxesChartStyler, S extends AxesChartSeries> exten
       yData.addAll(uniqueYData);
     }
 
-    if (axesChartStyler.getYAxisTickLabelsFormattingFunction() != null) {
+    if (axesChartStyler.getYAxisTickLabelsFormattingFunction() != null
+        && axesChartStyler.isYAxisLogarithmic()
+        && getDataType() != DataType.Date) {
+
+      return new AxisTickCalculator_Logarithmic(
+          Axis_.Direction.Y,
+          workingSpace,
+          min,
+          max,
+          axesChartStyler,
+          getYIndex(),
+          axesChartStyler.getYAxisTickLabelsFormattingFunction());
+
+    } else if (axesChartStyler.getYAxisTickLabelsFormattingFunction() != null) {
       if (!yData.isEmpty()) {
         return new AxisTickCalculator_Callback(
             axesChartStyler.getYAxisTickLabelsFormattingFunction(),

--- a/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
@@ -65,4 +65,38 @@ public class XYChartTest {
     assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
         .doesNotThrowAnyException();
   }
+
+  // https://github.com/knowm/XChart/issues/834 — custom formatter must not break logarithmic axis
+  @Test
+  public void customYAxisFormatterPreservesLogarithmicScale() throws Exception {
+    double[] xData = new double[] {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    double[] yData = new double[] {1, 10, 100, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8};
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+    chart.addSeries("test", xData, yData);
+    chart.getStyler().setYAxisLogarithmic(true);
+    chart.setCustomYAxisTickLabelsFormatter(
+        value -> {
+          if (value < 1e3) return String.format("%.0f nJ", value);
+          else if (value < 1e6) return String.format("%.2f µJ", value / 1e3);
+          else if (value < 1e9) return String.format("%.2f mJ", value / 1e6);
+          else return String.format("%.2f J", value / 1e9);
+        });
+
+    assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
+        .doesNotThrowAnyException();
+  }
+
+  // https://github.com/knowm/XChart/issues/834 — same for logarithmic X-axis
+  @Test
+  public void customXAxisFormatterPreservesLogarithmicScale() throws Exception {
+    double[] xData = new double[] {1, 10, 100, 1e3, 1e4, 1e5};
+    double[] yData = new double[] {1, 2, 3, 4, 5, 6};
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+    chart.addSeries("test", xData, yData);
+    chart.getStyler().setXAxisLogarithmic(true);
+    chart.setCustomXAxisTickLabelsFormatter(value -> String.format("10^%.0f", Math.log10(value)));
+
+    assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
+        .doesNotThrowAnyException();
+  }
 }

--- a/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
@@ -1,11 +1,14 @@
 package org.knowm.xchart;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.io.ByteArrayOutputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -74,16 +77,25 @@ public class XYChartTest {
     XYChart chart = new XYChartBuilder().width(800).height(600).build();
     chart.addSeries("test", xData, yData);
     chart.getStyler().setYAxisLogarithmic(true);
+
+    List<Double> seenValues = new ArrayList<>();
     chart.setCustomYAxisTickLabelsFormatter(
         value -> {
-          if (value < 1e3) return String.format("%.0f nJ", value);
-          else if (value < 1e6) return String.format("%.2f µJ", value / 1e3);
-          else if (value < 1e9) return String.format("%.2f mJ", value / 1e6);
-          else return String.format("%.2f J", value / 1e9);
+          seenValues.add(value);
+          return String.valueOf(value);
         });
 
-    assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
-        .doesNotThrowAnyException();
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+
+    // Every value the formatter receives must be a power of ten (log10 is a whole number).
+    // A linear fallback would produce evenly-spaced values like 0, 1e7, 2e7 ... which fail this.
+    assertThat(seenValues).isNotEmpty();
+    for (double v : seenValues) {
+      double log = Math.log10(v);
+      assertThat(Math.abs(log - Math.round(log)))
+          .as("Expected power-of-ten tick value but got %s", v)
+          .isLessThan(1e-9);
+    }
   }
 
   // https://github.com/knowm/XChart/issues/834 — same for logarithmic X-axis
@@ -94,9 +106,22 @@ public class XYChartTest {
     XYChart chart = new XYChartBuilder().width(800).height(600).build();
     chart.addSeries("test", xData, yData);
     chart.getStyler().setXAxisLogarithmic(true);
-    chart.setCustomXAxisTickLabelsFormatter(value -> String.format("10^%.0f", Math.log10(value)));
 
-    assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
-        .doesNotThrowAnyException();
+    List<Double> seenValues = new ArrayList<>();
+    chart.setCustomXAxisTickLabelsFormatter(
+        value -> {
+          seenValues.add(value);
+          return String.valueOf(value);
+        });
+
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+
+    assertThat(seenValues).isNotEmpty();
+    for (double v : seenValues) {
+      double log = Math.log10(v);
+      assertThat(Math.abs(log - Math.round(log)))
+          .as("Expected power-of-ten tick value but got %s", v)
+          .isLessThan(1e-9);
+    }
   }
 }


### PR DESCRIPTION
## Problem

When a custom axis tick label formatter was set alongside a logarithmic axis (`setYAxisLogarithmic(true)` + `setCustomYAxisTickLabelsFormatter(...)`), the logarithmic scaling was silently discarded. The formatter received linearly-spaced values (`0, 1e8, 2e8 ...`) instead of the expected powers-of-ten (`1, 10, 100 ... 1e8`), and the chart rendered as a linear axis.

The root cause: in both `Axis_Y.getAxisTickCalculatorForY()` and `Axis_X.getAxisTickCalculatorForX()`, the custom-formatter check came first in the if/else chain and unconditionally routed to `AxisTickCalculator_Callback`, which inherits the base *linear* `calculate()` method. The logarithmic branch was never reached.

## Approach

The fix combines logarithmic tick-position calculation with custom label formatting:

- **`AxisTickCalculator_Logarithmic`** -- all `formatterLogNumber.format()` calls inside `calculate()` are replaced with `axisFormat.format()`. Since `axisFormat` defaults to `formatterLogNumber`, existing behavior is unchanged. Two new constructors accept a `Function<Double, String>` and set `axisFormat = new Formatter_Custom(fn)` before `calculate()` runs, so tick *positions* remain logarithmic while tick *labels* come from the callback.

- **`Axis_Y` / `Axis_X`** -- a new combined-case branch is added *above* the plain callback branch: when both a custom formatter and logarithmic mode are active, it routes to the new constructors instead of `AxisTickCalculator_Callback`.

No changes to base classes; the fix is fully contained in these three files.

## Testing

- Two new unit tests in `XYChartTest` (Y-axis and X-axis variants) verify the chart renders without throwing.
- `TestForIssue834.java` demo reproduces the reporter's exact use case -- logarithmic Y-axis with an energy unit formatter (`nJ / µJ / mJ / J`). The axis now shows correct log spacing with custom labels.