### PR TITLE
feat: accept java.time types in addSeries() X-axis (issue #761)

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue761.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue761.java
@@ -1,0 +1,61 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+/**
+ * Reproducer / how-to for https://github.com/knowm/XChart/issues/761
+ *
+ * <p>"Update addSeries() to take in modern date and time classes."
+ *
+ * <p>addSeries()'s X-axis parameter is a {@code List<?>}, and XChart now accepts the {@code
+ * java.time} types (Instant, ZonedDateTime, OffsetDateTime, LocalDateTime, LocalDate, LocalTime) in
+ * addition to the legacy {@link java.util.Date}. No conversion by the caller is required. Zone-less
+ * types (LocalDateTime/LocalDate/LocalTime) are resolved using the styler timezone so the axis
+ * labels line up with the data.
+ */
+public class TestForIssue761 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static XYChart getChart() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(800)
+            .height(600)
+            .title("java.time on the X-axis (issue 761)")
+            .xAxisTitle("Time")
+            .yAxisTitle("Value")
+            .build();
+
+    chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
+    chart.getStyler().setDatePattern("HH:mm");
+    // Resolve the zone-less LocalDateTime values in UTC so the demo is deterministic everywhere.
+    chart.getStyler().setTimezone(java.util.TimeZone.getTimeZone(ZoneId.of("UTC")));
+
+    // X data as java.time.LocalDateTime — no java.util.Date needed
+    List<LocalDateTime> xData = new ArrayList<>();
+    List<Double> yData = new ArrayList<>();
+    LocalDateTime start = LocalDateTime.of(2021, 1, 1, 9, 0);
+    double[] values = {3.0, 5.0, 4.0, 7.0, 6.5, 9.0};
+    for (int i = 0; i < values.length; i++) {
+      xData.add(start.plusMinutes(30L * i));
+      yData.add(values[i]);
+    }
+
+    chart.addSeries("readings", xData, yData);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/OHLCChart.java
@@ -3,6 +3,7 @@ package org.knowm.xchart;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics2D;
+import java.time.temporal.Temporal;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -262,7 +263,7 @@ public class OHLCChart extends AxesChart<OHLCStyler, OHLCSeries> {
       case Date:
         return addSeries(
             seriesName,
-            Utils.getDoubleArrayFromDateList(xData),
+            Utils.getDoubleArrayFromDateList(xData, styler.getTimezone().toZoneId()),
             Utils.getDoubleArrayFromNumberList(openData),
             Utils.getDoubleArrayFromNumberList(highData),
             Utils.getDoubleArrayFromNumberList(lowData),
@@ -309,7 +310,7 @@ public class OHLCChart extends AxesChart<OHLCStyler, OHLCSeries> {
       case Date:
         return addSeries(
             seriesName,
-            Utils.getDoubleArrayFromDateList(xData),
+            Utils.getDoubleArrayFromDateList(xData, styler.getTimezone().toZoneId()),
             Utils.getDoubleArrayFromNumberList(openData),
             Utils.getDoubleArrayFromNumberList(highData),
             Utils.getDoubleArrayFromNumberList(lowData),
@@ -412,7 +413,7 @@ public class OHLCChart extends AxesChart<OHLCStyler, OHLCSeries> {
       case Date:
         return addSeries(
             seriesName,
-            Utils.getDoubleArrayFromDateList(xData),
+            Utils.getDoubleArrayFromDateList(xData, styler.getTimezone().toZoneId()),
             Utils.getDoubleArrayFromNumberList(yData),
             getDataType(xData));
 
@@ -437,7 +438,7 @@ public class OHLCChart extends AxesChart<OHLCStyler, OHLCSeries> {
     Object dataPoint = itr.next();
     if (dataPoint instanceof Number) {
       axisType = DataType.Number;
-    } else if (dataPoint instanceof Date) {
+    } else if (dataPoint instanceof Date || dataPoint instanceof Temporal) {
       axisType = DataType.Date;
     } else {
       throw new IllegalArgumentException("Series data must be either Number or Date type!!!");
@@ -588,7 +589,7 @@ public class OHLCChart extends AxesChart<OHLCStyler, OHLCSeries> {
       case Date:
         return updateOHLCSeries(
             seriesName,
-            Utils.getDoubleArrayFromDateList(newXData),
+            Utils.getDoubleArrayFromDateList(newXData, styler.getTimezone().toZoneId()),
             Utils.getDoubleArrayFromNumberList(newOpenData),
             Utils.getDoubleArrayFromNumberList(newHighData),
             Utils.getDoubleArrayFromNumberList(newLowData),
@@ -619,7 +620,7 @@ public class OHLCChart extends AxesChart<OHLCStyler, OHLCSeries> {
       case Date:
         return updateOHLCSeries(
             seriesName,
-            Utils.getDoubleArrayFromDateList(newXData),
+            Utils.getDoubleArrayFromDateList(newXData, styler.getTimezone().toZoneId()),
             Utils.getDoubleArrayFromNumberList(newOpenData),
             Utils.getDoubleArrayFromNumberList(newHighData),
             Utils.getDoubleArrayFromNumberList(newLowData),
@@ -722,7 +723,7 @@ public class OHLCChart extends AxesChart<OHLCStyler, OHLCSeries> {
       case Date:
         return updateOHLCSeries(
             seriesName,
-            Utils.getDoubleArrayFromDateList(newXData),
+            Utils.getDoubleArrayFromDateList(newXData, styler.getTimezone().toZoneId()),
             Utils.getDoubleArrayFromNumberList(newYData));
 
       default:

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -1,6 +1,7 @@
 package org.knowm.xchart;
 
 import java.awt.Graphics2D;
+import java.time.temporal.Temporal;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -235,7 +236,7 @@ public class XYChart extends AxesChart<XYStyler, XYSeries> {
       case Date:
         return addSeries(
             seriesName,
-            Utils.getDoubleArrayFromDateList(xData),
+            Utils.getDoubleArrayFromDateList(xData, styler.getTimezone().toZoneId()),
             Utils.getDoubleArrayFromNumberList(yData),
             Utils.getDoubleArrayFromNumberList(errorBars),
             DataType.Date);
@@ -263,7 +264,7 @@ public class XYChart extends AxesChart<XYStyler, XYSeries> {
     Object dataPoint = itr.next();
     if (dataPoint instanceof Number) {
       axisType = DataType.Number;
-    } else if (dataPoint instanceof Date) {
+    } else if (dataPoint instanceof Date || dataPoint instanceof Temporal) {
       axisType = DataType.Date;
     } else {
       throw new IllegalArgumentException("Series data must be either Number or Date type!!!");
@@ -332,7 +333,7 @@ public class XYChart extends AxesChart<XYStyler, XYSeries> {
       case Date:
         return updateXYSeries(
             seriesName,
-            Utils.getDoubleArrayFromDateList(newXData),
+            Utils.getDoubleArrayFromDateList(newXData, styler.getTimezone().toZoneId()),
             Utils.getDoubleArrayFromNumberList(newYData),
             Utils.getDoubleArrayFromNumberList(newErrorBarData));
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/Utils.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/Utils.java
@@ -1,5 +1,12 @@
 package org.knowm.xchart.internal;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -114,6 +121,19 @@ public class Utils {
 
   public static double[] getDoubleArrayFromDateList(List<?> data) {
 
+    return getDoubleArrayFromDateList(data, ZoneId.systemDefault());
+  }
+
+  /**
+   * Converts a list of date/time values to an array of epoch milliseconds. Supports {@link Date} as
+   * well as the {@code java.time} types {@link Instant}, {@link ZonedDateTime}, {@link
+   * OffsetDateTime}, {@link LocalDateTime}, {@link LocalDate} and {@link LocalTime}. The supplied
+   * {@code zoneId} is only used for the zone-less types ({@code LocalDateTime}, {@code LocalDate},
+   * {@code LocalTime}); the zoned/instant types carry their own offset. Pass the chart's styler
+   * timezone so that conversion and axis-label formatting agree.
+   */
+  public static double[] getDoubleArrayFromDateList(List<?> data, ZoneId zoneId) {
+
     if (data == null) {
       return null;
     }
@@ -121,9 +141,34 @@ public class Utils {
 
     int i = 0;
     for (Object date : data) {
-      doubles[i++] = ((Date) date).getTime();
+      doubles[i++] = toEpochMillis(date, zoneId);
     }
     return doubles;
+  }
+
+  private static double toEpochMillis(Object value, ZoneId zoneId) {
+
+    if (value instanceof Date) {
+      return ((Date) value).getTime();
+    } else if (value instanceof Instant) {
+      return ((Instant) value).toEpochMilli();
+    } else if (value instanceof ZonedDateTime) {
+      return ((ZonedDateTime) value).toInstant().toEpochMilli();
+    } else if (value instanceof OffsetDateTime) {
+      return ((OffsetDateTime) value).toInstant().toEpochMilli();
+    } else if (value instanceof LocalDateTime) {
+      return ((LocalDateTime) value).atZone(zoneId).toInstant().toEpochMilli();
+    } else if (value instanceof LocalDate) {
+      return ((LocalDate) value).atStartOfDay(zoneId).toInstant().toEpochMilli();
+    } else if (value instanceof LocalTime) {
+      // anchor a time-of-day to the epoch day so it renders correctly with a time-only pattern
+      return ((LocalTime) value).atDate(LocalDate.ofEpochDay(0)).atZone(zoneId).toInstant().toEpochMilli();
+    }
+    throw new IllegalArgumentException(
+        "Unsupported date/time type: "
+            + (value == null ? "null" : value.getClass().getName())
+            + ". Supported types are java.util.Date, Instant, ZonedDateTime, OffsetDateTime, "
+            + "LocalDateTime, LocalDate and LocalTime.");
   }
 
   public static double[] getGeneratedDataAsArray(int length) {

--- a/xchart/src/test/java/org/knowm/xchart/internal/UtilsTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/UtilsTest.java
@@ -1,10 +1,28 @@
 package org.knowm.xchart.internal;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import org.junit.jupiter.api.Test;
 
 public class UtilsTest {
+
+  /** 2021-01-01T00:00:00Z */
+  private static final long EPOCH_MILLIS = 1_609_459_200_000L;
+
+  private static final ZoneId UTC = ZoneOffset.UTC;
 
   @Test
   void addFileExtension() {
@@ -12,5 +30,74 @@ public class UtilsTest {
     assertEquals(Utils.addFileExtension("yourchart.png", ".pn"), "yourchart.png.pn");
     assertEquals(Utils.addFileExtension("a", ".png"), "a.png");
     assertEquals(Utils.addFileExtension("a.PNG", ".png"), "a.PNG");
+  }
+
+  @Test
+  void nullDateListReturnsNull() {
+    assertEquals(null, Utils.getDoubleArrayFromDateList(null, UTC));
+  }
+
+  @Test
+  void legacyDateConvertsToEpochMillis() {
+    double[] result =
+        Utils.getDoubleArrayFromDateList(Collections.singletonList(new Date(EPOCH_MILLIS)), UTC);
+    assertArrayEquals(new double[] {EPOCH_MILLIS}, result);
+  }
+
+  @Test
+  void javaTimeTypesAllMapToTheSameInstant() {
+    // The same moment expressed with different java.time types must all yield the same epoch millis.
+    Date date = new Date(EPOCH_MILLIS);
+    Instant instant = Instant.ofEpochMilli(EPOCH_MILLIS);
+    ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, UTC);
+    OffsetDateTime odt = OffsetDateTime.ofInstant(instant, UTC);
+    LocalDateTime ldt = LocalDateTime.ofInstant(instant, UTC);
+    LocalDate ld = LocalDate.of(2021, 1, 1);
+
+    double[] result =
+        Utils.getDoubleArrayFromDateList(Arrays.asList(date, instant, zdt, odt, ldt, ld), UTC);
+
+    assertArrayEquals(
+        new double[] {
+          EPOCH_MILLIS, EPOCH_MILLIS, EPOCH_MILLIS, EPOCH_MILLIS, EPOCH_MILLIS, EPOCH_MILLIS
+        },
+        result);
+  }
+
+  @Test
+  void zonedTypesIgnoreSuppliedZone() {
+    // Instant/ZonedDateTime carry their own offset, so the zoneId argument must not affect them.
+    Instant instant = Instant.ofEpochMilli(EPOCH_MILLIS);
+    double[] utc = Utils.getDoubleArrayFromDateList(Collections.singletonList(instant), UTC);
+    double[] tokyo =
+        Utils.getDoubleArrayFromDateList(
+            Collections.singletonList(instant), ZoneId.of("Asia/Tokyo"));
+    assertArrayEquals(utc, tokyo);
+  }
+
+  @Test
+  void localTypesRespectSuppliedZone() {
+    // A zone-less LocalDateTime resolves to a different instant depending on the zone.
+    LocalDateTime ldt = LocalDateTime.of(2021, 1, 1, 0, 0);
+    double utc = Utils.getDoubleArrayFromDateList(Collections.singletonList(ldt), UTC)[0];
+    double tokyo =
+        Utils.getDoubleArrayFromDateList(
+            Collections.singletonList(ldt), ZoneId.of("Asia/Tokyo"))[0];
+    // Tokyo is UTC+9, so the same wall-clock time is an earlier instant there.
+    assertEquals(9 * 60 * 60 * 1000.0, utc - tokyo);
+  }
+
+  @Test
+  void localTimeAnchorsToEpochDay() {
+    double millis =
+        Utils.getDoubleArrayFromDateList(Collections.singletonList(LocalTime.of(1, 0)), UTC)[0];
+    assertEquals(60 * 60 * 1000.0, millis);
+  }
+
+  @Test
+  void unsupportedTypeThrows() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Utils.getDoubleArrayFromDateList(Collections.singletonList("not a date"), UTC));
   }
 }


### PR DESCRIPTION
Closes #761. (Also a slice of #546.)

Lets callers pass Java 8 `java.time` types on the X-axis of `XYChart` and `OHLCChart` instead of `java.util.Date`.

### Why it's small
`addSeries(...)`'s X parameter is already `List<?>`, and the internal storage is `double[]` epoch-millis. So no new overloads and no rendering changes are needed — the existing `Date → millis → SimpleDateFormat` pipeline handles everything. Two runtime blockers were removed:

- **Detection:** `getDataType()` now maps `java.time.temporal.Temporal` (as well as `Date`) to `DataType.Date`.
- **Conversion:** `Utils.getDoubleArrayFromDateList(list, zoneId)` converts `Date`, `Instant`, `ZonedDateTime`, `OffsetDateTime`, `LocalDateTime`, `LocalDate`, and `LocalTime` to epoch millis.

### Timezone handling
Zone-less types (`LocalDateTime` / `LocalDate` / `LocalTime`) are resolved with the chart's **styler timezone**, so conversion and axis-label formatting agree. Zoned/instant types carry their own offset and ignore the supplied zone.

### Usage
```java
List<LocalDateTime> x = ...;   // no java.util.Date needed
chart.addSeries("readings", x, y);
```

### Scope / follow-up
`CategoryChart`'s date axis is a **separate path** — it keeps the original objects and casts to `Date` in `AxisTickCalculator_Category`, so extending it also needs a renderer change. Left as a follow-up and noted in the commit.

### Tests / verification
- `UtilsTest` — 7 new cases: cross-type instant equality, zoned-vs-local zone behavior, `LocalTime` anchoring, unsupported-type error. Full `xchart` suite: **100 passed**.
- `TestForIssue761` demo renders a `LocalDateTime` time-series; X-axis shows `09:00 … 11:30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)