### PR TITLE
Unified ChartEncoder + optional export deps (#772)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ log/
 *.eps
 *.png
 *.gif
+*.tif
+*.tiff
+*.webp
+*.avif

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ XYChart chart = QuickChart.getChart("Sample Chart", "X", "Y", "y(x)", xData, yDa
 // Show it
 new SwingWrapper(chart).displayChart();
 
-// Save it
-BitmapEncoder.saveBitmap(chart, "./Sample_Chart",BitmapFormat.PNG);
+// Save it (any format: png, jpg, bmp, gif, tiff, svg, eps, pdf, …)
+ChartEncoder.saveChart(chart, "./Sample_Chart", "png");
 
 // or save it in high-res
 BitmapEncoder.saveBitmapWithDPI(chart, "./Sample_Chart_300_DPI",BitmapFormat.PNG, 300);
@@ -143,11 +143,45 @@ repaint.
 * [x] Definable legend placement
 * [x] CSV import and export
 * [x] High resolution chart export
-* [x] Export as PNG, JPG, BMP, GIF with custom DPI setting
+* [x] Unified `ChartEncoder.saveChart(chart, fileName, format)` export for every format
+* [x] Export as PNG, JPG, BMP, GIF, TIFF (with custom DPI setting for bitmaps)
+* [x] Export any other raster format (e.g. WebP, AVIF) by adding a matching ImageIO plugin to the classpath
 * [x] Export SVG, EPS using optional `de.erichseifert.vectorgraphics2d` library
 * [x] Export PDF using optional `pdfbox-graphics2d` library
 * [x] Real-time charts
 * [x] Java 8 and up
+
+## Exporting Charts
+
+Use the unified `ChartEncoder` to export a chart to any format. The format string selects the encoder:
+
+```java
+ChartEncoder.saveChart(chart, "./MyChart", "png");   // raster via ImageIO
+ChartEncoder.saveChart(chart, "./MyChart", "tiff");  // raster via ImageIO (built into the JDK)
+ChartEncoder.saveChart(chart, "./MyChart", "svg");   // vector
+ChartEncoder.saveChart(chart, "./MyChart", "pdf");   // vector
+
+// stream / byte[] variants
+ChartEncoder.saveChart(chart, outputStream, "png");
+byte[] bytes = ChartEncoder.getBytes(chart, "png");
+```
+
+* **Raster formats** (`png`, `jpg`, `bmp`, `gif`, `tiff`) are delegated to `javax.imageio.ImageIO`. Any other format for which an `ImageWriter` plugin is registered on the classpath works too — e.g. add `com.github.usefulness:webp-imageio` to export `webp` (see the `ExampleWebP` demo), or an AVIF plugin to export `avif`. Call `ChartEncoder.getSupportedRasterFormats()` to see what the current classpath can write. For AVIF, where no bundleable ImageIO writer exists yet, the `ExampleAvif` demo shows a portable fallback that pipes a PNG through the `avifenc` CLI (`brew install libavif`).
+* **Vector formats** (`svg`, `eps`, `pdf`) require the optional dependencies below.
+
+### Optional export dependencies
+
+The vector/animated encoders are declared `<optional>true</optional>`, so they are **not** pulled in transitively. Add the one(s) you need to your own build:
+
+| Format(s)        | Dependency                                    |
+|------------------|-----------------------------------------------|
+| SVG, EPS         | `de.erichseifert.vectorgraphics2d:VectorGraphics2D` |
+| PDF              | `de.rototor.pdfbox:graphics2d`                |
+| Animated GIF     | `com.madgag:animated-gif-lib`                 |
+
+If the dependency is missing, XChart throws an `IllegalStateException` naming the exact artifact to add.
+
+> The per-format `BitmapEncoder.saveBitmap(...)`, `VectorGraphicsEncoder.saveVectorGraphic(...)` and `PdfboxGraphicsEncoder.savePdfboxGraphics(...)` methods are now **deprecated** in favor of `ChartEncoder`. `BitmapEncoder.saveBitmapWithDPI(...)` (custom DPI) and `saveJPGWithQuality(...)` (JPEG quality) remain, as they have no `ChartEncoder` equivalent.
 
 ## Chart Types
 

--- a/xchart-demo/pom.xml
+++ b/xchart-demo/pom.xml
@@ -27,6 +27,28 @@
             <groupId>org.scilab.forge</groupId>
             <artifactId>jlatexmath</artifactId>
         </dependency>
+        <!-- XChart's export dependencies are optional; the demo exercises them, so it must
+             declare them explicitly (SVG/EPS, PDF and animated-GIF export). -->
+        <dependency>
+            <groupId>de.erichseifert.vectorgraphics2d</groupId>
+            <artifactId>VectorGraphics2D</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.rototor.pdfbox</groupId>
+            <artifactId>graphics2d</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.madgag</groupId>
+            <artifactId>animated-gif-lib</artifactId>
+        </dependency>
+        <!-- Demo-only: an ImageIO WebP writer plugin (bundles native binaries) so the ExampleWebP
+             sample can be generated. This is NOT a dependency of the xchart library itself; WebP
+             export works with any ImageIO WebP plugin the user chooses to add. -->
+        <dependency>
+            <groupId>com.github.usefulness</groupId>
+            <artifactId>webp-imageio</artifactId>
+            <version>0.11.0</version>
+        </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-swing</artifactId>

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/Example1.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/Example1.java
@@ -2,13 +2,17 @@ package org.knowm.xchart.standalone;
 
 import org.knowm.xchart.BitmapEncoder;
 import org.knowm.xchart.BitmapEncoder.BitmapFormat;
-import org.knowm.xchart.VectorGraphicsEncoder;
-import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
+import org.knowm.xchart.ChartEncoder;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYSeries;
 import org.knowm.xchart.style.markers.SeriesMarkers;
 
-/** Creates a simple Chart and saves it as a PNG and JPEG image file. */
+/**
+ * Creates a simple Chart and saves it in every supported export format via the unified {@link
+ * ChartEncoder}. The raster format tiff ships with the JDK; svg/eps/pdf use the optional vector
+ * dependencies. Additional raster formats (e.g. webp, avif) work automatically if a matching ImageIO
+ * plugin is on the classpath.
+ */
 public class Example1 {
 
   public static void main(String[] args) throws Exception {
@@ -19,22 +23,27 @@ public class Example1 {
     XYChart chart = new XYChart(500, 400);
     chart.setTitle("Sample Chart");
     chart.setXAxisTitle("X");
-    chart.setXAxisTitle("Y");
+    chart.setYAxisTitle("Y");
     XYSeries series = chart.addSeries("y(x)", null, yData);
     series.setMarker(SeriesMarkers.CIRCLE);
 
-    BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.PNG);
-    BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.JPG);
-    BitmapEncoder.saveJPGWithQuality(chart, "./Sample_Chart_With_Quality.jpg", 0.95f);
-    BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.BMP);
-    BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.GIF);
+    // Unified export: one method, any format name ImageIO (or a vector encoder) can write.
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "png");
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "jpg");
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "bmp");
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "gif");
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "tiff");
 
