### PR TITLE
Support stacked area charts for CategoryChart (issue #465)

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue465.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue465.java
@@ -1,0 +1,64 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Arrays;
+import java.util.List;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.SwingWrapper;
+
+/**
+ * Issue #465 — Stacked Area chart.
+ *
+ * <p>The CategoryChart stacking engine now supports the {@link CategorySeriesRenderStyle#Area}
+ * render style, so a stacked area chart works whenever the X-axis is categorical. This demo shows
+ * the same dataset rendered as a stacked bar chart and a stacked area chart side by side, so the
+ * area tops line up with the bar tops.
+ *
+ * <p>The data mirrors the AnyChart "stacked area" example the reporter linked. AnyChart's rows are
+ * {@code [category, s1, s2, s3]}; here they are transposed into one series per column.
+ */
+public class TestForIssue465 {
+
+  // AnyChart data set:
+  //   ["Winter", 20000, 40000, 20000]
+  //   ["Spring", 20000, 40000, 40000]
+  //   ["Summer", 40000, 30000, 30000]
+  //   ["Autumn", 20000, 20000, 40000]
+  private static final List<String> SEASONS = Arrays.asList("Winter", "Spring", "Summer", "Autumn");
+  private static final List<Integer> SERIES_1 = Arrays.asList(20000, 20000, 40000, 20000);
+  private static final List<Integer> SERIES_2 = Arrays.asList(40000, 40000, 30000, 20000);
+  private static final List<Integer> SERIES_3 = Arrays.asList(20000, 40000, 30000, 40000);
+
+  public static void main(String[] args) {
+
+    List<CategoryChart> charts =
+        Arrays.asList(
+            buildChart("Stacked Bar", CategorySeriesRenderStyle.Bar),
+            buildChart("Stacked Area", CategorySeriesRenderStyle.Area));
+
+    new SwingWrapper<>(charts, 1, 2).displayChartMatrix();
+  }
+
+  private static CategoryChart buildChart(String title, CategorySeriesRenderStyle renderStyle) {
+
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(600)
+            .height(500)
+            .title(title)
+            .xAxisTitle("Season")
+            .yAxisTitle("Value")
+            .build();
+
+    chart.getStyler().setStacked(true);
+    chart.getStyler().setDefaultSeriesRenderStyle(renderStyle);
+    chart.getStyler().setLegendVisible(false);
+
+    chart.addSeries("Series 1", SEASONS, SERIES_1);
+    chart.addSeries("Series 2", SEASONS, SERIES_2);
+    chart.addSeries("Series 3", SEASONS, SERIES_3);
+
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue465.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue465.java
@@ -32,12 +32,21 @@ public class TestForIssue465 {
 
   public static void main(String[] args) {
 
-    List<CategoryChart> charts =
-        Arrays.asList(
-            buildChart("Stacked Bar", CategorySeriesRenderStyle.Bar),
-            buildChart("Stacked Area", CategorySeriesRenderStyle.Area));
+    new SwingWrapper<>(getCharts(), 1, 2).displayChartMatrix();
+  }
 
-    new SwingWrapper<>(charts, 1, 2).displayChartMatrix();
+  /** The stacked area chart, for headless/automated callers. */
+  public CategoryChart getChart() {
+
+    return buildChart("Stacked Area", CategorySeriesRenderStyle.Area);
+  }
+
+  /** The stacked bar and stacked area charts, shown side by side. */
+  public static List<CategoryChart> getCharts() {
+
+    return Arrays.asList(
+        buildChart("Stacked Bar", CategorySeriesRenderStyle.Bar),
+        buildChart("Stacked Area", CategorySeriesRenderStyle.Area));
   }
 
   private static CategoryChart buildChart(String title, CategorySeriesRenderStyle renderStyle) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -303,7 +303,8 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
 
       CategoryStyler categoryStyler = (CategoryStyler) chart.getStyler();
       if (categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Bar
-          || categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Stick) {
+          || categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Stick
+          || categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Area) {
 
         // if stacked, we need to completely re-calculate min and max.
         if (categoryStyler.isStacked() && !chart.getSeriesMap().isEmpty()) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -302,67 +302,68 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
     if (chart.getStyler() instanceof CategoryStyler) {
 
       CategoryStyler categoryStyler = (CategoryStyler) chart.getStyler();
-      if (categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Bar
-          || categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Stick
-          || categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Area) {
 
-        // if stacked, we need to completely re-calculate min and max.
-        if (categoryStyler.isStacked() && !chart.getSeriesMap().isEmpty()) {
+      // If stacked, recalculate min and max from the per-category stack sums. This is independent of
+      // the render style (bar, stick, area, ...) since stacking sums the series values the same way,
+      // and it also covers charts where individual series override the default render style.
+      if (categoryStyler.isStacked() && !chart.getSeriesMap().isEmpty()) {
 
-          AxesChartSeriesCategory axesChartSeries =
-              (AxesChartSeriesCategory) chart.getSeriesMap().values().iterator().next();
-          List<?> categories = (List<?>) axesChartSeries.getXData();
+        AxesChartSeriesCategory axesChartSeries =
+            (AxesChartSeriesCategory) chart.getSeriesMap().values().iterator().next();
+        List<?> categories = (List<?>) axesChartSeries.getXData();
 
-          int numCategories = categories.size();
-          double[] accumulatedStackOffsetPos = new double[numCategories];
-          double[] accumulatedStackOffsetNeg = new double[numCategories];
+        int numCategories = categories.size();
+        double[] accumulatedStackOffsetPos = new double[numCategories];
+        double[] accumulatedStackOffsetNeg = new double[numCategories];
 
-          for (S series : chart.getSeriesMap().values()) {
+        for (S series : chart.getSeriesMap().values()) {
 
-            AxesChartSeriesCategory axesChartSeriesCategory = (AxesChartSeriesCategory) series;
+          AxesChartSeriesCategory axesChartSeriesCategory = (AxesChartSeriesCategory) series;
 
-            if (!series.isEnabled()) {
+          if (!series.isEnabled()) {
+            continue;
+          }
+
+          int categoryCounter = 0;
+          double[] yArr = axesChartSeriesCategory.getYData();
+          for (double next : yArr) {
+
+            // skip when a value is NaN (was null in the original list)
+            if (Double.isNaN(next)) {
+              categoryCounter++;
               continue;
             }
 
-            int categoryCounter = 0;
-            double[] yArr = axesChartSeriesCategory.getYData();
-            for (double next : yArr) {
-
-              // skip when a value is NaN (was null in the original list)
-              if (Double.isNaN(next)) {
-                categoryCounter++;
-                continue;
-              }
-
-              if (next > 0) {
-                accumulatedStackOffsetPos[categoryCounter] += next;
-              } else if (next < 0) {
-                accumulatedStackOffsetNeg[categoryCounter] += next;
-              }
-              categoryCounter++;
+            if (next > 0) {
+              accumulatedStackOffsetPos[categoryCounter] += next;
+            } else if (next < 0) {
+              accumulatedStackOffsetNeg[categoryCounter] += next;
             }
+            categoryCounter++;
           }
-
-          double max = accumulatedStackOffsetPos[0];
-          for (int i = 1; i < accumulatedStackOffsetPos.length; i++) {
-            if (accumulatedStackOffsetPos[i] > max) {
-              max = accumulatedStackOffsetPos[i];
-            }
-          }
-
-          double min = accumulatedStackOffsetNeg[0];
-          for (int i = 1; i < accumulatedStackOffsetNeg.length; i++) {
-            if (accumulatedStackOffsetNeg[i] < min) {
-              min = accumulatedStackOffsetNeg[i];
-            }
-          }
-
-          overrideYAxisMaxValue = max;
-          overrideYAxisMinValue = min;
-          // System.out.println("overrideYAxisMaxValue: " + overrideYAxisMaxValue);
-          // System.out.println("overrideYAxisMinValue: " + overrideYAxisMinValue);
         }
+
+        double max = accumulatedStackOffsetPos[0];
+        for (int i = 1; i < accumulatedStackOffsetPos.length; i++) {
+          if (accumulatedStackOffsetPos[i] > max) {
+            max = accumulatedStackOffsetPos[i];
+          }
+        }
+
+        double min = accumulatedStackOffsetNeg[0];
+        for (int i = 1; i < accumulatedStackOffsetNeg.length; i++) {
+          if (accumulatedStackOffsetNeg[i] < min) {
+            min = accumulatedStackOffsetNeg[i];
+          }
+        }
+
+        overrideYAxisMaxValue = max;
+        overrideYAxisMinValue = min;
+      }
+
+      if (categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Bar
+          || categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Stick
+          || categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Area) {
 
         // override min/max value for bar charts' Y-Axis
         // There is a special case where it's desired to anchor the axis min or max to zero, like in

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category.java
@@ -134,6 +134,10 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
             smoothPath = null;
           }
 
+          // flush the current stacked-area band so it does not bridge across the gap
+          fillStackedAreaBand(
+              g, series, stackedAreaTopPoints, stackedAreaFloorYOffsets, series.isSmooth());
+
           previousX = -Double.MAX_VALUE;
           previousY = -Double.MAX_VALUE;
           categoryCounter++;
@@ -526,22 +530,9 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
       g.setColor(series.getFillColor());
       closePath(g, path, previousX, getBounds(), yTopMargin);
 
-      // fill the stacked-area band: top edge left-to-right, then floor edge right-to-left
-      if (!stackedAreaTopPoints.isEmpty()) {
-        Path2D.Double areaBand = new Path2D.Double();
-        Point2D.Double firstPoint = stackedAreaTopPoints.get(0);
-        areaBand.moveTo(firstPoint.getX(), firstPoint.getY());
-        for (int i = 1; i < stackedAreaTopPoints.size(); i++) {
-          Point2D.Double p = stackedAreaTopPoints.get(i);
-          areaBand.lineTo(p.getX(), p.getY());
-        }
-        for (int i = stackedAreaTopPoints.size() - 1; i >= 0; i--) {
-          areaBand.lineTo(stackedAreaTopPoints.get(i).getX(), stackedAreaFloorYOffsets.get(i));
-        }
-        areaBand.closePath();
-        g.setColor(series.getFillColor());
-        g.fill(areaBand);
-      }
+      // fill any remaining stacked-area band (a series with no NaN gaps has one band)
+      fillStackedAreaBand(
+          g, series, stackedAreaTopPoints, stackedAreaFloorYOffsets, series.isSmooth());
 
       // Final drawing of a steppedBar is done after the main loop,
       // as it continues on null and we may end up missing the final iteration.
@@ -657,6 +648,65 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
     steppedReturnPath.add(new Point2D.Double(xOffset + stepLength, yCenter));
 
     return y;
+  }
+
+  /**
+   * Fills one stacked-area band: the top edge (this series' cumulative line) left-to-right, then the
+   * floor edge (the previous series' cumulative line, or the zero line for the first series)
+   * right-to-left. When {@code smooth} is true the edges use the same cubic interpolation as
+   * non-stacked smooth areas, so a band's floor exactly retraces the curve of the band below it. The
+   * passed lists are cleared afterward so the caller can begin a new contiguous segment (e.g. after
+   * a NaN gap).
+   */
+  private void fillStackedAreaBand(
+      Graphics2D g,
+      S series,
+      ArrayList<Point2D.Double> topPoints,
+      ArrayList<Double> floorYOffsets,
+      boolean smooth) {
+
+    if (topPoints.isEmpty()) {
+      return;
+    }
+
+    Path2D.Double band = new Path2D.Double();
+    Point2D.Double first = topPoints.get(0);
+    band.moveTo(first.getX(), first.getY());
+
+    // top edge, left to right
+    for (int i = 1; i < topPoints.size(); i++) {
+      Point2D.Double prev = topPoints.get(i - 1);
+      Point2D.Double cur = topPoints.get(i);
+      if (smooth) {
+        double midX = (prev.getX() + cur.getX()) / 2;
+        band.curveTo(midX, prev.getY(), midX, cur.getY(), cur.getX(), cur.getY());
+      } else {
+        band.lineTo(cur.getX(), cur.getY());
+      }
+    }
+
+    // floor edge, right to left
+    int last = topPoints.size() - 1;
+    band.lineTo(topPoints.get(last).getX(), floorYOffsets.get(last));
+    for (int i = last; i > 0; i--) {
+      double curX = topPoints.get(i).getX();
+      double prevX = topPoints.get(i - 1).getX();
+      double curFloor = floorYOffsets.get(i);
+      double prevFloor = floorYOffsets.get(i - 1);
+      if (smooth) {
+        double midX = (curX + prevX) / 2;
+        band.curveTo(midX, curFloor, midX, prevFloor, prevX, prevFloor);
+      } else {
+        band.lineTo(prevX, prevFloor);
+      }
+    }
+
+    band.closePath();
+    g.setColor(series.getFillColor());
+    g.fill(band);
+
+    topPoints.clear();
+    floorYOffsets.clear();
   }
 
   /** Draws the accumulated stepped-bar path after all data points have been processed. */

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category.java
@@ -9,6 +9,7 @@ import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +70,23 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
     double[] accumulatedStackOffsetNeg = new double[numCategories];
     double[] accumulatedStackOffsetTotalYOffset = new double[numCategories];
 
+    // For stacked area charts, each series is drawn as a filled band between the previous series'
+    // cumulative line (the floor) and its own cumulative line. Positive and negative stacks grow
+    // away from the value-zero line in opposite directions (mirroring stacked bars), so track a
+    // floor per direction per category, both starting at the zero line.
+    double yAxisMinChart = axesChart.getYAxis().getMin();
+    double yAxisMaxChart = axesChart.getYAxis().getMax();
+    double zeroValue = Math.max(yAxisMinChart, Math.min(yAxisMaxChart, 0.0));
+    double zeroLineYOffset =
+        getBounds().getY()
+            + getBounds().getHeight()
+            - (yTopMargin
+                + (zeroValue - yAxisMinChart) / (yAxisMaxChart - yAxisMinChart) * yTickSpace);
+    double[] stackedAreaFloorYOffsetPos = new double[numCategories];
+    double[] stackedAreaFloorYOffsetNeg = new double[numCategories];
+    Arrays.fill(stackedAreaFloorYOffsetPos, zeroLineYOffset);
+    Arrays.fill(stackedAreaFloorYOffsetNeg, zeroLineYOffset);
+
     for (S series : seriesMap.values()) {
 
       if (!series.isEnabled()) {
@@ -96,6 +114,10 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
       // Stepped bars are drawn in chunks rather than for each individual bar
       ArrayList<Point2D.Double> steppedPath = new ArrayList<>();
       ArrayList<Point2D.Double> steppedReturnPath = new ArrayList<>();
+      // Stacked area top points and matching floor Y-offsets, collected across the data loop and
+      // painted as a single filled band afterward.
+      ArrayList<Point2D.Double> stackedAreaTopPoints = new ArrayList<>();
+      ArrayList<Double> stackedAreaFloorYOffsets = new ArrayList<>();
       Path2D.Double path = null;
       int categoryCounter = 0;
 
@@ -174,7 +196,10 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
               if (stylerCategory.isStacked() && !series.isOverlapped()) {
                 yTop += accumulatedStackOffsetPos[categoryCounter];
                 yBottom += accumulatedStackOffsetPos[categoryCounter];
-                accumulatedStackOffsetPos[categoryCounter] += (yTop - yBottom);
+                // Grow the stack by the actual value. For bars (yBottom == 0) this equals
+                // (yTop - yBottom), but for area/line (yBottom == yTop) that difference would be 0,
+                // so the stack must be advanced by y directly.
+                accumulatedStackOffsetPos[categoryCounter] += y;
               }
             } else {
               if (series.getChartCategorySeriesRenderStyle().orElseThrow()
@@ -192,7 +217,9 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
               if (stylerCategory.isStacked() && !series.isOverlapped()) {
                 yTop -= accumulatedStackOffsetNeg[categoryCounter];
                 yBottom -= accumulatedStackOffsetNeg[categoryCounter];
-                accumulatedStackOffsetNeg[categoryCounter] += (yTop - yBottom);
+                // Grow the negative stack by the magnitude of y (y < 0 here), for the same reason
+                // as the positive branch: for area/line (yTop - yBottom) would be 0.
+                accumulatedStackOffsetNeg[categoryCounter] -= y;
               }
             }
             break;
@@ -369,7 +396,21 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
           if (CategorySeriesRenderStyle.Area.equals(
               series.getChartCategorySeriesRenderStyle().orElseThrow())) {
 
-            if (previousX != -Double.MAX_VALUE && previousY != -Double.MAX_VALUE) {
+            double xCenter = xOffset + barWidth / 2;
+
+            if (stylerCategory.isStacked() && !series.isOverlapped()) {
+              // Stacked: collect this point and the floor it rests on (the previous series'
+              // cumulative line for this category). The band is filled after the data loop. Advance
+              // the floor so the next series stacks on top of this series.
+              double[] floors =
+                  (y >= 0.0) ? stackedAreaFloorYOffsetPos : stackedAreaFloorYOffsetNeg;
+              double floor = dataIndex < floors.length ? floors[dataIndex] : zeroLineYOffset;
+              stackedAreaTopPoints.add(new Point2D.Double(xCenter, yOffset));
+              stackedAreaFloorYOffsets.add(floor);
+              if (dataIndex < floors.length) {
+                floors[dataIndex] = yOffset;
+              }
+            } else if (previousX != -Double.MAX_VALUE && previousY != -Double.MAX_VALUE) {
 
               g.setColor(series.getFillColor());
               double yBottomOfArea = getBounds().getY() + getBounds().getHeight() - yTopMargin;
@@ -381,14 +422,14 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
               }
               if (series.isSmooth()) {
                 path.curveTo(
-                    (previousX + xOffset + barWidth / 2) / 2,
+                    (previousX + xCenter) / 2,
                     previousY,
-                    (previousX + xOffset + barWidth / 2) / 2,
+                    (previousX + xCenter) / 2,
                     yOffset,
-                    xOffset + barWidth / 2,
+                    xCenter,
                     yOffset);
               } else {
-                path.lineTo(xOffset + barWidth / 2, yOffset);
+                path.lineTo(xCenter, yOffset);
               }
             }
             if (xOffset < previousX) {
@@ -484,6 +525,23 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
       // close any open path for area charts
       g.setColor(series.getFillColor());
       closePath(g, path, previousX, getBounds(), yTopMargin);
+
+      // fill the stacked-area band: top edge left-to-right, then floor edge right-to-left
+      if (!stackedAreaTopPoints.isEmpty()) {
+        Path2D.Double areaBand = new Path2D.Double();
+        Point2D.Double firstPoint = stackedAreaTopPoints.get(0);
+        areaBand.moveTo(firstPoint.getX(), firstPoint.getY());
+        for (int i = 1; i < stackedAreaTopPoints.size(); i++) {
+          Point2D.Double p = stackedAreaTopPoints.get(i);
+          areaBand.lineTo(p.getX(), p.getY());
+        }
+        for (int i = stackedAreaTopPoints.size() - 1; i >= 0; i--) {
+          areaBand.lineTo(stackedAreaTopPoints.get(i).getX(), stackedAreaFloorYOffsets.get(i));
+        }
+        areaBand.closePath();
+        g.setColor(series.getFillColor());
+        g.fill(areaBand);
+      }
 
       // Final drawing of a steppedBar is done after the main loop,
       // as it continues on null and we may end up missing the final iteration.

--- a/xchart/src/test/java/org/knowm/xchart/CategoryChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/CategoryChartTest.java
@@ -11,6 +11,7 @@ import java.awt.image.BufferedImage;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
 import org.knowm.xchart.custom.CustomGraphic;
 import org.knowm.xchart.custom.CustomTheme;
 import org.knowm.xchart.internal.series.Series;
@@ -298,6 +299,66 @@ public class CategoryChartTest {
             diff5,
             diffNaN)
         .isGreaterThan(diffNaN);
+  }
+
+  /**
+   * Regression test for <a href="https://github.com/knowm/XChart/issues/465">issue 465</a>.
+   *
+   * <p>Stacked area charts must stack like stacked bars: the Y-axis has to scale to the per-category
+   * stacked sum, not the raw maximum single value. This mirrors the AnyChart "stacked area" data
+   * where three series per season sum to as much as 100k while no single value exceeds 40k.
+   *
+   * <p>{@code getScreenYFromChart(v)} maps a data value to its pixel Y using the computed axis, so a
+   * stacked area chart should map any value identically to a stacked bar chart of the same data
+   * (both scale to the stack sum), and differently from a non-stacked area chart (which scales only
+   * to the raw max).
+   */
+  @Test
+  void issue465StackedAreaScalesToStackSum() {
+    List<String> seasons = Arrays.asList("Winter", "Spring", "Summer", "Autumn");
+    List<Integer> s1 = Arrays.asList(20000, 20000, 40000, 20000);
+    List<Integer> s2 = Arrays.asList(40000, 40000, 30000, 20000);
+    List<Integer> s3 = Arrays.asList(20000, 40000, 30000, 40000); // Spring stack sum = 100k
+
+    CategoryChart stackedBar = buildIssue465Chart(seasons, s1, s2, s3, true, CategorySeriesRenderStyle.Bar);
+    CategoryChart stackedArea = buildIssue465Chart(seasons, s1, s2, s3, true, CategorySeriesRenderStyle.Area);
+    CategoryChart nonStackedArea = buildIssue465Chart(seasons, s1, s2, s3, false, CategorySeriesRenderStyle.Area);
+
+    // painting computes the axis min/max used by getScreenYFromChart
+    BitmapEncoder.getBufferedImage(stackedBar);
+    BitmapEncoder.getBufferedImage(stackedArea);
+    BitmapEncoder.getBufferedImage(nonStackedArea);
+
+    // The stack sum (100k) must land at the same pixel for stacked area as for stacked bar.
+    double barTop = stackedBar.getScreenYFromChart(100000);
+    double areaTop = stackedArea.getScreenYFromChart(100000);
+    double nonStackedTop = nonStackedArea.getScreenYFromChart(100000);
+
+    assertThat(areaTop)
+        .as("stacked area must scale to the stack sum just like a stacked bar chart")
+        .isEqualTo(barTop, org.assertj.core.api.Assertions.within(0.5));
+
+    // A non-stacked area chart only scales to the raw max (40k), so 100k maps far above the plot —
+    // proving the stacked behavior is actually engaged, not incidental.
+    assertThat(Math.abs(areaTop - nonStackedTop))
+        .as("stacked and non-stacked area charts must scale their Y-axis differently")
+        .isGreaterThan(1.0);
+  }
+
+  private CategoryChart buildIssue465Chart(
+      List<String> seasons,
+      List<Integer> s1,
+      List<Integer> s2,
+      List<Integer> s3,
+      boolean stacked,
+      CategorySeriesRenderStyle renderStyle) {
+    CategoryChart chart = new CategoryChart(800, 600, ChartTheme.Matlab);
+    chart.getStyler().setStacked(stacked);
+    chart.getStyler().setDefaultSeriesRenderStyle(renderStyle);
+    chart.addSeries("Series 1", seasons, s1);
+    chart.addSeries("Series 2", seasons, s2);
+    chart.addSeries("Series 3", seasons, s3);
+    return chart;
   }
 
   private CategoryChart buildIssue707Chart(


### PR DESCRIPTION
## Summary

Fixes stacked **area** charts for `CategoryChart`. Selecting the `Area` render style together with `setStacked(true)` previously produced overlapping, axis-clipped areas rather than a stacked area chart, because the stacking engine only ever handled `Bar`/`Stick`.

Closes #465 (for the categorical-X case; continuous `XYChart` stacking remains a separate follow-up).

## What was broken

Same data, `setStacked(true)`, only the render style differs:

| | Stacked Bar (worked) | Stacked Area (broken) |
|---|---|---|
| Y-axis | scales to stack sum | clipped at raw max |
| Layers | cleanly stacked | overlapping / blended |

Three independent root causes:

1. **Axis scaling** — `AxisPair` only recomputed the stacked Y-axis min/max for `Bar`/`Stick`, so `Area` clipped at the raw maximum single value instead of the per-category stack sum.
2. **Stack accumulator** — `PlotContent_Category` advanced the stack by `(yTop - yBottom)`, which is `0` for area/line styles (bars only worked because they set `yBottom = 0`). Now it advances by the actual data value `y` — identical for bars, correct for area.
3. **Band fill** — area always filled from the plot baseline, so translucent layers overlapped. Each stacked area is now filled as a band between the previous series' cumulative line and its own, using separate positive/negative floors anchored at the value-zero line (mirroring stacked-bar semantics), so mixed-sign data stacks correctly too.

## Verification

- Stacked bar output is unchanged (including negative values in `BarChart03`) — no regression.
- Non-stacked area and mixed-sign stacked area render correctly.
- All existing core tests pass, plus a new regression test `issue465StackedAreaScalesToStackSum` that pins the axis-scaling behavior via `getScreenYFromChart`.
- New `TestForIssue465` demo renders the same dataset as stacked bar and stacked area side by side; their tops line up exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)