### PR TITLE
Fix tooltip decimal separator to follow styler locale (issue #699)

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue699.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue699.java
@@ -1,0 +1,66 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Locale;
+
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+/**
+ * Reproducer / how-to for https://github.com/knowm/XChart/issues/699
+ *
+ * <p>"Time plot tooltip, float number display with comma."
+ *
+ * <p>When a Y-axis decimal pattern was set, the tooltip formatted the Y value with the JVM default
+ * locale, so on a comma-decimal-separator JVM (e.g. French/German) the tooltip showed "3,9" while
+ * the axis showed "3.9". The tooltip now uses the styler locale, matching the axis. Set a
+ * period-decimal locale (like {@link Locale#US}) via {@code setLocale(...)} to force periods.
+ *
+ * <p>Hover over a data point to see the tooltip.
+ */
+public class TestForIssue699 {
+
+  public static void main(String[] args) {
+
+    // Try another locale by passing its language tag as the first argument, e.g. "de-DE"
+    // (comma separator) or "en-US" (period separator). Defaults to US.
+    Locale locale = args.length > 0 ? Locale.forLanguageTag(args[0]) : Locale.GERMAN;
+    new SwingWrapper<>(getChart(locale)).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static XYChart getChart() {
+
+    return getChart(Locale.US);
+  }
+
+  /**
+   * Constructs the chart with the given styler locale. The tooltip's decimal separator follows this
+   * locale, just like the axis labels — {@link Locale#US} yields "3.9", {@link Locale#GERMANY}
+   * yields "3,9".
+   */
+  public static XYChart getChart(Locale locale) {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Tooltip decimal separator follows locale (issue 699): " + locale.toLanguageTag())
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .build();
+
+    chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
+    chart.getStyler().setToolTipsAlwaysVisible(true);
+    chart.getStyler().setYAxisDecimalPattern("#0.#########");
+    chart.getStyler().setLocale(locale);
+
+    double[] xData = {1.18, 2.5, 3.7, 4.2, 5.9};
+    double[] yData = {3.9, 5.1, 4.4, 7.25, 6.5};
+
+    chart.addSeries("readings", xData, yData);
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxesChart.java
@@ -1,6 +1,7 @@
 package org.knowm.xchart.internal.chartpart;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.Format;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -131,7 +132,13 @@ public abstract class AxesChart<ST extends AxesChartStyler, S extends AxesChartS
   Format getYAxisFormat(String yAxisDecimalPattern) {
     final Format format;
     if (yAxisDecimalPattern != null) {
-      format = new DecimalFormat(yAxisDecimalPattern);
+      // Use the styler's locale for the decimal format symbols so the tooltip's decimal separator
+      // matches the axis, which formats via the styler locale (see Formatter_Number). Otherwise a
+      // JVM default locale like French/German would render the decimal separator as a comma in the
+      // tooltip while the axis shows a period.
+      format =
+          new DecimalFormat(
+              yAxisDecimalPattern, DecimalFormatSymbols.getInstance(styler.getLocale()));
     } else {
       format = axisPair.getYAxis().getAxisTickCalculator().getAxisFormat();
     }

--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue699Test.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/RegressionIssue699Test.java
@@ -1,0 +1,34 @@
+package org.knowm.xchart.internal.chartpart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.text.Format;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.XYChart;
+
+/** Regression test for <a href="https://github.com/knowm/XChart/issues/699">issue 699</a>. */
+public class RegressionIssue699Test {
+
+  /**
+   * The tooltip Y value format (used with a Y-axis decimal pattern) must honor the styler locale,
+   * matching how the axis tick labels are formatted. Before the fix, the tooltip built a {@link
+   * java.text.DecimalFormat} with the JVM default locale, so a comma-locale JVM rendered "3,9" in
+   * the tooltip while the axis showed "3.9".
+   */
+  @Test
+  public void yAxisDecimalPatternTooltipFormatShouldHonorStylerLocale() {
+
+    AxesChart<?, ?> chart = new XYChart(500, 400);
+    chart.getStyler().setYAxisDecimalPattern("#0.#########");
+
+    chart.getStyler().setLocale(Locale.US);
+    Format usFormat = chart.getYAxisFormat("#0.#########");
+    assertThat(usFormat.format(3.9)).isEqualTo("3.9");
+
+    chart.getStyler().setLocale(Locale.GERMANY);
+    Format germanyFormat = chart.getYAxisFormat("#0.#########");
+    assertThat(germanyFormat.format(3.9)).isEqualTo("3,9");
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #699.

When a Y-axis decimal pattern is set, the XY/OHLC tooltip formatted its Y value using the **JVM default locale** instead of the styler locale. On a comma-decimal-separator JVM (e.g. French/German), the tooltip rendered `3,9` while the axis rendered `3.9` — an inconsistent, confusing display.

## Root cause

- Axis tick labels format through `Formatter_Number`, which uses `NumberFormat.getNumberInstance(styler.getLocale())` — so they honor the styler locale.
- The tooltip path went through `AxesChart.getYAxisFormat(String)`, which built `new DecimalFormat(pattern)` with **no locale**, falling back to `Locale.getDefault()`.

## Fix

Construct the tooltip's `DecimalFormat` with `DecimalFormatSymbols.getInstance(styler.getLocale())` so the tooltip and axis always agree. Users can force periods with `setLocale(Locale.US)`. The same method feeds both `XYChart` and `OHLCChart` tooltips.

## Tests / demo

- `RegressionIssue699Test` — asserts `US -> "3.9"` and `GERMANY -> "3,9"`; verified it fails before the fix and passes after.
- Full `xchart` suite: 101 tests pass.
- `TestForIssue699` demo — pass a language tag (e.g. `de-DE` / `en-US`) to see the separator follow the locale in both the axis and the tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)