### PR TITLE
Issue #1004: fix AnnotationImage screen-space vertical centering (width vs height)

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue1004.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue1004.java
@@ -1,0 +1,74 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import org.knowm.xchart.AnnotationImage;
+import org.knowm.xchart.AnnotationLine;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+
+/**
+ * Issue #1004 — {@link AnnotationImage} screen-space placement centers a NON-square image
+ * vertically using the image WIDTH instead of its HEIGHT.
+ *
+ * <p>A tall image (here 40&nbsp;wide &times; 140&nbsp;tall) is placed with {@code
+ * isValueInScreenSpace = true} at a fixed screen point. A crosshair (two screen-space {@link
+ * AnnotationLine}s) marks that exact point, and the image itself has a red line drawn across its own
+ * true vertical center.
+ *
+ * <p><b>Before the fix:</b> the image's red center line sits {@code (width - height) / 2 = 50px}
+ * BELOW the crosshair intersection — the image is not centered on the target point.
+ *
+ * <p><b>After the fix:</b> the image's red center line lines up with the crosshair.
+ *
+ * <p>Square images are unaffected, which is why this went unnoticed.
+ */
+public class TestForIssue1004 {
+
+  private static final int IMG_W = 40;
+  private static final int IMG_H = 140;
+
+  /** Screen-space target point (pixels; y measured from the BOTTOM, per AnnotationImage). */
+  private static final int TARGET_X = 400;
+  private static final int TARGET_Y = 300;
+
+  /** A tall, non-square image with a clearly marked vertical center. */
+  private static BufferedImage makeTallImage() {
+
+    BufferedImage img = new BufferedImage(IMG_W, IMG_H, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D g = img.createGraphics();
+    g.setColor(new Color(0, 120, 215, 160));
+    g.fillRect(0, 0, IMG_W, IMG_H);
+    g.setColor(Color.DARK_GRAY);
+    g.drawRect(0, 0, IMG_W - 1, IMG_H - 1);
+    // red line across the image's TRUE vertical center
+    g.setColor(Color.RED);
+    g.setStroke(new BasicStroke(2f));
+    g.drawLine(0, IMG_H / 2, IMG_W, IMG_H / 2);
+    g.dispose();
+    return img;
+  }
+
+  public static XYChart getChart() {
+
+    XYChart chart = new XYChart(900, 600);
+    chart.setTitle("Issue #1004 — tall image should be centered on the crosshair");
+
+    chart.addSeries("series", new double[] {0, 1, 2, 3}, new double[] {0, 1, 4, 9});
+
+    // crosshair marking the intended center of the image (screen space)
+    chart.addAnnotation(new AnnotationLine(TARGET_X, true, true)); // vertical line at x=TARGET_X
+    chart.addAnnotation(new AnnotationLine(TARGET_Y, false, true)); // horizontal line at y=TARGET_Y
+
+    // the tall image, placed in screen space at the same point
+    chart.addAnnotation(new AnnotationImage(makeTallImage(), TARGET_X, TARGET_Y, true));
+
+    return chart;
+  }
+
+  public static void main(String[] args) {
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/AnnotationImage.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationImage.java
@@ -45,7 +45,7 @@ public class AnnotationImage extends Annotation {
 
     if (isValueInScreenSpace) {
       xOffset = (int) x - image.getWidth() / 2;
-      yOffset = chart.getHeight() - (int) y - image.getWidth() / 2;
+      yOffset = chart.getHeight() - (int) y - image.getHeight() / 2;
     } else {
       xOffset = (int) (getXAxisScreenValue(x) + 0.5) - image.getWidth() / 2;
       yOffset = (int) (getYAxisScreenValue(y) + 0.5) - image.getHeight() / 2;


### PR DESCRIPTION
## Summary

Fixes #1004.

`AnnotationImage.paint()` centered the image vertically using `image.getWidth()` instead of `image.getHeight()` in the **screen-space** branch. A non-square image placed with `isValueInScreenSpace = true` was therefore mis-centered vertically by `(width - height) / 2` pixels. The data-space branch already used `getHeight()` correctly, and square images were unaffected — which is why it went unnoticed.

```diff
  if (isValueInScreenSpace) {
    xOffset = (int) x - image.getWidth() / 2;
-   yOffset = chart.getHeight() - (int) y - image.getWidth() / 2;
+   yOffset = chart.getHeight() - (int) y - image.getHeight() / 2;
```

## Demo

Adds `TestForIssue1004`, which places a tall (40×140) image in screen space at a fixed point marked by a crosshair; the image has a red line across its true center.

| Before | After |
| --- | --- |
| red center line sits ~50px below the crosshair | red center line lands on the crosshair |

## Origin

Found while triaging #506 (which is resolved on `develop` — the old `ChartImage`/`addPlotPart` API is now `AnnotationImage`/`addAnnotation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
