### PR TITLE
Issue #892: fix horizontal legend layout with mixed render styles

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue892.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue892.java
@@ -1,0 +1,67 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.Color;
+import java.util.Arrays;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.style.markers.SeriesMarkers;
+
+/**
+ * Reproducer for https://github.com/knowm/XChart/issues/892
+ *
+ * <p>"When you have series using different render styles, like bar and line, the legend markers and
+ * text is displayed wonky." (reported with a horizontal, OutsideS legend)
+ *
+ * <p>Expected: in a horizontal legend, the markers/boxes and their text should line up uniformly
+ * across mixed render styles. Currently a Bar entry centers its text within the 20px legend box
+ * while a Line entry centers within the (smaller) marker size, so the two entries sit at different
+ * vertical baselines.
+ *
+ * <p>This is the reporter's original example, verbatim except for being wrapped in a headless-safe
+ * {@link #getChart()} so it can also be rendered/asserted in tests.
+ */
+public class TestForIssue892 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static CategoryChart getChart() {
+
+    // Create chart
+    CategoryChart chart =
+        new CategoryChartBuilder()
+            .width(800)
+            .height(600)
+            .title("Bar + Line Series Legend Marker Demo")
+            .xAxisTitle("Category")
+            .yAxisTitle("Value")
+            .build();
+
+    // General Styler settings
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.OutsideS);
+    chart.getStyler().setLegendLayout(Styler.LegendLayout.Horizontal);
+    chart.getStyler().setLegendVisible(true);
+
+    // Bar Series
+    CategorySeries barSeries =
+        chart.addSeries("Bar Series", Arrays.asList("A", "B", "C"), Arrays.asList(20, 40, 55));
+    barSeries.setChartCategorySeriesRenderStyle(CategorySeries.CategorySeriesRenderStyle.Bar);
+    barSeries.setFillColor(new Color(35, 127, 211));
+
+    // Line Series
+    CategorySeries lineSeries =
+        chart.addSeries("Line Series", Arrays.asList("A", "B", "C"), Arrays.asList(15, 30, 45));
+    lineSeries.setChartCategorySeriesRenderStyle(CategorySeries.CategorySeriesRenderStyle.Line);
+    lineSeries.setLineColor(new Color(237, 133, 53));
+    lineSeries.setLineWidth(2.5f);
+    lineSeries.setMarker(SeriesMarkers.CIRCLE);
+
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue892.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue892.java
@@ -16,9 +16,9 @@ import org.knowm.xchart.style.markers.SeriesMarkers;
  * text is displayed wonky." (reported with a horizontal, OutsideS legend)
  *
  * <p>Expected: in a horizontal legend, the markers/boxes and their text should line up uniformly
- * across mixed render styles. Currently a Bar entry centers its text within the 20px legend box
- * while a Line entry centers within the (smaller) marker size, so the two entries sit at different
- * vertical baselines.
+ * across mixed render styles. Before the fix, a Bar entry centered its text within the 20px legend
+ * box while a Line entry centered within the (smaller) marker size, so the two entries sat at
+ * different vertical baselines.
  *
  * <p>This is the reporter's original example, verbatim except for being wrapped in a headless-safe
  * {@link #getChart()} so it can also be rendered/asserted in tests.

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_.java
@@ -256,8 +256,13 @@ public abstract class Legend_<ST extends Styler, S extends Series> implements Ch
       }
 
       legendEntryHeight -= MULTI_LINE_SPACE; // subtract away the bottom MULTI_LINE_SPACE
+      // Accumulate the tallest entry across ALL series (text or graphic, whichever is taller) so
+      // the single-row horizontal legend box is tall enough for the biggest entry (e.g. a 20px
+      // box) regardless of series order (issue #892).
       legendTextContentMaxHeight =
-          Math.max(legendEntryHeight, getSeriesLegendRenderGraphicHeight(series));
+          Math.max(
+              legendTextContentMaxHeight,
+              Math.max(legendEntryHeight, getSeriesLegendRenderGraphicHeight(series)));
 
       legendContentWidth += legendEntryMaxWidth + chart.getStyler().getLegendPadding();
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Marker.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Marker.java
@@ -80,8 +80,12 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
                   ? axesChartStyler.getMarkerSize()
                   : BOX_SIZE));
 
