### PR TITLE
Add BoxStyler.setBoxWidthFraction to control box plot width (#816)

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue816.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue816.java
@@ -1,0 +1,56 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Arrays;
+import java.util.List;
+import org.knowm.xchart.BoxChart;
+import org.knowm.xchart.BoxChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.Styler.ChartTheme;
+
+/**
+ * Demonstrates issue #816 — controlling the width of the boxes in a box plot.
+ *
+ * <p>By default the box width is a small, fixed amount derived from the plot margin and independent
+ * of the number of series. The new {@code BoxStyler#setBoxWidthFraction(double)} sizes each box
+ * relative to the horizontal slot available to it (a value in {@code (0, 1]}); {@code <= 0} keeps
+ * the legacy width.
+ *
+ * <p>This shows the same data rendered with the default width and with {@code 0.6} of the slot,
+ * side by side.
+ */
+public class TestForIssue816 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(Arrays.asList(getChart(-1), getChart(0.6))).displayChartMatrix();
+  }
+
+  /**
+   * Constructs a box chart (headless-safe).
+   *
+   * @param boxWidthFraction fraction of the per-series slot in {@code (0, 1]}, or {@code <= 0} for
+   *     the legacy default width
+   */
+  public static BoxChart getChart(double boxWidthFraction) {
+
+    BoxChart chart =
+        new BoxChartBuilder()
+            .width(600)
+            .height(450)
+            .title(boxWidthFraction > 0 ? "boxWidthFraction = " + boxWidthFraction : "default width")
+            .xAxisTitle("X")
+            .yAxisTitle("Y")
+            .theme(ChartTheme.GGPlot2)
+            .build();
+
+    chart.getStyler().setBoxWidthFraction(boxWidthFraction);
+
+    List<Integer> aaa = Arrays.asList(40, 30, 20, 60, 50);
+    List<Integer> bbb = Arrays.asList(-20, -10, -30, -15, -25);
+    List<Integer> ccc = Arrays.asList(50, -20);
+    chart.addSeries("aaa", aaa);
+    chart.addSeries("bbb", bbb);
+    chart.addSeries("ccc", ccc);
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Box.java
@@ -24,6 +24,7 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
   private double yTickSpace;
   private double xOffset;
   private double yOffset;
+  private double halfBoxWidth;
 
   PlotContent_Box(AxesChart<ST, S> chart) {
 
@@ -43,6 +44,15 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
     yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
     boolean toolTipsEnabled = interactionData != null;
     double gridStep = xTickSpace / chart.getSeriesMap().size();
+
+    // Box half-width: legacy default is tied to the plot margin (independent of the number of
+    // series); when a box width fraction is set, size each box relative to its per-series slot.
+    double boxWidthFraction = boxPlotStyler.getBoxWidthFraction();
+    if (boxWidthFraction > 0) {
+      halfBoxWidth = Math.min(boxWidthFraction, 1.0) * gridStep / 2.0;
+    } else {
+      halfBoxWidth = xLeftMargin;
+    }
 
     BoxPlotDataCalculator<ST, S> boxPlotDataCalculator = new BoxPlotDataCalculator<>();
     // Calculate box plot data for all series
@@ -200,24 +210,24 @@ public class PlotContent_Box<ST extends BoxStyler, S extends BoxSeries>
                     * yTickSpace);
     Shape middleline =
         new Line2D.Double(
-            xOffset - xLeftMargin, medianYOffset, xOffset + xLeftMargin, medianYOffset);
+            xOffset - halfBoxWidth, medianYOffset, xOffset + halfBoxWidth, medianYOffset);
     Shape maxLine =
         new Line2D.Double(
-            xOffset - (xLeftMargin / 2.0),
+            xOffset - (halfBoxWidth / 2.0),
             upperYOffset,
-            xOffset + (xLeftMargin / 2.0),
+            xOffset + (halfBoxWidth / 2.0),
             upperYOffset);
     Shape minLine =
         new Line2D.Double(
-            xOffset - (xLeftMargin / 2.0),
+            xOffset - (halfBoxWidth / 2.0),
             lowerYOffset,
-            xOffset + (xLeftMargin / 2.0),
+            xOffset + (halfBoxWidth / 2.0),
             lowerYOffset);
     Shape upLine = new Line2D.Double(xOffset, upperYOffset, xOffset, q3YOffset);
     Shape lowLine = new Line2D.Double(xOffset, lowerYOffset, xOffset, q1YOffset);
     Rectangle2D rect =
         new Rectangle2D.Double(
-            xOffset - xLeftMargin, q3YOffset, 2.0 * xLeftMargin, q1YOffset - q3YOffset);
+            xOffset - halfBoxWidth, q3YOffset, 2.0 * halfBoxWidth, q1YOffset - q3YOffset);
     g.setColor(Color.BLUE);
     g.setStroke(new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
     g.draw(rect);

--- a/xchart/src/main/java/org/knowm/xchart/style/BoxStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/BoxStyler.java
@@ -5,6 +5,7 @@ import org.knowm.xchart.style.theme.Theme;
 public class BoxStyler extends AxesChartStyler {
 
   private BoxplotCalCulationMethod boxplotCalCulationMethod;
+  private double boxWidthFraction = -1;
 
   public BoxStyler() {
 
@@ -18,6 +19,7 @@ public class BoxStyler extends AxesChartStyler {
     this.theme = theme;
     super.setAllStyles();
     boxplotCalCulationMethod = BoxplotCalCulationMethod.N_LESS_1_PLUS_1;
+    boxWidthFraction = -1;
   }
 
   public BoxplotCalCulationMethod getBoxplotCalCulationMethod() {
@@ -28,6 +30,26 @@ public class BoxStyler extends AxesChartStyler {
   public BoxStyler setBoxplotCalCulationMethod(BoxplotCalCulationMethod boxplotCalCulationMethod) {
 
     this.boxplotCalCulationMethod = boxplotCalCulationMethod;
+    return this;
+  }
+
+  public double getBoxWidthFraction() {
+
+    return boxWidthFraction;
+  }
+
+  /**
+   * Set the width of each box as a fraction of the horizontal space available to it (i.e. the slot
+   * for one series). Valid values are in the range (0, 1]; a value of 1 makes adjacent boxes touch.
+   * Any value &lt;= 0 (the default of -1) keeps the legacy width, which is derived from {@link
+   * #setPlotContentSize(double)} and is independent of the number of series.
+   *
+   * @param boxWidthFraction fraction of the per-series slot, in (0, 1]; &lt;= 0 for legacy width
+   * @return the styler
+   */
+  public BoxStyler setBoxWidthFraction(double boxWidthFraction) {
+
+    this.boxWidthFraction = boxWidthFraction;
     return this;
   }
 

--- a/xchart/src/test/java/org/knowm/xchart/BoxChartTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/BoxChartTest.java
@@ -81,4 +81,33 @@ class BoxChartTest {
     assertDoesNotThrow(
         () -> BitmapEncoder.saveBitmap(chart, out, BitmapEncoder.BitmapFormat.PNG));
   }
+
+  // https://github.com/knowm/XChart/issues/816
+  @Test
+  void boxWidthFractionDefaultsToLegacy() {
+
+    assertThat(chart.getStyler().getBoxWidthFraction()).isEqualTo(-1);
+  }
+
+  // https://github.com/knowm/XChart/issues/816
+  @Test
+  void boxWidthFractionRoundTrips() {
+
+    chart.getStyler().setBoxWidthFraction(0.4);
+
+    assertThat(chart.getStyler().getBoxWidthFraction()).isEqualTo(0.4);
+  }
+
+  // https://github.com/knowm/XChart/issues/816
+  @Test
+  void chartWithBoxWidthFractionCanBeSaved() {
+
+    chart.addSeries("aaa", Arrays.asList(40, 30, 20, 60, 50));
+    chart.addSeries("bbb", Arrays.asList(-20, -10, -30, -15, -25));
+    chart.getStyler().setBoxWidthFraction(0.3);
+
+    java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+    assertDoesNotThrow(
+        () -> BitmapEncoder.saveBitmap(chart, out, BitmapEncoder.BitmapFormat.PNG));
+  }
 }


### PR DESCRIPTION
Closes #816.

## Problem
Box widths in a `BoxChart` were hard-wired to the plot margin (`2 * xLeftMargin`) in `PlotContent_Box`. That produces a thin, fixed width that is independent of the number of series and offers no way to make boxes wider or narrower.

## Change
Add `BoxStyler#setBoxWidthFraction(double)` / `getBoxWidthFraction()`:
- A value in `(0, 1]` sizes each box relative to the horizontal slot available to it (the per-series slot). `1.0` makes adjacent boxes touch.
- `<= 0` (the default of `-1`) keeps the **legacy** width, so existing charts render identically.

`PlotContent_Box` now derives a single `halfBoxWidth` (from the fraction, or the legacy margin when unset) and uses it for the box rectangle, median line, whisker caps, and tooltip bounds. Box **center** positioning is unchanged.

## Tests / demo
- `BoxChartTest`: default value, setter round-trip, and render-doesn't-throw with a fraction set.
- `standalone/issues/TestForIssue816`: default vs. `0.6` side by side (headless-safe `getChart(double)`).
- Full `xchart` suite: **125 pass**. Pixel measurement confirms width scales monotonically with the fraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)