### PR TITLE
docs: demo custom Y-axis label formatting (issue #256)

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue256.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue256.java
@@ -1,0 +1,65 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
+
+/**
+ * Reproducer / how-to for https://github.com/knowm/XChart/issues/256
+ *
+ * <p>"It is possible to change the decimal pattern format of the y axis. But it would be nice to be
+ * able to override the whole label formatting. E.g. to be able to apply time and date formatting on
+ * the y values."
+ *
+ * <p>This is already supported: {@code styler.setYAxisTickLabelsFormattingFunction(Function<Double,
+ * String>)} completely replaces the default (decimal-pattern) formatting for Y-axis tick labels.
+ * The function receives the raw tick value as a {@code Double} and returns the exact String to
+ * render — so time/date formatting, units, currency, or any custom logic is possible. The same
+ * hook exists for the X-axis via {@code setXAxisTickLabelsFormattingFunction(...)}.
+ */
+public class TestForIssue256 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static XYChart getChart() {
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Custom Y-Axis label formatting: time-of-day (issue 256)")
+            .xAxisTitle("Sample #")
+            .yAxisTitle("Time of day")
+            .build();
+
+    chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Line);
+    chart.getStyler().setLegendVisible(false);
+
+    // Y values are epoch-millis timestamps (here: a base time plus a few minutes per sample).
+    long base = 0L; // 1970-01-01T00:00:00Z, kept simple/deterministic for the demo
+    double[] xData = new double[12];
+    double[] yData = new double[12];
+    for (int i = 0; i < xData.length; i++) {
+      xData[i] = i;
+      yData[i] = base + (i * 7 + (i % 3) * 3) * 60_000L; // minutes -> millis
+    }
+    chart.addSeries("event time", xData, yData);
+
+    // The key: override the whole Y-axis label formatting. Instead of the default decimal pattern,
+    // interpret each tick value as epoch millis and render it as HH:mm.
+    SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm");
+    chart
+        .getStyler()
+        .setYAxisTickLabelsFormattingFunction(
+            value -> timeFormat.format(new Date(value.longValue())));
+
+    return chart;
+  }
+}


### PR DESCRIPTION
Closes #256.

### Context
Issue #256 requested the ability to "override the whole label formatting" of the Y-axis (beyond the decimal pattern), e.g. to apply **time/date formatting** to Y values.

### Finding: already supported
`AxesChartStyler.setYAxisTickLabelsFormattingFunction(Function<Double, String>)` (and the convenience `AxesChart.setCustomYAxisTickLabelsFormatter(...)`) completely replaces the default numeric formatting. The function receives each raw tick value and returns the label string.

Wiring:
- `Axis_Y.getAxisTickCalculator` selects `AxisTickCalculator_Callback` (or `AxisTickCalculator_Logarithmic` for log/non-Date axes) when the function is set.
- `Formatter_Custom` invokes the user function per tick, bypassing the decimal pattern entirely.

The symmetric X-axis hook (`setXAxisTickLabelsFormattingFunction`) already existed as well.

### This PR
Adds a how-to demo, `TestForIssue256`, that plots epoch-millis Y values and renders them as `HH:mm` time-of-day labels via a `SimpleDateFormat` — the reporter's exact use case. No library code change is needed.

Verified headless: the Y-axis renders `01:00`, `01:08`, `01:16`, …

🤖 Generated with [Claude Code](https://claude.com/claude-code)