-      // vertical centering reference for this entry's graphics and text
-      float rowHeight = isHorizontal ? commonRowHeight : legendEntryHeight;
+      // In a horizontal layout every entry shares one row, so center this entry's natural block
+      // within the shared row by shifting its vertical origin. All per-element math below then
+      // stays exactly as in the vertical layout, just drawn from entryStarty. In a vertical layout
+      // each entry has its own row, so the shift is zero.
+      double entryStarty =
+          isHorizontal ? starty + (commonRowHeight - legendEntryHeight) / 2.0 : starty;
 
       // paint line and marker
       if (series.getLegendRenderType() == LegendRenderType.Line
@@ -95,9 +99,9 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
           Shape line =
               new Line2D.Double(
                   startx,
-                  starty + rowHeight / 2.0,
+                  entryStarty + legendEntryHeight / 2.0,
                   startx + chart.getStyler().getLegendSeriesLineLength(),
-                  starty + rowHeight / 2.0);
+                  entryStarty + legendEntryHeight / 2.0);
           g.draw(line);
         }
 
@@ -109,13 +113,12 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
               .paint(
                   g,
                   startx + chart.getStyler().getLegendSeriesLineLength() / 2.0,
-                  starty + rowHeight / 2.0,
+                  entryStarty + legendEntryHeight / 2.0,
                   axesChartStyler.getMarkerSize());
         }
       } else { // bar/pie type series
 
-        // center the box within the (possibly taller) shared row
-        double boxStarty = starty + (rowHeight - BOX_SIZE) / 2.0;
+        double boxStarty = entryStarty;
 
         // paint inner box
         Shape rectSmall = new Rectangle2D.Double(startx, boxStarty, BOX_SIZE, BOX_SIZE);
@@ -165,11 +168,11 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
             startx
                 + chart.getStyler().getLegendSeriesLineLength()
                 + chart.getStyler().getLegendPadding();
-        paintSeriesText(g, seriesTextBounds, (int) rowHeight, x, starty);
+        paintSeriesText(g, seriesTextBounds, axesChartStyler.getMarkerSize(), x, entryStarty);
       } else { // bar/pie type series
 
         double x = startx + BOX_SIZE + chart.getStyler().getLegendPadding();
-        paintSeriesText(g, seriesTextBounds, (int) rowHeight, x, starty);
+        paintSeriesText(g, seriesTextBounds, BOX_SIZE, x, entryStarty);
       }
 
       if (chart.getStyler().getLegendLayout() == Styler.LegendLayout.Vertical) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Marker.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Marker.java
@@ -40,6 +40,28 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
             : RenderingHints.VALUE_ANTIALIAS_OFF);
 
     Map<String, S> map = chart.getSeriesMap();
+
+    // In a horizontal legend all entries share one row, so they must be vertically centered
+    // against a common row height. Otherwise mixed render styles (e.g. a Bar's 20px box vs. a
+    // Line's smaller marker) center against their own graphic height and sit at different
+    // baselines (issue #892). In a vertical legend each entry gets its own row, so the per-entry
+    // height is the correct reference.
+    boolean isHorizontal =
+        chart.getStyler().getLegendLayout() == Styler.LegendLayout.Horizontal;
+    float commonRowHeight = 0;
+    if (isHorizontal) {
+      for (S series : map.values()) {
+        if (!series.isShowInLegend() || !series.isEnabled()) {
+          continue;
+        }
+        commonRowHeight =
+            Math.max(
+                commonRowHeight,
+                getLegendEntryHeight(
+                    getSeriesTextBounds(series), (int) getSeriesLegendRenderGraphicHeight(series)));
+      }
+    }
+
     for (S series : map.values()) {
 
       if (!series.isShowInLegend()) {
@@ -58,6 +80,9 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
                   ? axesChartStyler.getMarkerSize()
                   : BOX_SIZE));
 
