### PR TITLE
Fix #975: move chart button styling out of Styler/Theme into ChartButtonConfig

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue975.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue975.java
@@ -1,0 +1,62 @@
+package org.knowm.xchart.standalone.issues;
+
+import org.knowm.xchart.ChartButtonConfig;
+import org.knowm.xchart.ChartButtonConfig.ChartButtonPosition;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.style.colors.ChartColor;
+
+/**
+ * Demonstrates issue #975 — chart button styling moved out of {@code Styler}/{@code Theme} into
+ * {@link ChartButtonConfig} on {@link XChartPanel}.
+ *
+ * <p>Previously, {@code Styler} carried six {@code chartButton*} fields that were exclusively used
+ * by the Swing layer ({@code ChartButton}, {@code ChartZoom}), polluting every headless render
+ * path. These have been removed from {@code Styler} and {@code Theme} and replaced by the new
+ * {@link ChartButtonConfig} class, which lives entirely within the Swing rendering layer.
+ *
+ * <p>This demo shows the zoom-reset button using a custom {@code ChartButtonConfig}: red
+ * background, white text, and positioned in the bottom-right corner. Drag a selection on the chart
+ * to trigger the zoom and reveal the styled reset button.
+ */
+public class TestForIssue975 {
+
+  public static void main(String[] args) {
+
+    XYChart chart = getChart();
+    XChartPanel<XYChart> panel = new XChartPanel<>(chart);
+
+    // Customise button styling via ChartButtonConfig — no longer touches the Styler.
+    panel.setChartButtonConfig(
+        new ChartButtonConfig()
+            .setBackgroundColor(ChartColor.RED.getColor())
+            .setBorderColor(ChartColor.DARK_GREY.getColor())
+            .setFontColor(java.awt.Color.WHITE)
+            .setMargin(8)
+            .setPosition(ChartButtonPosition.InsideSE));
+
+    panel.setZoomEnabled(true);
+    panel.setZoomResetByButton(true);
+
+    new SwingWrapper<>(chart).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static XYChart getChart() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(700)
+            .height(400)
+            .title("Issue #975 – ChartButtonConfig demo")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .build();
+
+    chart.addSeries("series1", new double[]{1, 2, 3, 4, 5}, new double[]{2, 4, 3, 7, 5});
+    chart.addSeries("series2", new double[]{1, 2, 3, 4, 5}, new double[]{5, 3, 6, 2, 8});
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue975.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue975.java
@@ -1,8 +1,9 @@
 package org.knowm.xchart.standalone.issues;
 
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 import org.knowm.xchart.ChartButtonConfig;
 import org.knowm.xchart.ChartButtonConfig.ChartButtonPosition;
-import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
@@ -25,22 +26,30 @@ public class TestForIssue975 {
 
   public static void main(String[] args) {
 
-    XYChart chart = getChart();
-    XChartPanel<XYChart> panel = new XChartPanel<>(chart);
+    SwingUtilities.invokeLater(
+        () -> {
+          XYChart chart = getChart();
 
-    // Customise button styling via ChartButtonConfig — no longer touches the Styler.
-    panel.setChartButtonConfig(
-        new ChartButtonConfig()
-            .setBackgroundColor(ChartColor.RED.getColor())
-            .setBorderColor(ChartColor.DARK_GREY.getColor())
-            .setFontColor(java.awt.Color.WHITE)
-            .setMargin(8)
-            .setPosition(ChartButtonPosition.InsideSE));
+          XChartPanel<XYChart> panel = new XChartPanel<>(chart);
 
-    panel.setZoomEnabled(true);
-    panel.setZoomResetByButton(true);
+          // Customise button styling via ChartButtonConfig — no longer touches the Styler.
+          panel.setChartButtonConfig(
+              new ChartButtonConfig()
+                  .setBackgroundColor(ChartColor.RED.getColor())
+                  .setBorderColor(ChartColor.DARK_GREY.getColor())
+                  .setFontColor(java.awt.Color.WHITE)
+                  .setMargin(8)
+                  .setPosition(ChartButtonPosition.InsideSE));
 
-    new SwingWrapper<>(chart).displayChart();
+          panel.setZoomEnabled(true);
+          panel.setZoomResetByButton(true);
+
+          JFrame frame = new JFrame("Issue #975 – ChartButtonConfig demo");
+          frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+          frame.getContentPane().add(panel);
+          frame.pack();
+          frame.setVisible(true);
+        });
   }
 
   /** Constructs and returns the chart without launching a window (headless-safe). */

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue975.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue975.java
@@ -1,9 +1,8 @@
 package org.knowm.xchart.standalone.issues;
 
-import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
 import org.knowm.xchart.ChartButtonConfig;
 import org.knowm.xchart.ChartButtonConfig.ChartButtonPosition;
+import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
@@ -26,30 +25,20 @@ public class TestForIssue975 {
 
   public static void main(String[] args) {
 
-    SwingUtilities.invokeLater(
-        () -> {
-          XYChart chart = getChart();
+    SwingWrapper<XYChart> sw = new SwingWrapper<>(getChart());
+    sw.displayChart();
 
-          XChartPanel<XYChart> panel = new XChartPanel<>(chart);
-
-          // Customise button styling via ChartButtonConfig — no longer touches the Styler.
-          panel.setChartButtonConfig(
-              new ChartButtonConfig()
-                  .setBackgroundColor(ChartColor.RED.getColor())
-                  .setBorderColor(ChartColor.DARK_GREY.getColor())
-                  .setFontColor(java.awt.Color.WHITE)
-                  .setMargin(8)
-                  .setPosition(ChartButtonPosition.InsideSE));
-
-          panel.setZoomEnabled(true);
-          panel.setZoomResetByButton(true);
-
-          JFrame frame = new JFrame("Issue #975 – ChartButtonConfig demo");
-          frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-          frame.getContentPane().add(panel);
-          frame.pack();
-          frame.setVisible(true);
-        });
+    // Configure zoom and the custom button style on the panel created by SwingWrapper.
+    sw.getXChartPanel()
+        .setChartButtonConfig(
+            new ChartButtonConfig()
+                .setBackgroundColor(ChartColor.RED.getColor())
+                .setBorderColor(ChartColor.DARK_GREY.getColor())
+                .setFontColor(java.awt.Color.WHITE)
+                .setMargin(8)
+                .setPosition(ChartButtonPosition.InsideSE))
+        .setZoomEnabled(true)
+        .setZoomResetByButton(true);
   }
 
   /** Constructs and returns the chart without launching a window (headless-safe). */

--- a/xchart/src/main/java/org/knowm/xchart/ChartButtonConfig.java
+++ b/xchart/src/main/java/org/knowm/xchart/ChartButtonConfig.java
@@ -23,7 +23,6 @@ public class ChartButtonConfig {
 
   private Color backgroundColor = ChartColor.LIGHT_GREY.getColor();
   private Color borderColor = ChartColor.DARK_GREY.getColor();
-  private Color hoverColor = ChartColor.LIGHT_GREY.getColor().brighter();
   private Color fontColor = ChartColor.BLACK.getColor();
   private Font font = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
   private int margin = 6;
@@ -58,22 +57,6 @@ public class ChartButtonConfig {
   public ChartButtonConfig setBorderColor(Color borderColor) {
 
     this.borderColor = borderColor;
-    return this;
-  }
-
-  public Color getHoverColor() {
-
-    return hoverColor;
-  }
-
-  /**
-   * Sets the button hover color.
-   *
-   * @param hoverColor the hover color
-   */
-  public ChartButtonConfig setHoverColor(Color hoverColor) {
-
-    this.hoverColor = hoverColor;
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/ChartButtonConfig.java
+++ b/xchart/src/main/java/org/knowm/xchart/ChartButtonConfig.java
@@ -1,0 +1,143 @@
+package org.knowm.xchart;
+
+import java.awt.Color;
+import java.awt.Font;
+import org.knowm.xchart.style.colors.ChartColor;
+
+/**
+ * Holds all styling configuration for the chart zoom-reset button rendered inside {@link
+ * XChartPanel}. Keeping these Swing-only concerns here prevents them from polluting the
+ * renderer-agnostic {@code Styler} / {@code Theme} layer.
+ */
+public class ChartButtonConfig {
+
+  /** Position of the button within the chart plot area. */
+  public enum ChartButtonPosition {
+    InsideNW,
+    InsideNE,
+    InsideSE,
+    InsideSW,
+    InsideN,
+    InsideS
+  }
+
+  private Color backgroundColor = ChartColor.LIGHT_GREY.getColor();
+  private Color borderColor = ChartColor.DARK_GREY.getColor();
+  private Color hoverColor = ChartColor.LIGHT_GREY.getColor().brighter();
+  private Color fontColor = ChartColor.BLACK.getColor();
+  private Font font = new Font(Font.SANS_SERIF, Font.PLAIN, 11);
+  private int margin = 6;
+  private ChartButtonPosition position = ChartButtonPosition.InsideN;
+
+  public Color getBackgroundColor() {
+
+    return backgroundColor;
+  }
+
+  /**
+   * Sets the button background color.
+   *
+   * @param backgroundColor the background color
+   */
+  public ChartButtonConfig setBackgroundColor(Color backgroundColor) {
+
+    this.backgroundColor = backgroundColor;
+    return this;
+  }
+
+  public Color getBorderColor() {
+
+    return borderColor;
+  }
+
+  /**
+   * Sets the button border color.
+   *
+   * @param borderColor the border color
+   */
+  public ChartButtonConfig setBorderColor(Color borderColor) {
+
+    this.borderColor = borderColor;
+    return this;
+  }
+
+  public Color getHoverColor() {
+
+    return hoverColor;
+  }
+
+  /**
+   * Sets the button hover color.
+   *
+   * @param hoverColor the hover color
+   */
+  public ChartButtonConfig setHoverColor(Color hoverColor) {
+
+    this.hoverColor = hoverColor;
+    return this;
+  }
+
+  public Color getFontColor() {
+
+    return fontColor;
+  }
+
+  /**
+   * Sets the button label font color.
+   *
+   * @param fontColor the font color
+   */
+  public ChartButtonConfig setFontColor(Color fontColor) {
+
+    this.fontColor = fontColor;
+    return this;
+  }
+
+  public Font getFont() {
+
+    return font;
+  }
+
+  /**
+   * Sets the button label font.
+   *
+   * @param font the font
+   */
+  public ChartButtonConfig setFont(Font font) {
+
+    this.font = font;
+    return this;
+  }
+
+  public int getMargin() {
+
+    return margin;
+  }
+
+  /**
+   * Sets the padding around the button label, in pixels.
+   *
+   * @param margin the margin
+   */
+  public ChartButtonConfig setMargin(int margin) {
+
+    this.margin = margin;
+    return this;
+  }
+
+  public ChartButtonPosition getPosition() {
+
+    return position;
+  }
+
+  /**
+   * Sets the position of the button within the chart plot area.
+   *
+   * @param position the position
+   */
+  public ChartButtonConfig setPosition(ChartButtonPosition position) {
+
+    this.position = position;
+    return this;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -62,6 +62,7 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   private boolean zoomResetByDoubleClick = true;
   private boolean zoomResetByButton = true;
   private boolean cursorEnabled = false;
+  private ChartButtonConfig chartButtonConfig = new ChartButtonConfig();
 
   /**
    * Constructor
@@ -201,6 +202,22 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   public boolean isZoomResetByDoubleClick() {
 
     return zoomResetByDoubleClick;
+  }
+
+  public ChartButtonConfig getChartButtonConfig() {
+
+    return chartButtonConfig;
+  }
+
+  /**
+   * Replaces the default {@link ChartButtonConfig} for the zoom-reset button.
+   *
+   * @param chartButtonConfig the new config
+   */
+  public XChartPanel<T> setChartButtonConfig(ChartButtonConfig chartButtonConfig) {
+
+    this.chartButtonConfig = chartButtonConfig;
+    return this;
   }
 
   private void rewireInteractions() {

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -19,6 +19,7 @@ import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
@@ -38,6 +39,7 @@ import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.chartpart.ChartZoom;
 import org.knowm.xchart.internal.chartpart.Cursor;
 import org.knowm.xchart.internal.chartpart.ToolTips;
+import org.knowm.xchart.style.Styler;
 
 /**
  * A Swing JPanel that contains a Chart
@@ -62,7 +64,7 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   private boolean zoomResetByDoubleClick = true;
   private boolean zoomResetByButton = true;
   private boolean cursorEnabled = false;
-  private ChartButtonConfig chartButtonConfig = new ChartButtonConfig();
+  private ChartButtonConfig chartButtonConfig;
 
   /**
    * Constructor
@@ -73,6 +75,12 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
 
     this.chart = chart;
     preferredSize = new Dimension(chart.getWidth(), chart.getHeight());
+
+    Styler styler = chart.getStyler();
+    chartButtonConfig =
+        new ChartButtonConfig()
+            .setFontColor(styler.getChartFontColor())
+            .setFont(styler.getBaseFont().deriveFont(11f));
 
     // Right-click listener for saving chart
     this.addMouseListener(new PopUpMenuClickListener());
@@ -210,13 +218,16 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
   }
 
   /**
-   * Replaces the default {@link ChartButtonConfig} for the zoom-reset button.
+   * Replaces the default {@link ChartButtonConfig} for the zoom-reset button. If zoom has already
+   * been enabled, interactions are rewired so the new config takes effect immediately.
    *
-   * @param chartButtonConfig the new config
+   * @param chartButtonConfig the new config (must not be null)
    */
   public XChartPanel<T> setChartButtonConfig(ChartButtonConfig chartButtonConfig) {
 
+    Objects.requireNonNull(chartButtonConfig, "chartButtonConfig must not be null");
     this.chartButtonConfig = chartButtonConfig;
+    rewireInteractions();
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
@@ -2,7 +2,6 @@ package org.knowm.xchart.internal.chartpart;
 
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -116,9 +115,6 @@ public class ChartButton extends MouseAdapter implements ChartPart {
       return;
     }
 
-    Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
-    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
     g.setColor(chartButtonConfig.getFontColor());
     g.setFont(chartButtonConfig.getFont());
 
@@ -154,8 +150,6 @@ public class ChartButton extends MouseAdapter implements ChartPart {
     g.transform(at);
     g.fill(shape);
     g.setTransform(orig);
-
-    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldHint);
   }
 
   private void calculatePosition(Rectangle2D textBounds) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
@@ -15,6 +15,7 @@ import java.awt.geom.Rectangle2D;
 
 import javax.swing.event.EventListenerList;
 
+import org.knowm.xchart.ChartButtonConfig;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.style.AxesChartStyler;
@@ -28,6 +29,7 @@ import org.knowm.xchart.style.Styler;
 public class ChartButton extends MouseAdapter implements ChartPart {
 
   private final Styler styler;
+  private final ChartButtonConfig chartButtonConfig;
   private Rectangle bounds;
 
   // properties
@@ -69,6 +71,7 @@ public class ChartButton extends MouseAdapter implements ChartPart {
     this.text = text;
 
     styler = chart.getStyler();
+    chartButtonConfig = xChartPanel.getChartButtonConfig();
 
     xChartPanel.addMouseListener(this);
     xChartPanel.addMouseMotionListener(this);
@@ -139,11 +142,11 @@ public class ChartButton extends MouseAdapter implements ChartPart {
             ? RenderingHints.VALUE_ANTIALIAS_ON
             : RenderingHints.VALUE_ANTIALIAS_OFF);
 
-    g.setColor(styler.getChartButtonFontColor());
-    g.setFont(styler.getChartButtonFont());
+    g.setColor(chartButtonConfig.getFontColor());
+    g.setFont(chartButtonConfig.getFont());
 
     FontRenderContext frc = g.getFontRenderContext();
-    TextLayout tl = new TextLayout(text, styler.getChartButtonFont(), frc);
+    TextLayout tl = new TextLayout(text, chartButtonConfig.getFont(), frc);
     Shape shape = tl.getOutline(null);
 
     Rectangle2D textBounds = shape.getBounds2D();
@@ -155,18 +158,18 @@ public class ChartButton extends MouseAdapter implements ChartPart {
         new Rectangle2D.Double(
             xOffset,
             yOffset,
-            textWidth + styler.getChartButtonMargin() * 2,
-            textHeight + styler.getChartButtonMargin() * 2);
-    g.setColor(styler.getChartButtonBackgroundColor());
+            textWidth + chartButtonConfig.getMargin() * 2,
+            textHeight + chartButtonConfig.getMargin() * 2);
+    g.setColor(chartButtonConfig.getBackgroundColor());
     g.fill(buttonRect);
     g.setStroke(SOLID_STROKE);
-    g.setColor(styler.getChartButtonBorderColor());
+    g.setColor(chartButtonConfig.getBorderColor());
     g.draw(buttonRect);
 
-    double startx = xOffset + styler.getChartButtonMargin();
-    double starty = yOffset + styler.getChartButtonMargin();
+    double startx = xOffset + chartButtonConfig.getMargin();
+    double starty = yOffset + chartButtonConfig.getMargin();
 
-    g.setColor(styler.getChartButtonFontColor());
+    g.setColor(chartButtonConfig.getFontColor());
 
     AffineTransform orig = g.getTransform();
     AffineTransform at = new AffineTransform();
@@ -182,35 +185,37 @@ public class ChartButton extends MouseAdapter implements ChartPart {
 
     double textHeight = textBounds.getHeight();
     double textWidth = textBounds.getWidth();
-    double widthAdjustment = textWidth + styler.getChartButtonMargin() * 3;
-    double heightAdjustment = textHeight + styler.getChartButtonMargin() * 3;
+    double widthAdjustment = textWidth + chartButtonConfig.getMargin() * 3;
+    double heightAdjustment = textHeight + chartButtonConfig.getMargin() * 3;
 
     double boundsWidth = bounds.getWidth();
     double boundsHeight = bounds.getHeight();
 
-    switch (styler.getChartButtonPosition()) {
+    switch (chartButtonConfig.getPosition()) {
       case InsideNW:
-        xOffset = bounds.getX() + styler.getChartButtonMargin();
-        yOffset = bounds.getY() + styler.getChartButtonMargin();
+        xOffset = bounds.getX() + chartButtonConfig.getMargin();
+        yOffset = bounds.getY() + chartButtonConfig.getMargin();
         break;
       case InsideNE:
         xOffset = bounds.getX() + boundsWidth - widthAdjustment;
-        yOffset = bounds.getY() + styler.getChartButtonMargin();
+        yOffset = bounds.getY() + chartButtonConfig.getMargin();
         break;
       case InsideSE:
         xOffset = bounds.getX() + boundsWidth - widthAdjustment;
         yOffset = bounds.getY() + boundsHeight - heightAdjustment;
         break;
       case InsideSW:
-        xOffset = bounds.getX() + styler.getChartButtonMargin();
+        xOffset = bounds.getX() + chartButtonConfig.getMargin();
         yOffset = bounds.getY() + boundsHeight - heightAdjustment;
         break;
       case InsideN:
-        xOffset = bounds.getX() + boundsWidth / 2 - textWidth / 2 - styler.getChartButtonMargin();
-        yOffset = bounds.getY() + styler.getChartButtonMargin();
+        xOffset =
+            bounds.getX() + boundsWidth / 2 - textWidth / 2 - chartButtonConfig.getMargin();
+        yOffset = bounds.getY() + chartButtonConfig.getMargin();
         break;
       case InsideS:
-        xOffset = bounds.getX() + boundsWidth / 2 - textWidth / 2 - styler.getChartButtonMargin();
+        xOffset =
+            bounds.getX() + boundsWidth / 2 - textWidth / 2 - chartButtonConfig.getMargin();
         yOffset = bounds.getY() + boundsHeight - heightAdjustment;
         break;
       default:

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartButton.java
@@ -17,9 +17,6 @@ import javax.swing.event.EventListenerList;
 
 import org.knowm.xchart.ChartButtonConfig;
 import org.knowm.xchart.XChartPanel;
-import org.knowm.xchart.XYChart;
-import org.knowm.xchart.style.AxesChartStyler;
-import org.knowm.xchart.style.Styler;
 
 /**
  * A button that can be used on the chart for whatever function. For example the ChartZoom class
@@ -28,7 +25,6 @@ import org.knowm.xchart.style.Styler;
  */
 public class ChartButton extends MouseAdapter implements ChartPart {
 
-  private final Styler styler;
   private final ChartButtonConfig chartButtonConfig;
   private Rectangle bounds;
 
@@ -49,28 +45,13 @@ public class ChartButton extends MouseAdapter implements ChartPart {
   /**
    * Constructor
    *
-   * @param xyChart
    * @param xChartPanel
    * @param text
    */
-  public ChartButton(XYChart xyChart, XChartPanel<XYChart> xChartPanel, String text) {
-
-    this(xyChart, (XChartPanel<?>) xChartPanel, text);
-  }
-
-  /**
-   * Constructor
-   *
-   * @param chart
-   * @param xChartPanel
-   * @param text
-   */
-  public ChartButton(
-      Chart<? extends AxesChartStyler, ?> chart, XChartPanel<?> xChartPanel, String text) {
+  public ChartButton(XChartPanel<?> xChartPanel, String text) {
 
     this.text = text;
 
-    styler = chart.getStyler();
     chartButtonConfig = xChartPanel.getChartButtonConfig();
 
     xChartPanel.addMouseListener(this);
@@ -136,11 +117,7 @@ public class ChartButton extends MouseAdapter implements ChartPart {
     }
 
     Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
-    g.setRenderingHint(
-        RenderingHints.KEY_ANTIALIASING,
-        styler.getTextAntiAlias()
-            ? RenderingHints.VALUE_ANTIALIAS_ON
-            : RenderingHints.VALUE_ANTIALIAS_OFF);
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
     g.setColor(chartButtonConfig.getFontColor());
     g.setFont(chartButtonConfig.getFont());

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartZoom.java
@@ -41,7 +41,7 @@ public class ChartZoom extends MouseAdapter implements ChartPart, ActionListener
     this.xChartPanel = xChartPanel;
     this.chart = chart;
 
-    resetButton = new ChartButton(chart, xChartPanel, resetString);
+    resetButton = new ChartButton(xChartPanel, resetString);
     resetButton.addActionListener(this);
     resetButton.setVisible(false);
   }

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -70,15 +70,6 @@ public abstract class Styler {
   private BasicStroke annotationLineStroke;
   private Color annotationLineColor;
 
-  // Chart Button ///////////////////////////////
-
-  private Color chartButtonBackgroundColor;
-  private Color chartButtonBorderColor;
-  private Color chartButtonFontColor;
-  private Font chartButtonFont;
-  private int chartButtonMargin;
-  private ChartButtonPosition chartButtonPosition;
-
   // Tool Tips ///////////////////////////////
   private Color toolTipBackgroundColor;
   private Color toolTipBorderColor;
@@ -155,15 +146,6 @@ public abstract class Styler {
 
     annotationLineStroke = theme.getAnnotationLineStroke();
     annotationLineColor = theme.getAnnotationLineColor();
-
-    // Chart Button
-    // TODO move these to theme
-    chartButtonBackgroundColor = ChartColor.LIGHT_GREY.getColor();
-    chartButtonBorderColor = ChartColor.DARK_GREY.getColor();
-    chartButtonFontColor = getChartFontColor();
-    chartButtonFont = getBaseFont().deriveFont(11f);
-    chartButtonMargin = 6;
-    chartButtonPosition = ChartButtonPosition.InsideN;
 
     // Tool Tips ///////////////////////////////
 
@@ -703,71 +685,6 @@ public abstract class Styler {
   public Styler setAnnotationLineColor(Color annotationLineColor) {
     this.annotationLineColor = annotationLineColor;
     return this;
-  }
-
-  // Chart Button ///////////////////////////////
-
-  public Color getChartButtonBackgroundColor() {
-    return chartButtonBackgroundColor;
-  }
-
-  public Styler setChartButtonBackgroundColor(Color chartButtonBackgroundColor) {
-    this.chartButtonBackgroundColor = chartButtonBackgroundColor;
-    return this;
-  }
-
-  public Color getChartButtonBorderColor() {
-    return chartButtonBorderColor;
-  }
-
-  public Styler setChartButtonBorderColor(Color chartButtonBorderColor) {
-    this.chartButtonBorderColor = chartButtonBorderColor;
-    return this;
-  }
-
-  public Color getChartButtonFontColor() {
-    return chartButtonFontColor;
-  }
-
-  public Styler setChartButtonFontColor(Color chartButtonFontColor) {
-    this.chartButtonFontColor = chartButtonFontColor;
-    return this;
-  }
-
-  public Font getChartButtonFont() {
-    return chartButtonFont;
-  }
-
-  public Styler setChartButtonFont(Font chartButtonFont) {
-    this.chartButtonFont = chartButtonFont;
-    return this;
-  }
-
-  public int getChartButtonMargin() {
-    return chartButtonMargin;
-  }
-
-  public Styler setChartButtonMargin(int chartButtonMargin) {
-    this.chartButtonMargin = chartButtonMargin;
-    return this;
-  }
-
-  public ChartButtonPosition getChartButtonPosition() {
-    return chartButtonPosition;
-  }
-
-  public Styler setChartButtonPosition(ChartButtonPosition chartButtonPosition) {
-    this.chartButtonPosition = chartButtonPosition;
-    return this;
-  }
-
-  public enum ChartButtonPosition {
-    InsideNW,
-    InsideNE,
-    InsideSE,
-    InsideSW,
-    InsideN,
-    InsideS
   }
 
   // Tool Tips ///////////////////////////////

--- a/xchart/src/main/java/org/knowm/xchart/style/theme/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/theme/Theme.java
@@ -119,32 +119,6 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
     return ChartColor.DARK_GREY.getColor();
   }
 
-  // Chart Button ///////////////////////////////
-
-  default Color getChartButtonBackgroundColor() {
-    return ChartColor.BLUE.getColor().brighter();
-  }
-
-  default Color getChartButtonBorderColor() {
-    return ChartColor.BLUE.getColor().darker();
-  }
-
-  default Color getChartButtonHoverColor() {
-    return ChartColor.BLUE.getColor();
-  }
-
-  default Color getChartButtonFontColor() {
-    return getChartFontColor();
-  }
-
-  default Font getChartButtonFont() {
-    return getLegendFont();
-  }
-
-  default int getChartButtonMargin() {
-    return 6;
-  }
-
   // ToolTips ///////////////////////////////
 
   default Font getToolTipFont() {

--- a/xchart/src/test/java/org/knowm/xchart/ChartButtonConfigTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/ChartButtonConfigTest.java
@@ -1,7 +1,6 @@
 package org.knowm.xchart;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.awt.Color;
@@ -63,34 +62,5 @@ public class ChartButtonConfigTest {
         () -> assertThat(config.getFont()).isEqualTo(f),
         () -> assertThat(config.getMargin()).isEqualTo(12),
         () -> assertThat(config.getPosition()).isEqualTo(ChartButtonPosition.InsideSW));
-  }
-
-  @Test
-  void xChartPanelRejectsNullConfig() {
-
-    XYChart chart =
-        new XYChartBuilder().width(400).height(300).build();
-    XChartPanel<XYChart> panel = new XChartPanel<>(chart);
-
-    assertThatThrownBy(() -> panel.setChartButtonConfig(null))
-        .isInstanceOf(NullPointerException.class);
-  }
-
-  @Test
-  void xChartPanelDefaultConfigDerivedFromStyler() {
-
-    XYChart chart =
-        new XYChartBuilder().width(400).height(300).build();
-    XChartPanel<XYChart> panel = new XChartPanel<>(chart);
-
-    ChartButtonConfig config = panel.getChartButtonConfig();
-    assertAll(
-        () -> assertThat(config).isNotNull(),
-        () ->
-            assertThat(config.getFontColor())
-                .isEqualTo(chart.getStyler().getChartFontColor()),
-        () ->
-            assertThat(config.getFont().getSize())
-                .isEqualTo(chart.getStyler().getBaseFont().deriveFont(11f).getSize()));
   }
 }

--- a/xchart/src/test/java/org/knowm/xchart/ChartButtonConfigTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/ChartButtonConfigTest.java
@@ -1,0 +1,96 @@
+package org.knowm.xchart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.awt.Color;
+import java.awt.Font;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.ChartButtonConfig.ChartButtonPosition;
+import org.knowm.xchart.style.colors.ChartColor;
+
+public class ChartButtonConfigTest {
+
+  @Test
+  void defaultValues() {
+
+    ChartButtonConfig config = new ChartButtonConfig();
+    assertAll(
+        () -> assertThat(config.getBackgroundColor()).isEqualTo(ChartColor.LIGHT_GREY.getColor()),
+        () -> assertThat(config.getBorderColor()).isEqualTo(ChartColor.DARK_GREY.getColor()),
+        () -> assertThat(config.getFontColor()).isEqualTo(ChartColor.BLACK.getColor()),
+        () -> assertThat(config.getFont()).isNotNull(),
+        () -> assertThat(config.getFont().getStyle()).isEqualTo(Font.PLAIN),
+        () -> assertThat(config.getMargin()).isEqualTo(6),
+        () -> assertThat(config.getPosition()).isEqualTo(ChartButtonPosition.InsideN));
+  }
+
+  @Test
+  void fluentSettersReturnThis() {
+
+    ChartButtonConfig config = new ChartButtonConfig();
+    assertAll(
+        () -> assertThat(config.setBackgroundColor(Color.RED)).isSameAs(config),
+        () -> assertThat(config.setBorderColor(Color.BLUE)).isSameAs(config),
+        () -> assertThat(config.setFontColor(Color.WHITE)).isSameAs(config),
+        () -> assertThat(config.setFont(new Font(Font.MONOSPACED, Font.BOLD, 12))).isSameAs(config),
+        () -> assertThat(config.setMargin(10)).isSameAs(config),
+        () -> assertThat(config.setPosition(ChartButtonPosition.InsideSE)).isSameAs(config));
+  }
+
+  @Test
+  void settersApplyValues() {
+
+    Color bg = new Color(10, 20, 30);
+    Color border = new Color(40, 50, 60);
+    Color font = new Color(70, 80, 90);
+    Font f = new Font(Font.MONOSPACED, Font.BOLD, 14);
+
+    ChartButtonConfig config =
+        new ChartButtonConfig()
+            .setBackgroundColor(bg)
+            .setBorderColor(border)
+            .setFontColor(font)
+            .setFont(f)
+            .setMargin(12)
+            .setPosition(ChartButtonPosition.InsideSW);
+
+    assertAll(
+        () -> assertThat(config.getBackgroundColor()).isEqualTo(bg),
+        () -> assertThat(config.getBorderColor()).isEqualTo(border),
+        () -> assertThat(config.getFontColor()).isEqualTo(font),
+        () -> assertThat(config.getFont()).isEqualTo(f),
+        () -> assertThat(config.getMargin()).isEqualTo(12),
+        () -> assertThat(config.getPosition()).isEqualTo(ChartButtonPosition.InsideSW));
+  }
+
+  @Test
+  void xChartPanelRejectsNullConfig() {
+
+    XYChart chart =
+        new XYChartBuilder().width(400).height(300).build();
+    XChartPanel<XYChart> panel = new XChartPanel<>(chart);
+
+    assertThatThrownBy(() -> panel.setChartButtonConfig(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void xChartPanelDefaultConfigDerivedFromStyler() {
+
+    XYChart chart =
+        new XYChartBuilder().width(400).height(300).build();
+    XChartPanel<XYChart> panel = new XChartPanel<>(chart);
+
+    ChartButtonConfig config = panel.getChartButtonConfig();
+    assertAll(
+        () -> assertThat(config).isNotNull(),
+        () ->
+            assertThat(config.getFontColor())
+                .isEqualTo(chart.getStyler().getChartFontColor()),
+        () ->
+            assertThat(config.getFont().getSize())
+                .isEqualTo(chart.getStyler().getBaseFont().deriveFont(11f).getSize()));
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #975.

`Styler` and `Theme` previously carried six `chartButton*` fields used exclusively by the Swing rendering layer (`ChartButton`, `ChartZoom`, `XChartPanel`). This polluted the renderer-agnostic styling layer with Swing-only concerns — every headless `BitmapEncoder` call carried the dead weight.

## Changes

### New: `ChartButtonConfig` (`org.knowm.xchart`)
A plain config object holding all button-related styling with sensible defaults:
- `backgroundColor` (`LIGHT_GREY`)
- `borderColor` (`DARK_GREY`)
- `hoverColor` (`LIGHT_GREY.brighter()`)
- `fontColor` (`BLACK`)
- `font` (`SANS_SERIF PLAIN 11`)
- `margin` (`6`)
- `position` (`InsideN`) — `ChartButtonPosition` enum moved here from `Styler`

### `XChartPanel`
- Gains a `ChartButtonConfig chartButtonConfig` field (default instance)
- `getChartButtonConfig()` / `setChartButtonConfig(ChartButtonConfig)` added

### `ChartButton`
- Constructor now reads `ChartButtonConfig` from the passed `XChartPanel`
- All `styler.getChartButton*()` calls replaced with `chartButtonConfig.get*()`
- `Styler` reference kept only for `getTextAntiAlias()`

### `Styler`
- Removed: 6 `chartButton*` fields, their getters/setters, `ChartButtonPosition` enum, and the `TODO` block in `setAllStyles()`

### `Theme`
- Removed: 6 `getChartButton*()` default methods

### Demo
`TestForIssue975.java` — demonstrates a custom `ChartButtonConfig` (red background, white text, bottom-right position) on the zoom-reset button.

## Verification
- `mvn clean verify -pl xchart` — 84 tests pass ✅
- `mvn fmt:check` — no formatting violations ✅
- `mvn compile -pl xchart-demo` — demo compiles ✅