+    // Vector formats (optional VectorGraphics2D / pdfbox-graphics2d dependencies).
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "eps");
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "pdf");
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "svg");
+
+    // Features without a ChartEncoder equivalent still live on BitmapEncoder:
+    // JPEG quality control and custom-DPI raster export.
+    BitmapEncoder.saveJPGWithQuality(chart, "./Sample_Chart_With_Quality.jpg", 0.95f);
     BitmapEncoder.saveBitmapWithDPI(chart, "./Sample_Chart_300_DPI", BitmapFormat.PNG, 300);
     BitmapEncoder.saveBitmapWithDPI(chart, "./Sample_Chart_300_DPI", BitmapFormat.JPG, 300);
     BitmapEncoder.saveBitmapWithDPI(chart, "./Sample_Chart_300_DPI", BitmapFormat.GIF, 300);
-
-    VectorGraphicsEncoder.saveVectorGraphic(chart, "./Sample_Chart", VectorGraphicsFormat.EPS);
-    VectorGraphicsEncoder.saveVectorGraphic(chart, "./Sample_Chart", VectorGraphicsFormat.PDF);
-    VectorGraphicsEncoder.saveVectorGraphic(chart, "./Sample_Chart", VectorGraphicsFormat.SVG);
   }
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/ExampleAvif.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/ExampleAvif.java
@@ -1,0 +1,56 @@
+package org.knowm.xchart.standalone;
+
+import java.io.File;
+import java.io.IOException;
+import org.knowm.xchart.ChartEncoder;
+import org.knowm.xchart.XYChart;
+
+/**
+ * Generates an AVIF sample chart ({@code ./Sample_Chart.avif}) in the project root.
+ *
+ * <p>Unlike WebP, there is currently no reliable Maven-Central ImageIO AVIF <em>writer</em> plugin,
+ * so this example cannot go through {@link ChartEncoder} directly out of the box. There are two ways
+ * to produce an AVIF:
+ *
+ * <ol>
+ *   <li><b>ImageIO plugin (preferred, XChart-native):</b> if you add an ImageIO AVIF writer to the
+ *       classpath, then {@code ChartEncoder.saveChart(chart, "./Sample_Chart", "avif")} just works,
+ *       exactly like {@link ExampleWebP}. No such plugin is bundled here.
+ *   <li><b>libavif CLI (used below):</b> export a PNG with XChart, then convert it with the {@code
+ *       avifenc} tool from <a href="https://github.com/AOMediaCodec/libavif">libavif</a>. On macOS:
+ *       {@code brew install libavif}. This is the most portable way to produce a sample today.
+ * </ol>
+ */
+public class ExampleAvif {
+
+  public static void main(String[] args) throws Exception {
+
+    XYChart chart = ExampleWebP.buildSampleChart();
+
+    // 1) Render to a temporary PNG using XChart's built-in raster export.
+    File png = File.createTempFile("xchart-", ".png");
+    ChartEncoder.saveChart(chart, png.getAbsolutePath(), "png");
+
+    // 2) Convert PNG -> AVIF with libavif's avifenc CLI.
+    File avif = new File("./Sample_Chart.avif");
+    try {
+      Process process =
+          new ProcessBuilder("avifenc", png.getAbsolutePath(), avif.getAbsolutePath())
+              .inheritIO()
+              .start();
+      int exit = process.waitFor();
+      if (exit != 0) {
+        throw new IllegalStateException("avifenc exited with code " + exit + ".");
+      }
+      System.out.println("Wrote " + avif.getPath());
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Could not run 'avifenc'. Install libavif and ensure avifenc is on your PATH"
+              + " (macOS: 'brew install libavif'). Alternatively, add an ImageIO AVIF writer"
+              + " plugin and call ChartEncoder.saveChart(chart, fileName, \"avif\") directly.",
+          e);
+    } finally {
+      png.delete();
+    }
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/ExampleWebP.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/ExampleWebP.java
@@ -9,8 +9,8 @@ import org.knowm.xchart.style.markers.SeriesMarkers;
  * Generates a WebP sample chart ({@code ./Sample_Chart.webp}) in the project root.
  *
  * <p>WebP is not built into the JDK. This example works because the demo module declares an ImageIO
- * WebP writer plugin ({@code com.github.gotson:webp-imageio}, which bundles native binaries for
- * Windows/Linux/macOS). With any such plugin on the classpath, {@link ChartEncoder} needs no
+ * WebP writer plugin ({@code com.github.usefulness:webp-imageio}, which bundles native binaries for
+ * Windows/Linux/macOS including Apple Silicon). With any such plugin on the classpath, {@link ChartEncoder} needs no
  * special-casing: it simply hands the {@code "webp"} format name to {@code javax.imageio.ImageIO}.
  *
  * <p>To enable WebP export in your own project, add a WebP ImageIO plugin to your build; no XChart

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/ExampleWebP.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/ExampleWebP.java
@@ -1,0 +1,38 @@
+package org.knowm.xchart.standalone;
+
+import org.knowm.xchart.ChartEncoder;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.style.markers.SeriesMarkers;
+
+/**
+ * Generates a WebP sample chart ({@code ./Sample_Chart.webp}) in the project root.
+ *
+ * <p>WebP is not built into the JDK. This example works because the demo module declares an ImageIO
+ * WebP writer plugin ({@code com.github.gotson:webp-imageio}, which bundles native binaries for
+ * Windows/Linux/macOS). With any such plugin on the classpath, {@link ChartEncoder} needs no
+ * special-casing: it simply hands the {@code "webp"} format name to {@code javax.imageio.ImageIO}.
+ *
+ * <p>To enable WebP export in your own project, add a WebP ImageIO plugin to your build; no XChart
+ * change is required.
+ */
+public class ExampleWebP {
+
+  public static void main(String[] args) throws Exception {
+
+    XYChart chart = buildSampleChart();
+    ChartEncoder.saveChart(chart, "./Sample_Chart", "webp");
+    System.out.println("Wrote ./Sample_Chart.webp");
+  }
+
+  static XYChart buildSampleChart() {
+
+    XYChart chart = new XYChart(500, 400);
+    chart.setTitle("Sample Chart");
+    chart.setXAxisTitle("X");
+    chart.setYAxisTitle("Y");
+    XYSeries series = chart.addSeries("y(x)", null, new double[] {2.0, 1.0, 0.0});
+    series.setMarker(SeriesMarkers.CIRCLE);
+    return chart;
+  }
+}

--- a/xchart/pom.xml
+++ b/xchart/pom.xml
@@ -15,17 +15,27 @@
     <description>The core XChart library</description>
 
     <dependencies>
+        <!--
+            The three encoders below are optional: they are only needed if you export to their
+            formats (SVG/EPS, PDF, animated GIF). Marking them <optional>true</optional> here (not
+            just in the parent's <dependencyManagement>, where the flag is NOT inherited) keeps them
+            off the transitive classpath of projects that only need the built-in PNG/JPG/BMP/GIF/TIFF
+            raster export. Add the matching dependency to your own build to enable a format.
+        -->
         <dependency>
             <groupId>de.erichseifert.vectorgraphics2d</groupId>
             <artifactId>VectorGraphics2D</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>de.rototor.pdfbox</groupId>
             <artifactId>graphics2d</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.madgag</groupId>
             <artifactId>animated-gif-lib</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.scilab.forge</groupId>

--- a/xchart/src/main/java/org/knowm/xchart/BitmapEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/BitmapEncoder.java
@@ -61,7 +61,9 @@ public final class BitmapEncoder {
    * @param fileName
    * @param bitmapFormat
    * @throws IOException
+   * @deprecated use {@link ChartEncoder#saveChart(IChart, String, String)} instead
    */
+  @Deprecated
   public static void saveBitmap(
       IChart chart, String fileName, BitmapFormat bitmapFormat) throws IOException {
 
@@ -78,7 +80,9 @@ public final class BitmapEncoder {
    * @param targetStream
    * @param bitmapFormat
    * @throws IOException
+   * @deprecated use {@link ChartEncoder#saveChart(IChart, OutputStream, String)} instead
    */
+  @Deprecated
   public static void saveBitmap(
       IChart chart, OutputStream targetStream, BitmapFormat bitmapFormat) throws IOException {
 
@@ -257,7 +261,9 @@ public final class BitmapEncoder {
    * @param chart
    * @return a byte[] for a given chart
    * @throws IOException
+   * @deprecated use {@link ChartEncoder#getBytes(IChart, String)} instead
    */
+  @Deprecated
   public static byte[] getBitmapBytes(IChart chart, BitmapFormat bitmapFormat)
       throws IOException {
 

--- a/xchart/src/main/java/org/knowm/xchart/ChartEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/ChartEncoder.java
@@ -1,0 +1,153 @@
+package org.knowm.xchart;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.TreeSet;
+import javax.imageio.ImageIO;
+import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
+import org.knowm.xchart.internal.Utils;
+import org.knowm.xchart.internal.chartpart.IChart;
+
+/**
+ * Unified, format-agnostic entry point for exporting a {@link org.knowm.xchart.internal.chartpart.IChart}.
+ *
+ * <p>A single {@code format} string selects the encoder:
+ *
+ * <ul>
+ *   <li>{@code "svg"} / {@code "eps"} &rarr; {@link VectorGraphicsEncoder} (optional {@code
+ *       de.erichseifert.vectorgraphics2d:VectorGraphics2D})
+ *   <li>{@code "pdf"} &rarr; {@link PdfboxGraphicsEncoder} (optional {@code
+ *       de.rototor.pdfbox:graphics2d})
+ *   <li>any other name &rarr; the raster path, delegating to {@link javax.imageio.ImageIO}. This
+ *       covers the JDK's built-in writers ({@code png}, {@code jpg}/{@code jpeg}, {@code bmp}, {@code
+ *       gif}, {@code tiff}/{@code tif}, {@code wbmp}) plus <em>any</em> additional format for which
+ *       an ImageIO plugin is registered on the classpath (e.g. {@code webp}, {@code avif} via a
+ *       TwelveMonkeys / native plugin).
+ * </ul>
+ *
+ * <p>Because raster export is delegated to ImageIO's pluggable Service Provider Interface, new
+ * formats can be supported without any change to XChart: drop a suitable {@code ImageWriter} plugin
+ * on the classpath and pass its format name here.
+ *
+ * <p>This class supersedes the per-format {@link BitmapEncoder}, {@link VectorGraphicsEncoder} and
+ * {@link PdfboxGraphicsEncoder} save methods, whose {@code save*} entry points are now deprecated.
+ */
+public final class ChartEncoder {
+
+  /** Constructor - Private constructor to prevent instantiation */
+  private ChartEncoder() {}
+
+  /**
+   * Save a chart to a file. The format string is also used as the file extension (appended if the
+   * file name does not already end with it).
+   *
+   * @param chart the chart to export
+   * @param fileName target file name, with or without extension
+   * @param format the format name, e.g. {@code "png"}, {@code "svg"}, {@code "pdf"}, {@code "tiff"},
+   *     {@code "webp"}
+   * @throws IOException if writing fails or no encoder is available for the format
+   */
+  public static void saveChart(IChart chart, String fileName, String format) throws IOException {
+
+    String fileNameWithExtension =
+        Utils.addFileExtension(fileName, "." + format.toLowerCase(Locale.ROOT));
+    try (OutputStream out = new FileOutputStream(fileNameWithExtension)) {
+      saveChart(chart, out, format);
+    }
+  }
+
+  /**
+   * Write a chart to a stream. Does not close the target stream.
+   *
+   * @param chart the chart to export
+   * @param out the target stream
+   * @param format the format name, e.g. {@code "png"}, {@code "svg"}, {@code "pdf"}, {@code "tiff"},
+   *     {@code "webp"}
+   * @throws IOException if writing fails or no encoder is available for the format
+   */
+  @SuppressWarnings("deprecation")
+  public static void saveChart(IChart chart, OutputStream out, String format) throws IOException {
+
+    switch (format.toLowerCase(Locale.ROOT)) {
+      case "svg":
+        VectorGraphicsEncoder.saveVectorGraphic(chart, out, VectorGraphicsFormat.SVG);
+        return;
+      case "eps":
+        VectorGraphicsEncoder.saveVectorGraphic(chart, out, VectorGraphicsFormat.EPS);
+        return;
+      case "pdf":
+        PdfboxGraphicsEncoder.savePdfboxGraphics(chart, out);
+        return;
+      default:
+        saveRaster(chart, out, format);
+    }
+  }
+
+  /**
+   * Generate the encoded bytes for a chart in the given format.
+   *
+   * @param chart the chart to export
+   * @param format the format name
+   * @return the encoded image bytes
+   * @throws IOException if writing fails or no encoder is available for the format
+   */
+  public static byte[] getBytes(IChart chart, String format) throws IOException {
+
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      saveChart(chart, baos, format);
+      return baos.toByteArray();
+    }
+  }
+
+  /** Raster export via ImageIO's pluggable writers. */
+  private static void saveRaster(IChart chart, OutputStream out, String format) throws IOException {
+
+    String normalized = format.toLowerCase(Locale.ROOT);
+    if (!ImageIO.getImageWritersByFormatName(normalized).hasNext()) {
+      TreeSet<String> available = new TreeSet<>();
+      for (String name : ImageIO.getWriterFormatNames()) {
+        available.add(name.toLowerCase(Locale.ROOT));
+      }
+      throw new IOException(
+          "No image writer is registered for format '"
+              + format
+              + "'. Available raster formats: "
+              + available
+              + ". To export formats such as webp or avif, add a matching ImageIO plugin to your"
+              + " classpath.");
+    }
+
+    if (!ImageIO.write(BitmapEncoder.getBufferedImage(chart), normalized, out)) {
+      // A writer exists but declined the image, almost always a color-model mismatch: e.g. the
+      // JDK's WBMP writer only accepts a 1-bit black-and-white image, not an RGB chart.
+      throw new IOException(
+          "The registered '"
+              + format
+              + "' writer could not encode the chart. Its writer likely does not support the"
+              + " chart's color model (for example, WBMP only supports 1-bit black-and-white"
+              + " images).");
+    }
+  }
+
+  /**
+   * Returns the sorted set of raster format names that can be written on the current classpath. This
+   * reflects the JDK's built-in writers plus any registered ImageIO plugins, but not the vector
+   * formats ({@code svg}, {@code eps}, {@code pdf}).
+   *
+   * @return the available raster format names, lower-cased
+   */
+  public static TreeSet<String> getSupportedRasterFormats() {
+
+    TreeSet<String> formats = new TreeSet<>();
+    formats.addAll(Arrays.asList(ImageIO.getWriterFormatNames()));
+    TreeSet<String> lowerCased = new TreeSet<>();
+    for (String name : formats) {
+      lowerCased.add(name.toLowerCase(Locale.ROOT));
+    }
+    return lowerCased;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/GifEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/GifEncoder.java
@@ -29,6 +29,10 @@ public class GifEncoder {
    * @param delay delay time in milliseconds
    */
   public static void saveGif(String filePath, List<BufferedImage> images, int repeat, int delay) {
+    Utils.requireOnClasspath(
+        "com.madgag.gif.fmsware.AnimatedGifEncoder",
+        "Animated GIF export",
+        "com.madgag:animated-gif-lib");
     AnimatedGifEncoder gif = new AnimatedGifEncoder();
     gif.setRepeat(repeat);
     gif.start(Utils.addFileExtension(filePath, GIF_FILE_EXTENSION));

--- a/xchart/src/main/java/org/knowm/xchart/PdfboxGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/PdfboxGraphicsEncoder.java
@@ -13,6 +13,7 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.IChart;
 
 /** A helper class with static methods for saving Charts as a PDF file */
@@ -30,6 +31,11 @@ public class PdfboxGraphicsEncoder {
    * @param fileName file name path
    * @throws IOException
    */
+  /**
+   * @deprecated use {@link ChartEncoder#saveChart(IChart, String, String)} with format {@code
+   *     "pdf"} instead
+   */
+  @Deprecated
   public static void savePdfboxGraphics(IChart chart, String fileName) throws IOException {
 
     savePdfboxGraphics(chart, new File(addFileExtension(fileName)));
@@ -42,6 +48,11 @@ public class PdfboxGraphicsEncoder {
    * @param file File
    * @throws IOException
    */
+  /**
+   * @deprecated use {@link ChartEncoder#saveChart(IChart, OutputStream, String)} with format {@code
+   *     "pdf"} instead
+   */
+  @Deprecated
   public static void savePdfboxGraphics(IChart chart, File file) throws IOException {
 
     savePdfboxGraphics(chart, new BufferedOutputStream(new FileOutputStream(file)));
@@ -54,6 +65,11 @@ public class PdfboxGraphicsEncoder {
    * @param os OutputStream
    * @throws IOException
    */
+  /**
+   * @deprecated use {@link ChartEncoder#saveChart(IChart, OutputStream, String)} with format {@code
+   *     "pdf"} instead
+   */
+  @Deprecated
   public static void savePdfboxGraphics(IChart chart, OutputStream os) throws IOException {
 
     List<IChart> charts = new ArrayList<>();
@@ -68,6 +84,10 @@ public class PdfboxGraphicsEncoder {
    * @param fileName file name path
    * @throws IOException
    */
+  /**
+   * @deprecated use {@link ChartEncoder} per chart, or merge charts before export
+   */
+  @Deprecated
   public static void savePdfboxGraphics(List<? extends IChart> charts, String fileName)
       throws IOException {
 
@@ -81,6 +101,10 @@ public class PdfboxGraphicsEncoder {
    * @param file File
    * @throws IOException
    */
+  /**
+   * @deprecated use {@link ChartEncoder} per chart, or merge charts before export
+   */
+  @Deprecated
   public static void savePdfboxGraphics(List<? extends IChart> charts, File file)
       throws IOException {
 
@@ -94,9 +118,17 @@ public class PdfboxGraphicsEncoder {
    * @param os OutputStream
    * @throws IOException
    */
+  /**
+   * @deprecated use {@link ChartEncoder} per chart, or merge charts before export
+   */
+  @Deprecated
   public static void savePdfboxGraphics(List<? extends IChart> charts, OutputStream os)
       throws IOException {
 
+    Utils.requireOnClasspath(
+        "de.rototor.pdfbox.graphics2d.PdfBoxGraphics2D",
+        "PDF export",
+        "de.rototor.pdfbox:graphics2d");
     PDDocument document = new PDDocument();
     PDRectangle mediaBox = null;
     PDPage page = null;

--- a/xchart/src/main/java/org/knowm/xchart/PdfboxGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/PdfboxGraphicsEncoder.java
@@ -30,8 +30,6 @@ public class PdfboxGraphicsEncoder {
    * @param chart Chart
    * @param fileName file name path
    * @throws IOException
-   */
-  /**
    * @deprecated use {@link ChartEncoder#saveChart(IChart, String, String)} with format {@code
    *     "pdf"} instead
    */
@@ -47,8 +45,6 @@ public class PdfboxGraphicsEncoder {
    * @param chart Chart
    * @param file File
    * @throws IOException
-   */
-  /**
    * @deprecated use {@link ChartEncoder#saveChart(IChart, OutputStream, String)} with format {@code
    *     "pdf"} instead
    */
@@ -64,8 +60,6 @@ public class PdfboxGraphicsEncoder {
    * @param chart Chart
    * @param os OutputStream
    * @throws IOException
-   */
-  /**
    * @deprecated use {@link ChartEncoder#saveChart(IChart, OutputStream, String)} with format {@code
    *     "pdf"} instead
    */
@@ -83,8 +77,6 @@ public class PdfboxGraphicsEncoder {
    * @param charts List&lt;? extends IChart&gt;
    * @param fileName file name path
    * @throws IOException
-   */
-  /**
    * @deprecated use {@link ChartEncoder} per chart, or merge charts before export
    */
   @Deprecated
@@ -100,8 +92,6 @@ public class PdfboxGraphicsEncoder {
    * @param charts List&lt;? extends IChart&gt;
    * @param file File
    * @throws IOException
-   */
-  /**
    * @deprecated use {@link ChartEncoder} per chart, or merge charts before export
    */
   @Deprecated
@@ -117,8 +107,6 @@ public class PdfboxGraphicsEncoder {
    * @param charts List&lt;? extends IChart&gt;
    * @param os OutputStream
    * @throws IOException
-   */
-  /**
    * @deprecated use {@link ChartEncoder} per chart, or merge charts before export
    */
   @Deprecated

--- a/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
@@ -10,6 +10,7 @@ import de.erichseifert.vectorgraphics2d.util.PageSize;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.IChart;
 
 /** A helper class with static methods for saving Charts as vectors */
@@ -18,7 +19,13 @@ public final class VectorGraphicsEncoder {
   /** Constructor - Private constructor to prevent instantiation */
   private VectorGraphicsEncoder() {}
 
-  /** Write a chart to a file. */
+  /**
+   * Write a chart to a file.
+   *
+   * @deprecated use {@link ChartEncoder#saveChart(IChart, String, String)} with format {@code
+   *     "svg"}, {@code "eps"} or {@code "pdf"} instead
+   */
+  @Deprecated
   public static void saveVectorGraphic(
       IChart chart, String fileName, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
     FileOutputStream file = new FileOutputStream(addFileExtension(fileName, vectorGraphicsFormat));
@@ -30,10 +37,25 @@ public final class VectorGraphicsEncoder {
     }
   }
 
-  /** Write a chart to an OutputStream. */
+  /**
+   * Write a chart to an OutputStream.
+   *
+   * @deprecated use {@link ChartEncoder#saveChart(IChart, OutputStream, String)} with format {@code
+   *     "svg"}, {@code "eps"} or {@code "pdf"} instead
+   */
+  @Deprecated
   public static void saveVectorGraphic(
       IChart chart, OutputStream os, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
     final Processor p;
+
+    if (VectorGraphicsFormat.PDF != vectorGraphicsFormat) {
+      // SVG and EPS are produced by VectorGraphics2D; PDF delegates to the (separately guarded)
+      // PdfboxGraphicsEncoder below.
+      Utils.requireOnClasspath(
+          "de.erichseifert.vectorgraphics2d.VectorGraphics2D",
+          vectorGraphicsFormat + " export",
+          "de.erichseifert.vectorgraphics2d:VectorGraphics2D");
+    }
 
     switch (vectorGraphicsFormat) {
       case EPS:
@@ -102,6 +124,7 @@ public final class VectorGraphicsEncoder {
       return null;
     }
 
+    @SuppressWarnings("deprecation")
     public void savePdf(IChart chart, OutputStream os) throws IOException {
 
       PdfboxGraphicsEncoder.savePdfboxGraphics(chart, os);

--- a/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
@@ -46,46 +46,40 @@ public final class VectorGraphicsEncoder {
   @Deprecated
   public static void saveVectorGraphic(
       IChart chart, OutputStream os, VectorGraphicsFormat vectorGraphicsFormat) throws IOException {
-    final Processor p;
 
-    if (VectorGraphicsFormat.PDF != vectorGraphicsFormat) {
-      // SVG and EPS are produced by VectorGraphics2D; PDF delegates to the (separately guarded)
-      // PdfboxGraphicsEncoder below.
-      Utils.requireOnClasspath(
-          "de.erichseifert.vectorgraphics2d.VectorGraphics2D",
-          vectorGraphicsFormat + " export",
-          "de.erichseifert.vectorgraphics2d:VectorGraphics2D");
+    // PDF is produced by pdfbox-graphics2d, not VectorGraphics2D. Delegate before referencing any
+    // VectorGraphics2D type so PDF export works even when the (now optional) VectorGraphics2D
+    // dependency is absent.
+    if (VectorGraphicsFormat.PDF == vectorGraphicsFormat) {
+      PdfboxGraphicsEncoder.savePdfboxGraphics(chart, os);
+      return;
     }
 
+    // SVG and EPS are produced by VectorGraphics2D.
+    Utils.requireOnClasspath(
+        "de.erichseifert.vectorgraphics2d.VectorGraphics2D",
+        vectorGraphicsFormat + " export",
+        "de.erichseifert.vectorgraphics2d:VectorGraphics2D");
+
+    final Processor p;
     switch (vectorGraphicsFormat) {
       case EPS:
         p = new EPSProcessor();
         break;
-      case PDF:
-        p = new PDFBoxProcessor();
-        break;
       case SVG:
         p = new SVGProcessor();
         break;
-
       default:
         throw new UnsupportedOperationException(
             "Unsupported vector graphics format: " + vectorGraphicsFormat);
     }
 
-    if (VectorGraphicsFormat.PDF != vectorGraphicsFormat) {
-      VectorGraphics2D vg2d = new VectorGraphics2D();
-      //    vg2d.draw(new Rectangle2D.Double(0.0, 0.0, chart.getWidth(), chart.getHeight()));
-      CommandSequence commands = vg2d.getCommands();
-
-      chart.paint(vg2d, chart.getWidth(), chart.getHeight());
-
-      PageSize pageSize = new PageSize(0.0, 0.0, chart.getWidth(), chart.getHeight());
-      Document doc = p.getDocument(commands, pageSize);
-      doc.writeTo(os);
-    } else {
-      ((PDFBoxProcessor) p).savePdf(chart, os);
-    }
+    VectorGraphics2D vg2d = new VectorGraphics2D();
+    CommandSequence commands = vg2d.getCommands();
+    chart.paint(vg2d, chart.getWidth(), chart.getHeight());
+    PageSize pageSize = new PageSize(0.0, 0.0, chart.getWidth(), chart.getHeight());
+    Document doc = p.getDocument(commands, pageSize);
+    doc.writeTo(os);
   }
 
   /**
@@ -114,20 +108,5 @@ public final class VectorGraphicsEncoder {
     EPS,
     PDF,
     SVG
-  }
-
-  private static class PDFBoxProcessor implements Processor {
-
-    @Override
-    public Document getDocument(CommandSequence arg0, PageSize arg1) {
-
-      return null;
-    }
-
-    @SuppressWarnings("deprecation")
-    public void savePdf(IChart chart, OutputStream os) throws IOException {
-
-      PdfboxGraphicsEncoder.savePdfboxGraphics(chart, os);
-    }
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/Utils.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/Utils.java
@@ -242,4 +242,29 @@ public class Utils {
     }
     return fileNameWithFileExtension;
   }
+
+  /**
+   * Verifies that an optional export dependency is present on the classpath, throwing a helpful
+   * message naming the missing Maven artifact if it is not. XChart marks the vector/PDF/animated-GIF
+   * libraries as optional, so they are not pulled in transitively; callers that need them must add
+   * the dependency to their own build.
+   *
+   * @param className a class that is only present when the dependency is on the classpath
+   * @param feature human-readable description of the feature that needs the dependency
+   * @param mavenCoordinate the {@code groupId:artifactId} the user must add
+   * @throws IllegalStateException if the class cannot be found
+   */
+  public static void requireOnClasspath(
+      String className, String feature, String mavenCoordinate) {
+    try {
+      Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(
+          feature
+              + " requires the optional dependency '"
+              + mavenCoordinate
+              + "', which is not on the classpath. Add it to your build to enable this format.",
+          e);
+    }
+  }
 }

--- a/xchart/src/test/java/org/knowm/xchart/ChartEncoderTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/ChartEncoderTest.java
@@ -1,0 +1,102 @@
+package org.knowm.xchart;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.knowm.xchart.style.markers.SeriesMarkers;
+
+/**
+ * Exercises the unified {@link ChartEncoder} across every export format: the built-in raster formats
+ * provided by ImageIO on the current JDK (png, jpg, bmp, gif, tiff, wbmp, plus any registered
+ * plugin), and the optional vector formats (svg, eps, pdf). Also serves as a generator that writes
+ * one sample chart per supported format, mirroring the {@code Sample_Chart.*} files produced by the
+ * demo.
+ */
+public class ChartEncoderTest {
+
+  private static XYChart sampleChart() {
+    XYChart chart = new XYChart(500, 400);
+    chart.setTitle("Sample Chart");
+    chart.setXAxisTitle("X");
+    chart.setYAxisTitle("Y");
+    XYSeries series = chart.addSeries("y(x)", null, new double[] {2.0, 1.0, 0.0});
+    series.setMarker(SeriesMarkers.CIRCLE);
+    return chart;
+  }
+
+  /** Every raster format the current classpath can write must produce a non-empty file. */
+  @Test
+  public void writesEverySupportedRasterFormat(@TempDir Path dir) throws IOException {
+
+    XYChart chart = sampleChart();
+    assertTrue(
+        ChartEncoder.getSupportedRasterFormats().contains("png"),
+        "png must always be available from the JDK");
+
+    for (String format : ChartEncoder.getSupportedRasterFormats()) {
+      // WBMP has a registered writer but only accepts 1-bit black-and-white images, so a color
+      // chart cannot be encoded to it. It is intentionally not a usable chart export format.
+      if (format.equals("wbmp")) {
+        continue;
+      }
+      File file = dir.resolve("Sample_Chart." + format).toFile();
+      ChartEncoder.saveChart(chart, file.getAbsolutePath(), format);
+      assertTrue(file.exists() && file.length() > 0, format + " output should be non-empty");
+    }
+  }
+
+  /** TIFF ships with the JDK (Java 9+), so it must be writable without any plugin. */
+  @Test
+  public void jdkProvidesTiffWriter() {
+    assertTrue(ChartEncoder.getSupportedRasterFormats().contains("tiff"));
+  }
+
+  /** The optional vector formats are on XChart's own test classpath, so they must produce output. */
+  @Test
+  public void writesVectorFormats(@TempDir Path dir) throws IOException {
+
+    XYChart chart = sampleChart();
+    for (String format : new String[] {"svg", "eps", "pdf"}) {
+      File file = dir.resolve("Sample_Chart." + format).toFile();
+      ChartEncoder.saveChart(chart, file.getAbsolutePath(), format);
+      assertTrue(file.exists() && file.length() > 0, format + " output should be non-empty");
+    }
+  }
+
+  @Test
+  public void getBytesReturnsEncodedImage() throws IOException {
+    byte[] bytes = ChartEncoder.getBytes(sampleChart(), "png");
+    assertNotNull(bytes);
+    assertTrue(bytes.length > 0);
+  }
+
+  /** The file-name overload appends the format as extension when missing. */
+  @Test
+  public void appendsExtension(@TempDir Path dir) throws IOException {
+    String base = dir.resolve("no_extension").toString();
+    ChartEncoder.saveChart(sampleChart(), base, "png");
+    assertTrue(new File(base + ".png").exists());
+  }
+
+  /** An unregistered raster format fails with an actionable message rather than silently. */
+  @Test
+  public void unsupportedFormatThrowsHelpfulError(@TempDir Path dir) {
+    // "avif" has no ImageIO writer on the default classpath.
+    assertFalse(ChartEncoder.getSupportedRasterFormats().contains("avif"));
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                ChartEncoder.saveChart(
+                    sampleChart(), dir.resolve("chart.avif").toString(), "avif"));
+    assertTrue(e.getMessage().toLowerCase().contains("avif"));
+    assertTrue(e.getMessage().contains("plugin"));
+  }
+}


### PR DESCRIPTION
## Summary

Adds a single, format-agnostic export facade and makes the heavy export dependencies genuinely optional. Motivated by #772 (AVIF export): rather than hard-code each format, export becomes **pluggable** through `javax.imageio.ImageIO`.

```java
ChartEncoder.saveChart(chart, "./MyChart", "png");   // raster via ImageIO
ChartEncoder.saveChart(chart, "./MyChart", "tiff");  // raster, built into the JDK
ChartEncoder.saveChart(chart, "./MyChart", "webp");  // raster, via any ImageIO WebP plugin
ChartEncoder.saveChart(chart, "./MyChart", "svg");   // vector
ChartEncoder.saveChart(chart, "./MyChart", "pdf");   // vector
byte[] bytes = ChartEncoder.getBytes(chart, "png");
```

## What changed

- **`ChartEncoder`** — new facade. `svg`/`eps`/`pdf` route to the existing vector encoders; every other format name is delegated to ImageIO, so any registered `ImageWriter` plugin (WebP, AVIF, …) works with **no XChart code change**. Includes `getBytes(...)` and `getSupportedRasterFormats()`.
- **Optional deps fixed** — `VectorGraphics2D`, `pdfbox-graphics2d` and `animated-gif-lib` are now marked `<optional>true</optional>` in the **module** pom. They were declared optional only in the parent `<dependencyManagement>`, where Maven does **not** inherit the flag, so they were being pulled transitively into every consumer. The demo module now declares them explicitly.
- **Friendly errors** — `Utils.requireOnClasspath(...)` makes a missing optional encoder throw an `IllegalStateException` naming the exact artifact to add, instead of a raw `NoClassDefFoundError`.
- **Deprecations** — the per-format `saveBitmap` / `saveVectorGraphic` / `savePdfboxGraphics` methods are deprecated in favor of `ChartEncoder`. `saveBitmapWithDPI` and `saveJPGWithQuality` remain (no facade equivalent).
- **Samples** — `Example1` uses `ChartEncoder` and emits a TIFF sample; new `ExampleWebP` (via `com.github.usefulness:webp-imageio`, demo-only) and `ExampleAvif` (via the libavif `avifenc` CLI) generate WebP/AVIF samples. Size story that motivated #772: PNG 15.7 KB → WebP 7.1 KB → AVIF 5.4 KB.
- **Tests / docs** — `ChartEncoderTest` covers every available raster format, the vector formats, byte output, extension handling, and the unsupported-format error. README gains an "Exporting Charts" section.

## Notes / caveats

- ⚠️ **Behavior change for consumers:** because the export libs are no longer transitive, projects that use PDF/SVG/EPS/GIF export must now add the matching dependency themselves. Worth a release-note. Fits the 4.x line.
- **AVIF is not yet an in-library format.** There is no bundleable Maven-Central ImageIO AVIF *writer* (vavi isn't on Central; the nemanjastokuca plugin is reader-only; JDeli is commercial). `ExampleAvif` therefore uses the `avifenc` CLI as a portable fallback. If/when a viable AVIF `ImageWriter` exists, `ChartEncoder.saveChart(chart, "avif")` will work with no code change.
- The demo's WebP plugin is `com.github.usefulness:webp-imageio` (maintained fork with macOS arm64 natives); the older `gotson` fork ships no Apple-Silicon binary.

Full build green: **122 tests pass**, demo + site build.

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)