### PR TITLE
Refactor CSVExporter writer handling

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/CSVExporter.java
+++ b/xchart/src/main/java/org/knowm/xchart/CSVExporter.java
@@ -1,6 +1,11 @@
 package org.knowm.xchart;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class is used to export Chart data to a folder containing one or more CSV files. The parent
@@ -8,6 +13,8 @@ import java.io.*;
  * series' name becomes the CSV files' name.
  */
 public class CSVExporter {
+
+  private static final String LINE_SEPARATOR = System.lineSeparator();
 
   /**
    * Export all XYChart series as rows in separate CSV files.
@@ -31,29 +38,20 @@ public class CSVExporter {
   public static void writeCSVRows(XYSeries series, String path2Dir) {
 
     File newFile = new File(path2Dir + series.getName() + ".csv");
-    Writer out = null;
-    try {
+    try (Writer out =
+        new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(newFile), StandardCharsets.UTF_8))) {
 
-      out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(newFile), "UTF8"));
-      String csv = join(series.getXData(), ",") + System.getProperty("line.separator");
+      String csv = join(series.getXData(), ",") + LINE_SEPARATOR;
       out.write(csv);
-      csv = join(series.getYData(), ",") + System.getProperty("line.separator");
+      csv = join(series.getYData(), ",") + LINE_SEPARATOR;
       out.write(csv);
       if (series.getExtraValues() != null) {
-        csv = join(series.getExtraValues(), ",") + System.getProperty("line.separator");
+        csv = join(series.getExtraValues(), ",") + LINE_SEPARATOR;
         out.write(csv);
       }
     } catch (Exception e) {
       e.printStackTrace();
-    } finally {
-      if (out != null) {
-        try {
-          out.flush();
-          out.close();
-        } catch (IOException e) {
-          // NOP
-        }
-      }
     }
   }
 
@@ -102,10 +100,10 @@ public class CSVExporter {
   public static void writeCSVColumns(XYSeries series, String path2Dir) {
 
     File newFile = new File(path2Dir + series.getName() + ".csv");
-    Writer out = null;
-    try {
+    try (Writer out =
+        new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(newFile), StandardCharsets.UTF_8))) {
 
-      out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(newFile), "UTF8"));
       double[] xData = series.getXData();
       double[] yData = series.getYData();
       double[] errorBarData = series.getExtraValues();
@@ -118,24 +116,12 @@ public class CSVExporter {
           sb.append(errorBarData[i]).append(",");
         }
         sb.setLength(sb.length() - 1);
-        sb.append(System.getProperty("line.separator"));
+        sb.append(LINE_SEPARATOR);
 
-        // String csv = xDataPoint + "," + yDataPoint + errorBarValue == null ? "" : ("," +
-        // errorBarValue) + System.getProperty("line.separator");
-        // String csv = + yDataPoint + System.getProperty("line.separator");
         out.write(sb.toString());
       }
     } catch (Exception e) {
       e.printStackTrace();
-    } finally {
-      if (out != null) {
-        try {
-          out.flush();
-          out.close();
-        } catch (IOException e) {
-          // NOP
-        }
-      }
     }
   }
 }

--- a/xchart/src/test/java/org/knowm/xchart/CSVExporterTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/CSVExporterTest.java
@@ -1,0 +1,51 @@
+package org.knowm.xchart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class CSVExporterTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  public void writeCSVRowsExportsXAndYDataRows() throws Exception {
+
+    XYChart chart = new XYChartBuilder().width(600).height(400).build();
+    chart.addSeries("series1", new double[] {1.0, 2.0, 3.0}, new double[] {12.0, 34.0, 56.0});
+
+    CSVExporter.writeCSVRows(chart.getSeries("series1"), tempDir.toString() + File.separator);
+
+    String csv = Files.readString(tempDir.resolve("series1.csv"), StandardCharsets.UTF_8);
+    assertThat(csv)
+        .isEqualTo(
+            "1.0,2.0,3.0"
+                + System.lineSeparator()
+                + "12.0,34.0,56.0"
+                + System.lineSeparator());
+  }
+
+  @Test
+  public void writeCSVColumnsExportsXAndYDataColumns() throws Exception {
+
+    XYChart chart = new XYChartBuilder().width(600).height(400).build();
+    chart.addSeries("series1", new double[] {1.0, 2.0, 3.0}, new double[] {12.0, 34.0, 56.0});
+
+    CSVExporter.writeCSVColumns(chart.getSeries("series1"), tempDir.toString() + File.separator);
+
+    String csv = Files.readString(tempDir.resolve("series1.csv"), StandardCharsets.UTF_8);
+    assertThat(csv)
+        .isEqualTo(
+            "1.0,12.0"
+                + System.lineSeparator()
+                + "2.0,34.0"
+                + System.lineSeparator()
+                + "3.0,56.0"
+                + System.lineSeparator());
+  }
+}


### PR DESCRIPTION
## Summary
Refactors `CSVExporter` writer handling while preserving the existing row-oriented and column-oriented CSV output formats.

## Problem
`CSVExporter` manually managed `Writer` lifecycle in both export paths using duplicated `try` / `finally` blocks. The close path swallowed `IOException` with a `// NOP` comment, the UTF-8 charset was passed as a string literal, and the platform line separator lookup was repeated across the class.

## Refactoring
This PR replaces the manual writer cleanup with try-with-resources, uses `StandardCharsets.UTF_8`, centralizes the platform line separator, and removes stale commented-out CSV construction code.

The public `CSVExporter` APIs are unchanged:
- `writeCSVRows(XYChart, String)`
- `writeCSVRows(XYSeries, String)`
- `writeCSVColumns(XYChart, String)`
- `writeCSVColumns(XYSeries, String)`

## Impact Check
I checked the existing `CSVExporter` call sites:
- `xchart-demo/.../csv/Export2Rows.java`
- `xchart-demo/.../csv/Export2Columns.java`
- `XChartPanel.java` CSV export path

The refactor keeps the same public signatures, same output orientation, same platform line separator behavior, and same broad exception handling. The removed commented-out CSV construction code referenced variables that are not present in the current method and was not a usable alternate implementation.

## What This PR Adds
A focused `CSVExporterTest` with temporary-file based checks for both supported export formats:
- row-oriented export writes X values and Y values as separate rows
- column-oriented export writes X/Y pairs as rows

The tests read the generated CSV files as UTF-8 and verify exact content, so the refactor is covered against output-format regressions.

## Validation
- [x] `mvn -pl xchart "-Dtest=CSVExporterTest" test`
- [x] `mvn fmt:check`
- [x] `mvn clean verify --no-transfer-progress --batch-mode --settings etc/settings.xml "-Dmaven.javadoc.skip=true" "-Dfmt.skip=true"`