### PR TITLE
Fix #712: guard against zero/negative plot area in Plot_AxesChart

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue712.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue712.java
@@ -1,0 +1,51 @@
+package org.knowm.xchart.standalone.issues;
+
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries;
+
+/**
+ * Demonstrates the fix for issue #712 — NullPointerException when the chart panel is resized to be
+ * very small.
+ *
+ * <p>When the chart window was made narrow (especially with multiple Y-axis groups), the axis
+ * columns consumed more space than the total chart width, leaving a zero or negative plot area.
+ * Painting with degenerate geometry caused a {@link NullPointerException} in AWT path operations.
+ *
+ * <p>The fix adds an early-exit guard in {@code Plot_AxesChart.paint()} that skips painting
+ * entirely when the computed plot width or height is &lt;= 0.
+ *
+ * <p>Run this demo, then shrink the window as narrow as possible — no exception should be thrown.
+ */
+public class TestForIssue712 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Builds an XYChart with multiple Y-axis groups to reproduce the original failure scenario. */
+  public static XYChart getChart() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(600)
+            .height(400)
+            .title("Issue #712 – resize me as narrow as possible")
+            .xAxisTitle("X")
+            .build();
+
+    chart.addSeries("Series A", new double[] {1, 2, 3, 4, 5}, new double[] {10, 20, 15, 25, 18});
+
+    XYSeries seriesB =
+        chart.addSeries("Series B", new double[] {1, 2, 3, 4, 5}, new double[] {100, 200, 150, 250, 180});
+    seriesB.setYAxisGroup(1);
+
+    XYSeries seriesC =
+        chart.addSeries("Series C", new double[] {1, 2, 3, 4, 5}, new double[] {1000, 2000, 1500, 2500, 1800});
+    seriesC.setYAxisGroup(2);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_AxesChart.java
@@ -42,6 +42,13 @@ public class Plot_AxesChart<ST extends AxesChartStyler, S extends AxesChartSerie
     // Rectangle2D. See issue #712.
     if (width <= 0 || height <= 0) {
       this.bounds = new Rectangle2D.Double(xOffset, yOffset, 0, 0);
+      // Clear any stale tooltip/cursor state so hover overlays don't persist after
+      // the window is shrunk to a size where no plot can be drawn.
+      PlotInteractionData id = plotContent.getInteractionData();
+      if (id != null) {
+        id.clear();
+        id.plotBounds = this.bounds;
+      }
       return;
     }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_AxesChart.java
@@ -33,6 +33,18 @@ public class Plot_AxesChart<ST extends AxesChartStyler, S extends AxesChartSerie
     double yOffset = yAxisBounds.getY();
     double width = xAxisBounds.getWidth();
     double height = yAxisBounds.getHeight();
+
+    // When the window is resized to be very small (especially with multiple Y-axis groups),
+    // axis columns can consume more space than the total chart width, leaving a zero or
+    // negative plot area. Painting with degenerate geometry causes NullPointerException in
+    // AWT path operations, so bail out early. We still assign a zero-size bounds so that
+    // downstream components (e.g. Legend_) that read getBounds() always receive a non-null
+    // Rectangle2D. See issue #712.
+    if (width <= 0 || height <= 0) {
+      this.bounds = new Rectangle2D.Double(xOffset, yOffset, 0, 0);
+      return;
+    }
+
     this.bounds = new Rectangle2D.Double(xOffset, yOffset, width, height);
 
     super.paint(g);

--- a/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
@@ -69,6 +69,34 @@ public class XYChartTest {
         .doesNotThrowAnyException();
   }
 
+  // https://github.com/knowm/XChart/issues/712 — painting a tiny chart (degenerate bounds) must not NPE
+  @Test
+  public void paintingTinyChartDoesNotThrow() throws Exception {
+
+    // A 1×1 pixel chart has a zero/negative plot area after axis columns are subtracted; the
+    // guard in Plot_AxesChart.paint() must bail out without throwing.
+    XYChart chart = new XYChartBuilder().width(1).height(1).build();
+    chart.addSeries("s", new double[] {1, 2, 3}, new double[] {1, 2, 3});
+
+    assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
+        .doesNotThrowAnyException();
+  }
+
+  // Variant: multiple Y-axis groups (more axis columns → plot area goes negative sooner)
+  @Test
+  public void paintingTinyChartWithMultipleYAxisGroupsDoesNotThrow() throws Exception {
+
+    XYChart chart = new XYChartBuilder().width(1).height(1).build();
+    chart.addSeries("a", new double[] {1, 2, 3}, new double[] {10, 20, 30});
+    XYSeries b = chart.addSeries("b", new double[] {1, 2, 3}, new double[] {100, 200, 300});
+    b.setYAxisGroup(1);
+    XYSeries c = chart.addSeries("c", new double[] {1, 2, 3}, new double[] {1000, 2000, 3000});
+    c.setYAxisGroup(2);
+
+    assertThatCode(() -> BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG))
+        .doesNotThrowAnyException();
+  }
+
   // https://github.com/knowm/XChart/issues/834 — custom formatter must not break logarithmic axis
   @Test
   public void customYAxisFormatterPreservesLogarithmicScale() throws Exception {


### PR DESCRIPTION
## Problem

When a `XChartPanel` is resized to be very narrow — especially with multiple Y-axis groups — each axis column consumes horizontal space. Once the total axis width exceeds the chart width, the remaining plot area becomes zero or negative. Painting with that degenerate geometry caused a repeating `NullPointerException` deep inside `PlotContent_XY.doPaint()`.

Fixes #712.

## Root Cause

`Plot_AxesChart.paint()` computed `width = xAxisBounds.getWidth()` and `height = yAxisBounds.getHeight()` and passed them straight to `new Rectangle2D.Double(...)`. When `width <= 0` or `height <= 0`, every downstream renderer (`PlotContent_XY`, `Legend_`, etc.) received a rectangle with invalid dimensions, causing NPEs in AWT path operations.

The existing guard in `PlotContent_.paint()` (`bounds.getWidth() < 30`) handles near-zero cases but is insufficient when the bounds goes fully non-positive at the `Plot_AxesChart` level.

## Fix

Added an early-exit guard in `Plot_AxesChart.paint()`:

```java
if (width <= 0 || height <= 0) {
  this.bounds = new Rectangle2D.Double(xOffset, yOffset, 0, 0);
  return;
}
```

A zero-size `Rectangle2D` is still assigned so downstream callers like `Legend_.paint()` (which reads `chart.getPlot().getBounds()`) always receive a non-null value; `Legend_`'s own existing `width < 30` check then correctly skips painting.

## Testing

- Added `paintingTinyChartDoesNotThrow()` — paints a 1×1 chart
- Added `paintingTinyChartWithMultipleYAxisGroupsDoesNotThrow()` — paints a 1×1 chart with 3 Y-axis groups (the original failure scenario)
- Added `TestForIssue712.java` demo — run and resize the window as narrow as possible to verify no exception is thrown
- Full `xchart` test suite passes (`mvn test -pl xchart`)