### PR TITLE
Add doji candle test coverage (issue #734)

### DIFF
--- a/xchart/src/test/java/org/knowm/xchart/standalone/issues/TestForIssue734.java
+++ b/xchart/src/test/java/org/knowm/xchart/standalone/issues/TestForIssue734.java
@@ -1,0 +1,49 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Arrays;
+import java.util.List;
+import org.knowm.xchart.OHLCChart;
+import org.knowm.xchart.OHLCChartBuilder;
+import org.knowm.xchart.OHLCSeries;
+import org.knowm.xchart.SwingWrapper;
+
+/**
+ * Demonstrates the two doji shapes reported in issue #734 (a duplicate of issue #781):
+ *
+ * <ul>
+ *   <li>open == high == low == close renders as a flat horizontal dash ("___") rather than a dot.
+ *   <li>open == close with distinct high/low renders as a cross ("+") rather than a lone vertical
+ *       line ("|").
+ * </ul>
+ *
+ * @see <a href="https://github.com/knowm/XChart/issues/734">Issue #734</a>
+ * @see <a href="https://github.com/knowm/XChart/issues/781">Issue #781</a>
+ */
+public class TestForIssue734 {
+
+  public static void main(String[] args) {
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  public static OHLCChart getChart() {
+
+    OHLCChart chart =
+        new OHLCChartBuilder().width(800).height(600).title("Issue 734 - Doji Candles").build();
+
+    // Four candles:
+    //  1. normal up
+    //  2. flat: open == high == low == close  -> should render as "___"
+    //  3. cross: open == close, high/low differ -> should render as "+"
+    //  4. normal down
+    List<Double> xData = Arrays.asList(1.0, 2.0, 3.0, 4.0);
+    List<Double> openData = Arrays.asList(100.0, 110.0, 110.0, 115.0);
+    List<Double> highData = Arrays.asList(108.0, 110.0, 118.0, 120.0);
+    List<Double> lowData = Arrays.asList(95.0, 110.0, 102.0, 105.0);
+    List<Double> closeData = Arrays.asList(106.0, 110.0, 110.0, 107.0);
+
+    OHLCSeries series = chart.addSeries("Candles", xData, openData, highData, lowData, closeData);
+    series.setOhlcSeriesRenderStyle(OHLCSeries.OHLCSeriesRenderStyle.Candle);
+
+    return chart;
+  }
+}


### PR DESCRIPTION
## Summary

Issue #734 reports two OHLC candlestick rendering bugs, both occurring when **open == close** (a doji):

1. `open == high == low == close` should render as a flat dash `___` but drew a dot `.`
2. `open == close` with distinct high/low should render as a cross `+` but drew only a vertical line `|`

This is effectively a **duplicate of #781**, whose fix (render the doji body as a full-width horizontal line) already landed on `develop` in `b258e1da` (PR #938). Both cases reported in #734 are covered by that logic.

The existing `TestForIssue781` only exercises case 2 (the cross). This PR adds `TestForIssue734`, which additionally covers case 1 — the fully flat candle (`open == high == low == close`) — the specific shape called out in #734.

## Changes

- Add `xchart/src/test/java/org/knowm/xchart/standalone/issues/TestForIssue734.java` — a visual demo (matching the repo's existing issue-test convention) with four candles: normal-up, flat doji, cross doji, normal-down.

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)