### PR TITLE
Issue #583: drop reflection from XChartPanelSaveTargetTest

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -661,7 +661,8 @@ public class XChartPanel<T extends Chart<?, ?>> extends JPanel {
     }
   }
 
-  private static class SuffixSaveFilter extends FileFilter {
+  // package-private so tests in this package can build the same filters the dialog installs
+  static class SuffixSaveFilter extends FileFilter {
 
     private final String suffix;
 

--- a/xchart/src/test/java/org/knowm/xchart/XChartPanelSaveTargetTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/XChartPanelSaveTargetTest.java
@@ -3,7 +3,6 @@ package org.knowm.xchart;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.lang.reflect.Constructor;
 import javax.swing.filechooser.FileFilter;
 import org.junit.jupiter.api.Test;
 
@@ -15,16 +14,13 @@ import org.junit.jupiter.api.Test;
 public class XChartPanelSaveTargetTest {
 
   /** Builds the same filter instances the Save As dialog installs. */
-  private static FileFilter filter(String suffix) throws Exception {
+  private static FileFilter filter(String suffix) {
 
-    Class<?> clazz = Class.forName("org.knowm.xchart.XChartPanel$SuffixSaveFilter");
-    Constructor<?> ctor = clazz.getDeclaredConstructor(String.class);
-    ctor.setAccessible(true);
-    return (FileFilter) ctor.newInstance(suffix);
+    return new XChartPanel.SuffixSaveFilter(suffix);
   }
 
   @Test
-  public void testExtensionIsAppendedWhenTheUserOmitsIt() throws Exception {
+  public void testExtensionIsAppendedWhenTheUserOmitsIt() {
 
     // The case that made the bug bite: "chart" is written as "chart.png", so an overwrite check
     // against the raw selection would never fire.
@@ -34,7 +30,7 @@ public class XChartPanelSaveTargetTest {
   }
 
   @Test
-  public void testExtensionIsNotDuplicatedWhenTheUserTypesIt() throws Exception {
+  public void testExtensionIsNotDuplicatedWhenTheUserTypesIt() {
 
     assertEquals(
         "chart.png", XChartPanel.resolveSaveTarget(new File("chart.png"), filter("png")).getName());
@@ -43,7 +39,7 @@ public class XChartPanelSaveTargetTest {
   }
 
   @Test
-  public void testResolvedTargetMatchesWhatTheEncoderWrites() throws Exception {
+  public void testResolvedTargetMatchesWhatTheEncoderWrites() {
 
     // The overwrite check is only trustworthy if it names the exact file the encoder opens.
     String selected = "chart";
@@ -65,7 +61,7 @@ public class XChartPanelSaveTargetTest {
   }
 
   @Test
-  public void testSuffixIsReadFromTheFilterRatherThanItsDescription() throws Exception {
+  public void testSuffixIsReadFromTheFilterRatherThanItsDescription() {
 
     assertEquals("eps", XChartPanel.suffixOf(filter("eps")));
     assertEquals("bmp", XChartPanel.suffixOf(filter("bmp")));


### PR DESCRIPTION
Follow-up to the #583 Save As work. No behavior change — test cleanup only.

## Problem

`XChartPanelSaveTargetTest` reached `XChartPanel.SuffixSaveFilter` reflectively:

```java
Class<?> clazz = Class.forName("org.knowm.xchart.XChartPanel$SuffixSaveFilter");
Constructor<?> ctor = clazz.getDeclaredConstructor(String.class);
ctor.setAccessible(true);
```

Two things wrong with that:

- The class name is a string literal, so renaming or moving the class fails at **runtime** with `ClassNotFoundException` instead of at compile time.
- It's inconsistent within the same file. `resolveSaveTarget` and `suffixOf` are already package-private statics and the test calls them directly; only the filter was reached reflectively.

The constructor was already `public` — only the nested class was `private`, so `setAccessible` wasn't even the thing unblocking it.

## Change

Relax `SuffixSaveFilter` to package-private and construct it directly:

```java
private static FileFilter filter(String suffix) {
  return new XChartPanel.SuffixSaveFilter(suffix);
}
```

This matches the established idiom in the codebase — `internal/chartpart` has ~86 package-private members serving as test seams, and tests there read them directly (e.g. `RegressionTestIssue577` asserts on `legend.xOffset`). `SuffixSaveFilter` stays invisible to library users; it was already nested inside `XChartPanel` with no public exposure.

Also drops the now-unneeded `throws Exception` from the five test methods and the `java.lang.reflect.Constructor` import.

## Verification

Full `xchart` suite green (146 tests); `XChartPanelSaveTargetTest` itself runs 5/5. With this and #1009, no test in the tree uses reflection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)