### PR TITLE
Fix stacked category charts stacking Line/Scatter series and mixing axis groups (#906)

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart13.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart13.java
@@ -49,6 +49,8 @@ public class BarChart13 implements ExampleChart<CategoryChart> {
     chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
     chart.getStyler().setStacked(true); // affects stackable (bar/area/stick) series only
     chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Right); // secondary axis on the right
+    chart.getStyler().setYAxisMax(0, 200.0); // primary (bars) axis
+    chart.getStyler().setYAxisMax(1, 200.0); // secondary (line) axis
 
     // Stacked bar series on the primary (left) Y-Axis group
     chart.addSeries("Series A", Arrays.asList("A", "B", "C", "D"), Arrays.asList(10, 20, 15, 25));

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart13.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/bar/BarChart13.java
@@ -1,0 +1,77 @@
+package org.knowm.xchart.demo.charts.bar;
+
+import java.util.Arrays;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.style.Styler.LegendPosition;
+import org.knowm.xchart.style.Styler.YAxisPosition;
+import org.knowm.xchart.style.markers.SeriesMarkers;
+
+/**
+ * Stacked Bars with a Line on a secondary Y-Axis
+ *
+ * <p>Demonstrates the following:
+ *
+ * <ul>
+ *   <li>Stacked bar series on the primary (left) Y-Axis group
+ *   <li>A Line series assigned to a secondary (right) Y-Axis group
+ *   <li>Line/Scatter series are excluded from stacking, and each axis group is ranged only from its
+ *       own series (see issue #906)
+ * </ul>
+ */
+public class BarChart13 implements ExampleChart<CategoryChart> {
+
+  public static void main(String[] args) {
+
+    ExampleChart<CategoryChart> exampleChart = new BarChart13();
+    CategoryChart chart = exampleChart.getChart();
+    new SwingWrapper<>(chart).displayChart();
+  }
+
+  @Override
+  public CategoryChart getChart() {
+
+    // Create Chart
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(800)
+            .height(600)
+            .title(getClass().getSimpleName())
+            .xAxisTitle("Category")
+            .yAxisTitle("Primary (Bars)")
+            .build();
+
+    // Customize Chart
+    chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
+    chart.getStyler().setStacked(true); // affects stackable (bar/area/stick) series only
+    chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Right); // secondary axis on the right
+
+    // Stacked bar series on the primary (left) Y-Axis group
+    chart.addSeries("Series A", Arrays.asList("A", "B", "C", "D"), Arrays.asList(10, 20, 15, 25));
+    chart.addSeries("Series B", Arrays.asList("A", "B", "C", "D"), Arrays.asList(5, 15, 10, 20));
+    chart.addSeries("Series C", Arrays.asList("A", "B", "C", "D"), Arrays.asList(8, 12, 18, 10));
+
+    // Line series on the secondary (right) Y-Axis group. It is drawn at its own values, not stacked
+    // on top of the bars, and the right axis is ranged only from this series' data.
+    CategorySeries lineSeries =
+        chart.addSeries(
+            "Trend Line", Arrays.asList("A", "B", "C", "D"), Arrays.asList(100, 150, 130, 180));
+    lineSeries.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
+    lineSeries.setYAxisGroup(1);
+    lineSeries.setMarker(SeriesMarkers.CIRCLE);
+
+    chart.setYAxisGroupTitle(1, "Secondary (Line)");
+
+    return chart;
+  }
+
+  @Override
+  public String getExampleChartName() {
+
+    return getClass().getSimpleName() + " - Stacked Bars with a Line on a secondary Y-Axis";
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
@@ -128,15 +128,25 @@ public class CategorySeries extends AxesChartSeriesCategory {
 
     /**
      * Whether this render style participates in stacking when {@link
-     * org.knowm.xchart.style.CategoryStyler#isStacked()} is enabled. Point- and line-based styles
-     * ({@link #Line}, {@link #Scatter}) are drawn at their own values and are never stacked on top
-     * of the bar/area stack.
+     * org.knowm.xchart.style.CategoryStyler#isStacked()} is enabled. Only the bar/area family ({@link
+     * #Bar}, {@link #Area}, {@link #Stick}, {@link #SteppedBar}) stacks; point- and line-based styles
+     * ({@link #Line}, {@link #Scatter}) are drawn at their own values and are never stacked on top of
+     * the bar/area stack. Enumerated as an explicit allow-list so any future render style defaults to
+     * non-stackable until intentionally opted in.
      *
      * @return true if series of this style are stacked
      */
     public boolean isStackable() {
 
-      return this != Line && this != Scatter;
+      switch (this) {
+        case Bar:
+        case Area:
+        case Stick:
+        case SteppedBar:
+          return true;
+        default:
+          return false;
+      }
     }
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategorySeries.java
@@ -125,5 +125,18 @@ public class CategorySeries extends AxesChartSeriesCategory {
 
       return legendRenderType;
     }
+
+    /**
+     * Whether this render style participates in stacking when {@link
+     * org.knowm.xchart.style.CategoryStyler#isStacked()} is enabled. Point- and line-based styles
+     * ({@link #Line}, {@link #Scatter}) are drawn at their own values and are never stacked on top
+     * of the bar/area stack.
+     *
+     * @return true if series of this style are stacked
+     */
+    public boolean isStackable() {
+
+      return this != Line && this != Scatter;
+    }
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -5,6 +5,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.List;
 import java.util.TreeMap;
 
+import org.knowm.xchart.CategorySeries;
 import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
 import org.knowm.xchart.internal.series.AxesChartSeries;
 import org.knowm.xchart.internal.series.AxesChartSeriesCategory;
@@ -303,9 +304,12 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
 
       CategoryStyler categoryStyler = (CategoryStyler) chart.getStyler();
 
-      // If stacked, recalculate min and max from the per-category stack sums. This is independent of
-      // the render style (bar, stick, area, ...) since stacking sums the series values the same way,
-      // and it also covers charts where individual series override the default render style.
+      // If stacked, recalculate min and max from the per-category stack sums. Only series belonging
+      // to this Y-axis group are summed, and only stackable render styles (bar, stick, stepped bar,
+      // area) contribute — Line and Scatter series are drawn at their own values, so they neither
+      // stack nor inflate another axis group's range. Stacking otherwise sums the series values the
+      // same way regardless of style, and covers charts where individual series override the default
+      // render style.
       if (categoryStyler.isStacked() && !chart.getSeriesMap().isEmpty()) {
 
         AxesChartSeriesCategory axesChartSeries =
@@ -316,14 +320,21 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
         double[] accumulatedStackOffsetPos = new double[numCategories];
         double[] accumulatedStackOffsetNeg = new double[numCategories];
 
+        boolean hasStackedSeries = false;
         for (S series : chart.getSeriesMap().values()) {
 
-          AxesChartSeriesCategory axesChartSeriesCategory = (AxesChartSeriesCategory) series;
-
-          if (!series.isEnabled()) {
+          if (!series.isEnabled() || series.getYAxisGroup() != yAxis.getYIndex()) {
             continue;
           }
+          if (!((CategorySeries) series)
+              .getChartCategorySeriesRenderStyle()
+              .orElseThrow()
+              .isStackable()) {
+            continue;
+          }
+          hasStackedSeries = true;
 
+          AxesChartSeriesCategory axesChartSeriesCategory = (AxesChartSeriesCategory) series;
           int categoryCounter = 0;
           double[] yArr = axesChartSeriesCategory.getYData();
           for (double next : yArr) {
@@ -343,22 +354,28 @@ public class AxisPair<ST extends AxesChartStyler, S extends AxesChartSeries> imp
           }
         }
 
-        double max = accumulatedStackOffsetPos[0];
-        for (int i = 1; i < accumulatedStackOffsetPos.length; i++) {
-          if (accumulatedStackOffsetPos[i] > max) {
-            max = accumulatedStackOffsetPos[i];
-          }
-        }
+        // Only override this axis group's range when it actually contains stacked series; a group
+        // with only Line/Scatter series keeps the raw data range computed earlier.
+        if (hasStackedSeries) {
 
-        double min = accumulatedStackOffsetNeg[0];
-        for (int i = 1; i < accumulatedStackOffsetNeg.length; i++) {
-          if (accumulatedStackOffsetNeg[i] < min) {
-            min = accumulatedStackOffsetNeg[i];
+          double max = accumulatedStackOffsetPos[0];
+          for (int i = 1; i < accumulatedStackOffsetPos.length; i++) {
+            if (accumulatedStackOffsetPos[i] > max) {
+              max = accumulatedStackOffsetPos[i];
+            }
           }
-        }
 
-        overrideYAxisMaxValue = max;
-        overrideYAxisMinValue = min;
+          double min = accumulatedStackOffsetNeg[0];
+          for (int i = 1; i < accumulatedStackOffsetNeg.length; i++) {
+            if (accumulatedStackOffsetNeg[i] < min) {
+              min = accumulatedStackOffsetNeg[i];
+            }
+          }
+
+          // Keep any non-stacked (Line/Scatter) series sharing this axis group in view.
+          overrideYAxisMaxValue = Math.max(max, yAxis.getMax());
+          overrideYAxisMinValue = Math.min(min, yAxis.getMin());
+        }
       }
 
       if (categoryStyler.getDefaultSeriesRenderStyle() == CategorySeriesRenderStyle.Bar

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category.java
@@ -111,6 +111,11 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
       double[] yArr = series.getYData();
       double[] errorBars = series.getExtraValues();
 
+      // Line and Scatter series are drawn at their own values; they never participate in stacking.
+      boolean seriesStacked =
+          stylerCategory.isStacked()
+              && series.getChartCategorySeriesRenderStyle().orElseThrow().isStackable();
+
       // Stepped bars are drawn in chunks rather than for each individual bar
       ArrayList<Point2D.Double> steppedPath = new ArrayList<>();
       ArrayList<Point2D.Double> steppedReturnPath = new ArrayList<>();
@@ -164,7 +169,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
             }
             yTop = y;
             yBottom = yMin;
-            if (stylerCategory.isStacked()) {
+            if (seriesStacked) {
               yTop += accumulatedStackOffsetPos[categoryCounter];
               yBottom += accumulatedStackOffsetPos[categoryCounter];
               accumulatedStackOffsetPos[categoryCounter] += (yTop - yBottom);
@@ -178,7 +183,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
             }
             yTop = yMax;
             yBottom = y;
-            if (stylerCategory.isStacked()) {
+            if (seriesStacked) {
               yTop -= accumulatedStackOffsetNeg[categoryCounter];
               yBottom -= accumulatedStackOffsetNeg[categoryCounter];
               accumulatedStackOffsetNeg[categoryCounter] += (yTop - yBottom);
@@ -197,7 +202,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
               } else {
                 yBottom = y;
               }
-              if (stylerCategory.isStacked() && !series.isOverlapped()) {
+              if (seriesStacked && !series.isOverlapped()) {
                 yTop += accumulatedStackOffsetPos[categoryCounter];
                 yBottom += accumulatedStackOffsetPos[categoryCounter];
                 // Grow the stack by the actual value. For bars (yBottom == 0) this equals
@@ -218,7 +223,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
                 // yBottom.
               }
               yBottom = y;
-              if (stylerCategory.isStacked() && !series.isOverlapped()) {
+              if (seriesStacked && !series.isOverlapped()) {
                 yTop -= accumulatedStackOffsetNeg[categoryCounter];
                 yBottom -= accumulatedStackOffsetNeg[categoryCounter];
                 // Grow the negative stack by the magnitude of y (y < 0 here), for the same reason
@@ -402,7 +407,7 @@ public class PlotContent_Category<ST extends CategoryStyler, S extends CategoryS
 
             double xCenter = xOffset + barWidth / 2;
 
-            if (stylerCategory.isStacked() && !series.isOverlapped()) {
+            if (seriesStacked && !series.isOverlapped()) {
               // Stacked: collect this point and the floor it rests on (the previous series'
               // cumulative line for this category). The band is filled after the data loop. Advance
               // the floor so the next series stacks on top of this series.

--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/StackedSecondaryAxisTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/StackedSecondaryAxisTest.java
@@ -1,0 +1,103 @@
+package org.knowm.xchart.internal.chartpart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Regression tests for issue #906: stacked bars on one Y-axis group plus a non-stacked Line series
+ * on a secondary Y-axis group. Each axis group must range from only its own series — the line must
+ * neither participate in the bar stack nor inflate either axis.
+ */
+public class StackedSecondaryAxisTest {
+
+  private static final List<String> X = List.of("A", "B", "C", "D");
+
+  /** Stacked bars on group 0, a Line on group 1. Mirrors the demo BarChart13 / the issue report. */
+  private static CategoryChart buildStackedBarsPlusSecondaryLine() {
+    CategoryChart chart =
+        new CategoryChartBuilder().width(800).height(600).title("issue906").build();
+    chart.getStyler().setStacked(true);
+    chart.getStyler().setYAxisGroupPosition(1, Styler.YAxisPosition.Right);
+
+    // Stacked bars on the primary (left) group. Per-category sums: A=23, B=47, C=43, D=55.
+    chart.addSeries("Series A", X, List.of(10, 20, 15, 25));
+    chart.addSeries("Series B", X, List.of(5, 15, 10, 20));
+    chart.addSeries("Series C", X, List.of(8, 12, 18, 10));
+
+    // Line on the secondary (right) group. Raw values 100..180, must not be stacked.
+    CategorySeries line = chart.addSeries("Trend Line", X, List.of(100, 150, 130, 180));
+    line.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
+    line.setYAxisGroup(1);
+    return chart;
+  }
+
+  @Test
+  public void primaryAxisRangesToStackedBarSumsOnly() throws Exception {
+    CategoryChart chart = buildStackedBarsPlusSecondaryLine();
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+
+    Axis_Y<?, ?> left = chart.axisPair.getYAxis(0);
+    // Bars are positive, so the axis anchors at 0 and tops out at the largest stack sum (D = 55).
+    assertThat(left.getMin()).isEqualTo(0.0);
+    assertThat(left.getMax()).isEqualTo(55.0);
+  }
+
+  @Test
+  public void secondaryAxisRangesToLineDataOnly() throws Exception {
+    CategoryChart chart = buildStackedBarsPlusSecondaryLine();
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+
+    Axis_Y<?, ?> right = chart.axisPair.getYAxis(1);
+    // The line is not stackable, so its group tops out at the raw line max (180) — it is NOT
+    // inflated by the bar stack (the pre-fix bug summed every series into every group, pushing this
+    // to 55 + 180 = 235). The min is 0 because the chart's default render style is Bar, which
+    // zero-anchors all groups.
+    assertThat(right.getMin()).isEqualTo(0.0);
+    assertThat(right.getMax()).isEqualTo(180.0);
+  }
+
+  /** A group containing only a non-stackable Line keeps its raw range even with stacking enabled. */
+  @Test
+  public void lineOnlyGroupIsNotStacked() throws Exception {
+    CategoryChart chart =
+        new CategoryChartBuilder().width(800).height(600).title("issue906-lineonly").build();
+    chart.getStyler().setStacked(true);
+
+    CategorySeries l1 = chart.addSeries("L1", X, List.of(10, 20, 30, 40));
+    l1.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
+    CategorySeries l2 = chart.addSeries("L2", X, List.of(5, 5, 5, 5));
+    l2.setChartCategorySeriesRenderStyle(CategorySeriesRenderStyle.Line);
+
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+
+    Axis_Y<?, ?> axis = chart.axisPair.getYAxis(0);
+    // If the lines were stacked the max would be 40 + 5 = 45; they are not, so it stays at 40.
+    assertThat(axis.getMax()).isEqualTo(40.0);
+  }
+
+  /** Sanity: with only stacked bars, the single-group range still equals the stack sum. */
+  @Test
+  public void singleGroupStackedBarsUnchanged() throws Exception {
+    CategoryChart chart =
+        new CategoryChartBuilder().width(800).height(600).title("issue906-barsonly").build();
+    chart.getStyler().setStacked(true);
+    chart.addSeries("Series A", X, List.of(10, 20, 15, 25));
+    chart.addSeries("Series B", X, List.of(5, 15, 10, 20));
+    chart.addSeries("Series C", X, List.of(8, 12, 18, 10));
+
+    BitmapEncoder.getBitmapBytes(chart, BitmapEncoder.BitmapFormat.PNG);
+
+    Axis_Y<?, ?> axis = chart.axisPair.getYAxis(0);
+    assertThat(axis.getMin()).isEqualTo(0.0);
+    assertThat(axis.getMax()).isEqualTo(55.0);
+  }
+}


### PR DESCRIPTION
Fixes #906.

## Problem
With `CategoryChart` + `setStacked(true)`, a `Line` series assigned to a secondary Y-axis group was (1) drawn stacked on top of the bars, and (2) caused **both** axis groups to be ranged from the combined stack of *all* series (bars + line), so neither axis reflected only its own data.

Two root causes:
- **`PlotContent_Category`** applied the stack offset to every series regardless of render style, so `Line`/`Scatter` participated in the bar stack.
- **`AxisPair.overrideMinMaxForYAxis`** recomputed the stacked min/max by summing *every* series in the chart, ignoring both `getYAxisGroup()` and render style — even though it is called once per axis group.

## Fix
- Add `CategorySeriesRenderStyle.isStackable()` — `false` for `Line`/`Scatter`, `true` for `Bar`/`Area`/`Stick`/`SteppedBar`.
- `PlotContent_Category`: only stackable render styles accumulate into the per-category stack offsets (single `seriesStacked` flag gates all stacking branches).
- `AxisPair`: recompute the stacked range **per axis group**, summing only stackable series belonging to that group; skip the override entirely when a group has no stackable series (a line-only group keeps its raw range), and keep any non-stacked series on the same group in view via `Math.max`/`Math.min`.
- Add `BarChart13` demo reproducing the reporter's exact scenario.

Behavior for single-group stacked charts is unchanged (verified: full `xchart` suite, 122 tests green).

## Result
Left axis ranges to the stacked bar sums (0–55), right axis to the line values (0–180), and the line is drawn at its own values instead of on top of the bars — matching the "Expected behavior" in the issue.

> Note: rendered PNG verification done locally; drop the image in if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)