### PR TITLE
fix: XYSeries.getXYSeriesRenderStyle() returns empty until paint()

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -408,11 +408,11 @@ public class XYChart extends AxesChart<XYStyler, XYSeries> {
     setWidth(width);
     setHeight(height);
 
-    // Resolve the series render styles if they are not set. Legend and Plot need it.
+    // Validate that every series has an effective render style (explicit or default). Legend and
+    // Plot need it. The style is resolved lazily by getXYSeriesRenderStyle(), so nothing is mutated
+    // here.
     for (XYSeries xySeries : seriesMap.values()) {
-      XYSeries.XYSeriesRenderStyle renderStyle =
-          xySeries.getXYSeriesRenderStyle().orElse(getStyler().getDefaultSeriesRenderStyle());
-      if (renderStyle == null) {
+      if (xySeries.getXYSeriesRenderStyle().isEmpty()) {
         throw new IllegalStateException("XY render style not set");
       }
     }

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -307,6 +307,9 @@ public class XYChart extends AxesChart<XYStyler, XYSeries> {
               seriesName, Utils.getGeneratedDataAsArray(yData.length), yData, errorBars, dataType);
     }
 
+    if (series.getXYSeriesRenderStyle().isEmpty()) {
+      series.setXYSeriesRenderStyle(styler.getDefaultSeriesRenderStyle());
+    }
     seriesMap.put(seriesName, series);
 
     return series;

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -408,10 +408,12 @@ public class XYChart extends AxesChart<XYStyler, XYSeries> {
     setWidth(width);
     setHeight(height);
 
-    // set the series render styles if they are not set. Legend and Plot need it.
+    // Resolve the series render styles if they are not set. Legend and Plot need it.
     for (XYSeries xySeries : seriesMap.values()) {
-      if (xySeries.getExplicitXYSeriesRenderStyle().isEmpty()) { // use default from Style Manager
-        xySeries.setXYSeriesRenderStyle(getStyler().getDefaultSeriesRenderStyle());
+      XYSeries.XYSeriesRenderStyle renderStyle =
+          xySeries.getXYSeriesRenderStyle().orElse(getStyler().getDefaultSeriesRenderStyle());
+      if (renderStyle == null) {
+        throw new IllegalStateException("XY render style not set");
       }
     }
     setSeriesStyles();

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -307,9 +307,7 @@ public class XYChart extends AxesChart<XYStyler, XYSeries> {
               seriesName, Utils.getGeneratedDataAsArray(yData.length), yData, errorBars, dataType);
     }
 
-    if (series.getXYSeriesRenderStyle().isEmpty()) {
-      series.setXYSeriesRenderStyle(styler.getDefaultSeriesRenderStyle());
-    }
+    series.setDefaultRenderStyleSupplier(() -> styler.getDefaultSeriesRenderStyle());
     seriesMap.put(seriesName, series);
 
     return series;
@@ -412,7 +410,7 @@ public class XYChart extends AxesChart<XYStyler, XYSeries> {
 
     // set the series render styles if they are not set. Legend and Plot need it.
     for (XYSeries xySeries : seriesMap.values()) {
-      if (xySeries.getXYSeriesRenderStyle().isEmpty()) { // wasn't overridden, use default from Style Manager
+      if (xySeries.getExplicitXYSeriesRenderStyle().isEmpty()) { // use default from Style Manager
         xySeries.setXYSeriesRenderStyle(getStyler().getDefaultSeriesRenderStyle());
       }
     }

--- a/xchart/src/main/java/org/knowm/xchart/XYSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYSeries.java
@@ -36,11 +36,6 @@ public class XYSeries extends AxesChartSeriesNumerical {
     return Optional.ofNullable(defaultRenderStyleSupplier.get());
   }
 
-  Optional<XYSeriesRenderStyle> getExplicitXYSeriesRenderStyle() {
-
-    return xySeriesRenderStyle;
-  }
-
   public XYSeries setXYSeriesRenderStyle(XYSeriesRenderStyle chartXYSeriesRenderStyle) {
 
     this.xySeriesRenderStyle = Optional.ofNullable(chartXYSeriesRenderStyle);

--- a/xchart/src/main/java/org/knowm/xchart/XYSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYSeries.java
@@ -1,6 +1,7 @@
 package org.knowm.xchart;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.knowm.xchart.internal.chartpart.RenderableSeries;
 import org.knowm.xchart.internal.chartpart.RenderableSeries.LegendRenderType;
 import org.knowm.xchart.internal.series.AxesChartSeriesNumerical;
@@ -9,6 +10,7 @@ import org.knowm.xchart.internal.series.AxesChartSeriesNumerical;
 public class XYSeries extends AxesChartSeriesNumerical {
 
   private Optional<XYSeriesRenderStyle> xySeriesRenderStyle = Optional.empty();
+  private Supplier<XYSeriesRenderStyle> defaultRenderStyleSupplier = () -> null;
   // smooth curve
   private boolean smooth;
 
@@ -28,6 +30,14 @@ public class XYSeries extends AxesChartSeriesNumerical {
 
   public Optional<XYSeriesRenderStyle> getXYSeriesRenderStyle() {
 
+    if (xySeriesRenderStyle.isPresent()) {
+      return xySeriesRenderStyle;
+    }
+    return Optional.ofNullable(defaultRenderStyleSupplier.get());
+  }
+
+  Optional<XYSeriesRenderStyle> getExplicitXYSeriesRenderStyle() {
+
     return xySeriesRenderStyle;
   }
 
@@ -37,10 +47,18 @@ public class XYSeries extends AxesChartSeriesNumerical {
     return this;
   }
 
+  XYSeries setDefaultRenderStyleSupplier(
+      Supplier<XYSeriesRenderStyle> defaultRenderStyleSupplier) {
+
+    this.defaultRenderStyleSupplier =
+        defaultRenderStyleSupplier == null ? () -> null : defaultRenderStyleSupplier;
+    return this;
+  }
+
   @Override
   public LegendRenderType getLegendRenderType() {
 
-    return xySeriesRenderStyle
+    return getXYSeriesRenderStyle()
         .orElseThrow(() -> new IllegalStateException("XY render style not set"))
         .getLegendRenderType();
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -77,6 +77,10 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
       double polygonStartY = -Double.MAX_VALUE;
 
       double[] errorBars = series.getExtraValues();
+
+      // resolve the effective render style once per series (not per data point)
+      XYSeriesRenderStyle seriesRenderStyle = series.getXYSeriesRenderStyle().orElseThrow();
+
       Path2D.Double path = null;
       // smooth curve
       Path2D.Double smoothPath = null;
@@ -152,12 +156,12 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
         // paint line
 
         boolean isSeriesLineOrArea =
-            XYSeriesRenderStyle.Line == series.getXYSeriesRenderStyle().orElseThrow()
-                || XYSeriesRenderStyle.Area == series.getXYSeriesRenderStyle().orElseThrow()
-                || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle().orElseThrow();
+            XYSeriesRenderStyle.Line == seriesRenderStyle
+                || XYSeriesRenderStyle.Area == seriesRenderStyle
+                || XYSeriesRenderStyle.PolygonArea == seriesRenderStyle;
         boolean isSeriesStepLineOrStepArea =
-            XYSeriesRenderStyle.Step == series.getXYSeriesRenderStyle().orElseThrow()
-                || XYSeriesRenderStyle.StepArea == series.getXYSeriesRenderStyle().orElseThrow();
+            XYSeriesRenderStyle.Step == seriesRenderStyle
+                || XYSeriesRenderStyle.StepArea == seriesRenderStyle;
 
         if (isSeriesLineOrArea || isSeriesStepLineOrStepArea) {
           if (series.getLineStyle() != SeriesLines.NONE) {
@@ -197,14 +201,14 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
         }
 
         // paint area
-        if (XYSeriesRenderStyle.Area == series.getXYSeriesRenderStyle().orElseThrow()
-            || XYSeriesRenderStyle.StepArea == series.getXYSeriesRenderStyle().orElseThrow()
-            || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle().orElseThrow()) {
+        if (XYSeriesRenderStyle.Area == seriesRenderStyle
+            || XYSeriesRenderStyle.StepArea == seriesRenderStyle
+            || XYSeriesRenderStyle.PolygonArea == seriesRenderStyle) {
 
           if (previousX != -Double.MAX_VALUE && previousY != -Double.MAX_VALUE) {
             if (path == null) {
               path = new Path2D.Double();
-              if (XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle().orElseThrow()) {
+              if (XYSeriesRenderStyle.PolygonArea == seriesRenderStyle) {
                 path.moveTo(previousX, previousY);
                 polygonStartX = previousX;
                 polygonStartY = previousY;
@@ -213,8 +217,8 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
                 path.lineTo(previousX, previousY);
               }
             }
-            if (XYSeriesRenderStyle.Area == series.getXYSeriesRenderStyle().orElseThrow()
-                || XYSeriesRenderStyle.PolygonArea == series.getXYSeriesRenderStyle().orElseThrow()) {
+            if (XYSeriesRenderStyle.Area == seriesRenderStyle
+                || XYSeriesRenderStyle.PolygonArea == seriesRenderStyle) {
               if (series.isSmooth()) {
                 path.curveTo(
                     (previousX + xOffset) / 2,
@@ -236,7 +240,7 @@ public class PlotContent_XY<ST extends XYStyler, S extends XYSeries> extends Plo
             }
           }
           if (xOffset < previousX
-              && XYSeriesRenderStyle.PolygonArea != series.getXYSeriesRenderStyle().orElseThrow()) {
+              && XYSeriesRenderStyle.PolygonArea != seriesRenderStyle) {
             throw new RuntimeException("X-Data must be in ascending order for Area Charts!!!");
           }
         }

--- a/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
 
 public class XYChartTest {
   private static final String digestType = "md5";
@@ -151,5 +152,36 @@ public class XYChartTest {
           .as("Expected power-of-ten tick value but got %s", v)
           .isLessThan(1e-9);
     }
+  }
+
+  @Test
+  public void addSeriesUsesConfiguredDefaultSeriesRenderStyleImmediately() {
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+    chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Area);
+
+    XYSeries series = chart.addSeries("test", new double[] {1, 2, 3}, new double[] {1, 2, 3});
+
+    assertThat(series.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Area);
+  }
+
+  @Test
+  public void addSeriesUsesDefaultLineRenderStyleImmediately() {
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+
+    XYSeries series = chart.addSeries("test", new double[] {1, 2, 3}, new double[] {1, 2, 3});
+
+    assertThat(series.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Line);
+  }
+
+  @Test
+  public void explicitSeriesRenderStyleSurvivesPaint() throws Exception {
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+    chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Area);
+    XYSeries series = chart.addSeries("test", new double[] {1, 2, 3}, new double[] {1, 2, 3});
+    series.setXYSeriesRenderStyle(XYSeriesRenderStyle.Scatter);
+
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+
+    assertThat(series.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Scatter);
   }
 }

--- a/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
@@ -3,6 +3,7 @@ package org.knowm.xchart;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
+import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.style.lines.SeriesLines;
 
 public class XYChartTest {
   private static final String digestType = "md5";
@@ -183,5 +186,78 @@ public class XYChartTest {
     BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
 
     assertThat(series.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Scatter);
+  }
+
+  @Test
+  public void defaultSeriesRenderStyleSetAfterAddIsUsedByGetterAndRendering()
+      throws Exception {
+
+    XYChart lateDefaultChart = buildIssue181LikeChart();
+    XYSeries lateDefaultSeries = addIssue181LikeSeries(lateDefaultChart);
+    lateDefaultChart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Scatter);
+
+    assertThat(lateDefaultSeries.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Scatter);
+
+    XYChart earlyDefaultChart = buildIssue181LikeChart();
+    earlyDefaultChart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Scatter);
+    XYSeries earlyDefaultSeries = addIssue181LikeSeries(earlyDefaultChart);
+
+    BufferedImage lateDefaultImage = BitmapEncoder.getBufferedImage(lateDefaultChart);
+    BufferedImage earlyDefaultImage = BitmapEncoder.getBufferedImage(earlyDefaultChart);
+
+    assertThat(lateDefaultSeries.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Scatter);
+    assertThat(earlyDefaultSeries.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Scatter);
+    assertThat(lateDefaultImage.getWidth()).isEqualTo(earlyDefaultImage.getWidth());
+    assertThat(lateDefaultImage.getHeight()).isEqualTo(earlyDefaultImage.getHeight());
+    assertThat(countDiffPixels(lateDefaultImage, earlyDefaultImage)).isZero();
+  }
+
+  private XYChart buildIssue181LikeChart() {
+
+    XYChart chart =
+        new XYChartBuilder().width(500).height(350).theme(Styler.ChartTheme.Matlab).build();
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.OutsideE);
+    chart.getStyler().setMarkerSize(5);
+    chart.getStyler().setAxisTicksVisible(true);
+    chart.getStyler().setXAxisMin(0.0);
+    chart.getStyler().setYAxisMin(0.0);
+    chart.getStyler().setPlotGridLinesVisible(false);
+    chart.getStyler().setPlotContentSize(1.0);
+    return chart;
+  }
+
+  private XYSeries addIssue181LikeSeries(XYChart chart) {
+
+    XYSeries gaussianBlob =
+        chart.addSeries(
+            "Gaussian Blob",
+            new double[] {0.3, 1.2, 2.1, 2.9, 3.8, 4.6, 5.4, 6.3, 7.1, 8.0},
+            new double[] {7.8, 5.9, 6.7, 4.8, 6.1, 3.9, 4.7, 2.6, 3.4, 1.5});
+
+    XYSeries vertical = chart.addSeries("vertical", new double[] {5, 5}, new double[] {0, 10});
+    vertical.setShowInLegend(false);
+    vertical.setXYSeriesRenderStyle(XYSeriesRenderStyle.Line);
+    vertical.setLineStyle(SeriesLines.SOLID);
+
+    XYSeries horizontal =
+        chart.addSeries("horizontal", new double[] {0, 10}, new double[] {5, 5});
+    horizontal.setShowInLegend(false);
+    horizontal.setXYSeriesRenderStyle(XYSeriesRenderStyle.Line);
+    horizontal.setLineStyle(SeriesLines.SOLID);
+
+    return gaussianBlob;
+  }
+
+  private int countDiffPixels(BufferedImage a, BufferedImage b) {
+
+    int count = 0;
+    for (int x = 0; x < a.getWidth(); x++) {
+      for (int y = 0; y < a.getHeight(); y++) {
+        if (a.getRGB(x, y) != b.getRGB(x, y)) {
+          count++;
+        }
+      }
+    }
+    return count;
   }
 }

--- a/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XYChartTest.java
@@ -205,11 +205,19 @@ public class XYChartTest {
     BufferedImage lateDefaultImage = BitmapEncoder.getBufferedImage(lateDefaultChart);
     BufferedImage earlyDefaultImage = BitmapEncoder.getBufferedImage(earlyDefaultChart);
 
+    XYChart repaintDefaultChart = buildIssue181LikeChart();
+    XYSeries repaintDefaultSeries = addIssue181LikeSeries(repaintDefaultChart);
+    BitmapEncoder.getBufferedImage(repaintDefaultChart);
+    repaintDefaultChart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Scatter);
+    BufferedImage repaintDefaultImage = BitmapEncoder.getBufferedImage(repaintDefaultChart);
+
     assertThat(lateDefaultSeries.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Scatter);
     assertThat(earlyDefaultSeries.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Scatter);
+    assertThat(repaintDefaultSeries.getXYSeriesRenderStyle()).contains(XYSeriesRenderStyle.Scatter);
     assertThat(lateDefaultImage.getWidth()).isEqualTo(earlyDefaultImage.getWidth());
     assertThat(lateDefaultImage.getHeight()).isEqualTo(earlyDefaultImage.getHeight());
     assertThat(countDiffPixels(lateDefaultImage, earlyDefaultImage)).isZero();
+    assertThat(countDiffPixels(repaintDefaultImage, earlyDefaultImage)).isZero();
   }
 
   private XYChart buildIssue181LikeChart() {


### PR DESCRIPTION
## Summary

`XYSeries.getXYSeriesRenderStyle()` now returns the effective render style before the chart is painted, instead of returning empty until the first `paint()`. When a series has no explicit style, the getter falls back to the chart's current default style, resolved lazily so later default changes are still reflected.

## Why this matters

Issue #849 reports that `getXYSeriesRenderStyle()` returns `null`/empty until the chart is rendered, so code that inspects a series' render style before painting gets no useful value. The naive fix (snapshotting the default when the series is added) regresses two real usages: setting `setDefaultSeriesRenderStyle(...)` after adding a series but before rendering (as in the demo's `TestForIssue181`), and changing the default between repaints in live-update scenarios.

This resolves the style lazily: an explicitly set per-series style always wins; otherwise the getter and the paint path both read the chart's current default at call time. The series' explicit-style field is never mutated by painting, so a default change after the first paint still applies to unoverridden series.

## Testing

`mvn -pl xchart -Dtest=XYChartTest test` — 11 tests pass, including new coverage for: the getter returning the default before paint, setting the default after adding a series (renders as the configured default), and changing the default between repaints (unoverridden series follow the new default).

Fixes #849
