### PR TITLE
Issue #580: clockwise/counter-clockwise radar chart direction

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart03.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart03.java
@@ -1,0 +1,60 @@
+package org.knowm.xchart.demo.charts.radar;
+
+import org.knowm.xchart.RadarChart;
+import org.knowm.xchart.RadarChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+/**
+ * Radar Chart with counter-clockwise layout
+ *
+ * <p>Demonstrates the following:
+ *
+ * <ul>
+ *   <li>Radar Chart drawing direction (issue #580)
+ *   <li>RadarStyler#setCounterClockwise
+ * </ul>
+ *
+ * <p>The radii are laid out clockwise by default (matching the common radar/spider chart
+ * convention). Here the labels 1..6 are laid out counter-clockwise instead.
+ */
+public class RadarChart03 implements ExampleChart<RadarChart> {
+
+  public static void main(String[] args) {
+
+    ExampleChart<RadarChart> exampleChart = new RadarChart03();
+    RadarChart chart = exampleChart.getChart();
+    SwingWrapper<RadarChart> wrapper = new SwingWrapper<>(chart);
+    wrapper.displayChart();
+    wrapper.getXChartPanel().setToolTipsEnabled(true);
+  }
+
+  @Override
+  public RadarChart getChart() {
+
+    RadarChart chart =
+        new RadarChartBuilder().width(800).height(600).title(getClass().getSimpleName()).build();
+    chart.getStyler().setLegendPosition(LegendPosition.InsideSW);
+    // draw counter-clockwise instead of the default clockwise
+    chart.getStyler().setCounterClockwise(true);
+
+    chart.setRadiiLabels(new String[] {"1", "2", "3", "4", "5", "6"});
+    chart.addSeries("Values", new double[] {0.9, 0.8, 0.7, 0.6, 0.5, 0.4});
+
+    return chart;
+  }
+
+  @Override
+  public void customizePanel(XChartPanel<RadarChart> panel) {
+
+    panel.setToolTipsEnabled(true);
+  }
+
+  @Override
+  public String getExampleChartName() {
+
+    return getClass().getSimpleName() + " - Radar Chart Direction";
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
@@ -65,6 +65,8 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
     int numRadiiLabels = radiiLabels.length;
     double[] cosArr = new double[numRadiiLabels];
     double[] sinArr = new double[numRadiiLabels];
+    // increasing angles wind counter-clockwise (math convention); negate for the default clockwise
+    double angleStep = styler.isCounterClockwise() ? radiiAngle : -radiiAngle;
     double startAngle = styler.getStartAngleInDegrees() + 90;
     for (int i = 0; i < numRadiiLabels; i++) {
       double radians = Math.toRadians(startAngle);
@@ -72,7 +74,7 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
       double sin = Math.sin(radians);
       cosArr[i] = cos;
       sinArr[i] = sin;
-      startAngle += radiiAngle;
+      startAngle += angleStep;
     }
 
     // paint radii lines and labels
@@ -129,7 +131,7 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
         g.setTransform(orig);
       }
 
-      startAngle += radiiAngle;
+      startAngle += angleStep;
     }
 
     // draw radii tick marks ie. concentric circles/polygons