+      // vertical centering reference for this entry's graphics and text
+      float rowHeight = isHorizontal ? commonRowHeight : legendEntryHeight;
+
       // paint line and marker
       if (series.getLegendRenderType() == LegendRenderType.Line
           || series.getLegendRenderType() == LegendRenderType.Scatter) {
@@ -70,9 +95,9 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
           Shape line =
               new Line2D.Double(
                   startx,
-                  starty + legendEntryHeight / 2.0,
+                  starty + rowHeight / 2.0,
                   startx + chart.getStyler().getLegendSeriesLineLength(),
-                  starty + legendEntryHeight / 2.0);
+                  starty + rowHeight / 2.0);
           g.draw(line);
         }
 
@@ -84,13 +109,16 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
               .paint(
                   g,
                   startx + chart.getStyler().getLegendSeriesLineLength() / 2.0,
-                  starty + legendEntryHeight / 2.0,
+                  starty + rowHeight / 2.0,
                   axesChartStyler.getMarkerSize());
         }
       } else { // bar/pie type series
 
+        // center the box within the (possibly taller) shared row
+        double boxStarty = starty + (rowHeight - BOX_SIZE) / 2.0;
+
         // paint inner box
-        Shape rectSmall = new Rectangle2D.Double(startx, starty, BOX_SIZE, BOX_SIZE);
+        Shape rectSmall = new Rectangle2D.Double(startx, boxStarty, BOX_SIZE, BOX_SIZE);
         g.setColor(series.getFillColor());
         g.fill(rectSmall);
 
@@ -119,10 +147,10 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
           Path2D.Double outlinePath = new Path2D.Double();
 
           double lineOffset = existingLineStyle.getLineWidth() * 0.5;
-          outlinePath.moveTo(startx + lineOffset, starty + lineOffset);
-          outlinePath.lineTo(startx + lineOffset, starty + BOX_SIZE - lineOffset);
-          outlinePath.lineTo(startx + BOX_SIZE - lineOffset, starty + BOX_SIZE - lineOffset);
-          outlinePath.lineTo(startx + BOX_SIZE - lineOffset, starty + lineOffset);
+          outlinePath.moveTo(startx + lineOffset, boxStarty + lineOffset);
+          outlinePath.lineTo(startx + lineOffset, boxStarty + BOX_SIZE - lineOffset);
+          outlinePath.lineTo(startx + BOX_SIZE - lineOffset, boxStarty + BOX_SIZE - lineOffset);
+          outlinePath.lineTo(startx + BOX_SIZE - lineOffset, boxStarty + lineOffset);
           outlinePath.closePath();
 
           g.draw(outlinePath);
@@ -137,11 +165,11 @@ public class Legend_Marker<ST extends Styler, S extends MarkerSeries> extends Le
             startx
                 + chart.getStyler().getLegendSeriesLineLength()
                 + chart.getStyler().getLegendPadding();
-        paintSeriesText(g, seriesTextBounds, axesChartStyler.getMarkerSize(), x, starty);
+        paintSeriesText(g, seriesTextBounds, (int) rowHeight, x, starty);
       } else { // bar/pie type series
 
         double x = startx + BOX_SIZE + chart.getStyler().getLegendPadding();
-        paintSeriesText(g, seriesTextBounds, BOX_SIZE, x, starty);
+        paintSeriesText(g, seriesTextBounds, (int) rowHeight, x, starty);
       }
 
       if (chart.getStyler().getLegendLayout() == Styler.LegendLayout.Vertical) {

--- a/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue892.java
+++ b/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue892.java
@@ -48,11 +48,19 @@ public class RegressionTestIssue892 {
 
     BufferedImage image = BitmapEncoder.getBufferedImage(chart);
 
-    // The OutsideS legend sits at the very bottom. Its background matches the (white) plot
-    // background higher up, so locate the legend container as the bottom-most contiguous block of
-    // background-colored rows (below it is only the chart-background margin). Then measure the
-    // entries strictly within its rows, so plot content can never leak into the measurement.
+    // Locate the legend container so the entries can be measured strictly within it (plot content
+    // can never leak in). In the default XChartTheme the chart background is grey while both the
+    // plot and legend backgrounds are white, so the white regions are the plot area (upper) and
+    // the legend (bottom), separated by a grey margin. The OutsideS legend is therefore the
+    // bottom-most contiguous band of white rows.
     int[] containerRows = bottomMostBand(image, chart.getStyler().getLegendBackgroundColor());
+    // Guard against a degenerate detection (e.g. if backgrounds ever became indistinguishable, the
+    // band would swallow the plot): a legend is a small fraction of the image height.
+    assertTrue(
+        containerRows[1] - containerRows[0] < image.getHeight() / 4,
+        "detected legend container is implausibly tall ("
+            + (containerRows[1] - containerRows[0])
+            + "px) — background detection likely captured the plot area");
     int[] barRows = verticalExtent(image, BAR_FILL, containerRows[0]);
     int[] lineRows = verticalExtent(image, LINE_COLOR, containerRows[0]);
     double barCenter = (barRows[0] + barRows[1]) / 2.0;

--- a/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue892.java
+++ b/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue892.java
@@ -1,0 +1,144 @@
+package org.knowm.xchart.regressiontests;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.style.markers.SeriesMarkers;
+
+/**
+ * Regression test for <a href="https://github.com/knowm/XChart/issues/892">issue 892</a>.
+ *
+ * <p>In a horizontal legend mixing render styles (Bar + Line), each entry used to be vertically
+ * centered against its own graphic height, so the Bar's 20px box and the Line's smaller
+ * marker/line ended up on different baselines. This asserts that the Bar box and the Line marker
+ * share (approximately) the same vertical center in the rendered legend.
+ */
+public class RegressionTestIssue892 {
+
+  private static final Color BAR_FILL = new Color(35, 127, 211);
+  private static final Color LINE_COLOR = new Color(237, 133, 53);
+
+  @Test
+  public void mixedStyleHorizontalLegendGraphicsAreVerticallyAligned() {
+
+    CategoryChart chart =
+        new CategoryChartBuilder().width(800).height(600).title("issue 892").build();
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.OutsideS);
+    chart.getStyler().setLegendLayout(Styler.LegendLayout.Horizontal);
+
+    CategorySeries bar =
+        chart.addSeries("Bar Series", Arrays.asList("A", "B", "C"), Arrays.asList(20, 40, 55));
+    bar.setChartCategorySeriesRenderStyle(CategorySeries.CategorySeriesRenderStyle.Bar);
+    bar.setFillColor(BAR_FILL);
+
+    CategorySeries line =
+        chart.addSeries("Line Series", Arrays.asList("A", "B", "C"), Arrays.asList(15, 30, 45));
+    line.setChartCategorySeriesRenderStyle(CategorySeries.CategorySeriesRenderStyle.Line);
+    line.setLineColor(LINE_COLOR);
+    line.setLineWidth(2.5f);
+    line.setMarker(SeriesMarkers.CIRCLE);
+
+    BufferedImage image = BitmapEncoder.getBufferedImage(chart);
+
+    // The OutsideS legend sits at the very bottom. Its background matches the (white) plot
+    // background higher up, so locate the legend container as the bottom-most contiguous block of
+    // background-colored rows (below it is only the chart-background margin). Then measure the
+    // entries strictly within its rows, so plot content can never leak into the measurement.
+    int[] containerRows = bottomMostBand(image, chart.getStyler().getLegendBackgroundColor());
+    int[] barRows = verticalExtent(image, BAR_FILL, containerRows[0]);
+    int[] lineRows = verticalExtent(image, LINE_COLOR, containerRows[0]);
+    double barCenter = (barRows[0] + barRows[1]) / 2.0;
+    double lineCenter = (lineRows[0] + lineRows[1]) / 2.0;
+
+    // (1) the entries must align to each other. Pre-fix the two centers were ~6px apart.
+    double diff = Math.abs(barCenter - lineCenter);
+    assertTrue(
+        diff <= 2.0,
+        "Bar box center ("
+            + barCenter
+            + ") and line marker center ("
+            + lineCenter
+            + ") should be vertically aligned in a horizontal legend, but differ by "
+            + diff
+            + "px");
+
+    // (2) the entries as a group must be vertically centered inside the legend container. Pre-fix
+    // the container was sized to the last series' height, so the taller box sat too low.
+    double containerCenter = (containerRows[0] + containerRows[1]) / 2.0;
+    double contentCenter =
+        (Math.min(barRows[0], lineRows[0]) + Math.max(barRows[1], lineRows[1])) / 2.0;
+    double offCenter = Math.abs(contentCenter - containerCenter);
+    assertTrue(
+        offCenter <= 2.0,
+        "Legend content center ("
+            + contentCenter
+            + ") should sit at the legend container center ("
+            + containerCenter
+            + "), but is off by "
+            + offCenter
+            + "px");
+  }
+
+  /** {top row, bottom row} of the bottom-most contiguous block of rows containing {@code bg}. */
+  private static int[] bottomMostBand(BufferedImage image, Color bg) {
+
+    int bottom = -1;
+    int top = -1;
+    for (int y = image.getHeight() - 1; y >= 0; y--) {
+      boolean rowHasBg = false;
+      for (int x = 0; x < image.getWidth(); x++) {
+        if (isClose(new Color(image.getRGB(x, y)), bg)) {
+          rowHasBg = true;
+          break;
+        }
+      }
+      if (rowHasBg) {
+        if (bottom == -1) {
+          bottom = y;
+        }
+        top = y;
+      } else if (bottom != -1) {
+        break; // reached the gap above the bottom-most block
+      }
+    }
+    if (bottom == -1) {
+      throw new AssertionError("legend background color " + bg + " not found");
+    }
+    return new int[] {top, bottom};
+  }
+
+  /** {min row, max row} of pixels matching {@code target} at or below {@code y0}. */
+  private static int[] verticalExtent(BufferedImage image, Color target, int y0) {
+
+    int minY = Integer.MAX_VALUE;
+    int maxY = Integer.MIN_VALUE;
+    for (int y = Math.max(0, y0); y < image.getHeight(); y++) {
+      for (int x = 0; x < image.getWidth(); x++) {
+        if (isClose(new Color(image.getRGB(x, y)), target)) {
+          minY = Math.min(minY, y);
+          maxY = Math.max(maxY, y);
+          break;
+        }
+      }
+    }
+    if (minY == Integer.MAX_VALUE) {
+      throw new AssertionError("color " + target + " not found in legend band");
+    }
+    return new int[] {minY, maxY};
+  }
+
+  private static boolean isClose(Color a, Color b) {
+    int tol = 25;
+    return Math.abs(a.getRed() - b.getRed()) < tol
+        && Math.abs(a.getGreen() - b.getGreen()) < tol
+        && Math.abs(a.getBlue() - b.getBlue()) < tol;
+  }
+}


### PR DESCRIPTION
Fixes #892.

## Problem
With a **horizontal** legend (`LegendLayout.Horizontal`, e.g. `LegendPosition.OutsideS`) mixing render styles such as **Bar + Line**, the legend markers/boxes and text were misaligned, and the whole entry group sat too low inside the legend box.

Reported by @JamesPaceOnTailwind.

## Root causes
Two independent bugs, both only visible when entries in one horizontal row differ in height:

1. **Entries not aligned to each other** — `Legend_Marker` centered each entry against *its own* graphic height, so a Bar's 20px box and a Line's smaller marker landed on different vertical baselines. In a horizontal layout every entry shares one row, so the fix computes a **common row height** (the tallest graphic/text across all shown series) and centers the box, line, marker, and text against it uniformly. Vertical layout is unchanged (each entry is its own row).

2. **Group sat too low** — `Legend_.getBoundsHintHorizontal()` computed the legend-box height by *assignment* inside the series loop, so the container was sized to the **last** series' height instead of the tallest. With the Line series added last, the box was too short for the 20px Bar box and the content overflowed downward. Now it **accumulates the max** across all series.

## Before / After
Before: the line/marker and its label sit higher than the box and its label, and the group is low in the box.
After: box, line, marker, and both labels share one vertical center, centered in the container.

## Testing
- Added `RegressionTestIssue892` — renders the reporter's chart and asserts (1) the Bar box center and Line marker center align, and (2) the entry group is vertically centered in the legend container. Each assertion fails independently if its respective fix is reverted.
- Added demo `TestForIssue892` (the reporter's example, headless-safe `getChart()`).
- Full `xchart` suite: 130 pass. `fmt:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)