--- a/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
@@ -9,6 +9,7 @@ public class RadarStyler extends Styler {
   private RadarRenderStyle radarRenderStyle;
   private boolean isCircular;
   private double startAngleInDegrees;
+  private boolean counterClockwise;
 
   // radii tick marks
   private boolean radiiTicksMarksVisible;
@@ -38,6 +39,7 @@ public class RadarStyler extends Styler {
     this.radarRenderStyle = RadarRenderStyle.Polygon;
     this.isCircular = theme.isCircular();
     this.startAngleInDegrees = theme.getStartAngleInDegrees();
+    this.counterClockwise = false;
 
     this.markerSize = theme.getMarkerSize();
 
@@ -81,6 +83,26 @@ public class RadarStyler extends Styler {
   public RadarStyler setStartAngleInDegrees(double startAngleInDegrees) {
 
     this.startAngleInDegrees = startAngleInDegrees;
+    return this;
+  }
+
+  public boolean isCounterClockwise() {
+
+    return counterClockwise;
+  }
+
+  /**
+   * Sets the direction in which the radii (labels and data points) are laid out around the chart.
+   * By default the chart is drawn clockwise, matching the common radar/spider chart convention. Set
+   * this to {@code true} to lay the radii out counter-clockwise instead. This only changes the
+   * winding direction; use {@link #setStartAngleInDegrees(double)} to also rotate the start
+   * position.
+   *
+   * @param counterClockwise true to draw counter-clockwise, false (default) for clockwise
+   */
+  public RadarStyler setCounterClockwise(boolean counterClockwise) {
+
+    this.counterClockwise = counterClockwise;
     return this;
   }
 

--- a/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue580.java
+++ b/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue580.java
@@ -1,0 +1,78 @@
+package org.knowm.xchart.regressiontests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.image.BufferedImage;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.RadarChart;
+import org.knowm.xchart.RadarChartBuilder;
+
+/**
+ * Regression test for <a href="https://github.com/knowm/XChart/issues/580">issue 580</a>: radar
+ * chart radii were laid out counter-clockwise with no way to reverse the direction. The default is
+ * now clockwise (the common radar/spider chart convention), toggleable via {@code
+ * setCounterClockwise}.
+ */
+public class RegressionTestIssue580 {
+
+  @Test
+  public void defaultIsClockwiseAndSetterRoundTrips() {
+
+    RadarChart chart = new RadarChartBuilder().build();
+    assertThat(chart.getStyler().isCounterClockwise()).isFalse();
+
+    chart.getStyler().setCounterClockwise(true);
+    assertThat(chart.getStyler().isCounterClockwise()).isTrue();
+  }
+
+  @Test
+  public void directionFlipsHorizontalBulge() {
+
+    // Index 0 is at the top; index 1 is one step around. Make index 1 the only large radius so the
+    // filled polygon clearly bulges toward that vertex. Clockwise puts index 1 on the right half;
+    // counter-clockwise puts it on the left half.
+    String[] labels = {"1", "2", "3", "4", "5", "6"};
+    double[] values = {0.05, 1.0, 0.05, 0.05, 0.05, 0.05};
+
+    int clockwiseRight = rightMinusLeftBlue(render(labels, values, false));
+    int counterRight = rightMinusLeftBlue(render(labels, values, true));
+
+    assertThat(clockwiseRight).isGreaterThan(0); // bulges right
+    assertThat(counterRight).isLessThan(0); // bulges left
+  }
+
+  private static BufferedImage render(String[] labels, double[] values, boolean counterClockwise) {
+
+    RadarChart chart = new RadarChartBuilder().width(500).height(500).build();
+    chart.getStyler().setCounterClockwise(counterClockwise);
+    chart.getStyler().setLegendVisible(false);
+    chart.setRadiiLabels(labels);
+    chart.addSeries("s", values);
+    return BitmapEncoder.getBufferedImage(chart);
+  }
+
+  /** Positive when the blue series fill sits more to the right of center than the left. */
+  private static int rightMinusLeftBlue(BufferedImage img) {
+
+    int cx = img.getWidth() / 2;
+    int left = 0;
+    int right = 0;
+    for (int y = 0; y < img.getHeight(); y++) {
+      for (int x = 0; x < img.getWidth(); x++) {
+        int rgb = img.getRGB(x, y);
+        int r = (rgb >> 16) & 0xFF;
+        int gg = (rgb >> 8) & 0xFF;
+        int b = rgb & 0xFF;
+        if (b > r + 20 && b > gg + 20) { // blue-dominant series pixel
+          if (x < cx) {
+            left++;
+          } else if (x > cx) {
+            right++;
+          }
+        }
+      }
+    }
+    return right - left;
+  }
+}

--- a/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue580.java
+++ b/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue580.java
@@ -2,11 +2,14 @@ package org.knowm.xchart.regressiontests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import org.junit.jupiter.api.Test;
 import org.knowm.xchart.BitmapEncoder;
 import org.knowm.xchart.RadarChart;
 import org.knowm.xchart.RadarChartBuilder;
+import org.knowm.xchart.RadarSeries;
+import org.knowm.xchart.style.markers.SeriesMarkers;
 
 /**
  * Regression test for <a href="https://github.com/knowm/XChart/issues/580">issue 580</a>: radar
@@ -48,7 +51,13 @@ public class RegressionTestIssue580 {
     chart.getStyler().setCounterClockwise(counterClockwise);
     chart.getStyler().setLegendVisible(false);
     chart.setRadiiLabels(labels);
-    chart.addSeries("s", values);
+
+    // Pin the series to a strong blue and drop markers so the pixel assertion isolates the
+    // clockwise/counter-clockwise winding from theme/color-cycler defaults.
+    RadarSeries series = chart.addSeries("s", values);
+    series.setLineColor(Color.BLUE);
+    series.setFillColor(Color.BLUE);
+    series.setMarker(SeriesMarkers.NONE);
     return BitmapEncoder.getBufferedImage(chart);
   }
 


### PR DESCRIPTION
Fixes #580.

## Problem
A radar chart with ascending labels `1 2 3 4 5 6` rendered them counter-clockwise, so reading the ring clockwise gave `6 5 4 3 2 1`. There was no way to reverse the drawing direction without reversing the underlying data (which the reporter explicitly did not want).

Root cause: in `PlotContent_Radar`, the vertex angle is stepped with `startAngle += radiiAngle` and positions use the math convention `y = cy - sin(θ)`, so increasing angles wind counter-clockwise. `setStartAngleInDegrees` only rotates the ring; it can't flip the winding.

## Fix
- Add `RadarStyler.setCounterClockwise(boolean)` / `isCounterClockwise()`, **defaulting to clockwise** — the common radar/spider chart convention (Excel, ECharts, Chart.js), which also makes ascending labels read `1..6` clockwise out of the box.
- `PlotContent_Radar` computes a single `angleStep` (negative by default, positive when counter-clockwise) and uses it for the angle table, radii lines/labels, tick-mark polygons, and series polygons, so labels, data, and grid stay aligned.

Note: the default flips from the previous (counter-clockwise) rendering. This is intentional per the 4.0.x breaking-changes policy and fixes the surprising behavior; users wanting the old layout call `setCounterClockwise(true)`.

## Verification
- `RegressionTestIssue580`: asserts the clockwise default + setter round-trip, and that a dominant vertex bulges to the right half when clockwise and the left half when counter-clockwise.
- New `RadarChart03` demo showing the counter-clockwise option.
- Full `xchart` suite passes (132 tests); `fmt:check` clean on both modules.

### Clockwise (new default) — labels read 1..6 clockwise
### Counter-clockwise — `setCounterClockwise(true)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)