### PR TITLE
Issue #589: let annotations target a Y-Axis group

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue589.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue589.java
@@ -1,0 +1,102 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.knowm.xchart.AnnotationLine;
+import org.knowm.xchart.AnnotationText;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
+import org.knowm.xchart.style.Styler.LegendPosition;
+import org.knowm.xchart.style.Styler.YAxisPosition;
+import org.knowm.xchart.style.markers.SeriesMarkers;
+
+/**
+ * Issue #589 — annotations could not be resolved against a secondary Y-Axis group.
+ *
+ * <p>Two series on wildly different scales: Temperature on group 0 (left, ~10–28 °C) and Barometric
+ * Pressure on group 1 (right, ~998–1022 hPa). Each gets a horizontal threshold line drawn at a value
+ * that is meaningful on ITS OWN axis.
+ *
+ * <p><b>Before the fix:</b> every annotation resolved its Y value through the group-0 axis, so the
+ * 1002 hPa line was interpreted on the 10–28 °C scale and flew far off the top of the plot — only
+ * the 22 °C line was visible, and there was no way to place the other one.
+ *
+ * <p><b>After the fix:</b> {@code setYAxisGroup(1)} puts the pressure threshold at 1002 hPa on the
+ * right-hand scale, cutting through the green pressure curve, while the temperature threshold stays
+ * on the left scale cutting through the red temperature curve.
+ *
+ * <p>Each line should intersect the curve of the same color-coded units it belongs to. If both lines
+ * land at the same height, or one is missing, the fix is not in effect.
+ */
+public class TestForIssue589 {
+
+  private static final double TEMP_THRESHOLD = 22.0; // °C, group 0 — "warm day"
+  private static final double PRESSURE_THRESHOLD = 1002.0; // hPa, group 1 — "storm watch"
+
+  public static XYChart getChart() {
+
+    int days = 30;
+    List<Double> x = new ArrayList<>();
+    List<Double> temperature = new ArrayList<>();
+    List<Double> pressure = new ArrayList<>();
+
+    for (int i = 0; i < days; i++) {
+      double t = i / (double) (days - 1); // 0.0 → 1.0
+      x.add((double) (i + 1));
+      // 10 °C – 28 °C
+      temperature.add(19.0 + 9.0 * Math.sin(2 * Math.PI * t - Math.PI / 2));
+      // 998 hPa – 1022 hPa
+      pressure.add(1010.0 + 12.0 * Math.cos(2 * Math.PI * t));
+    }
+
+    XYChart chart =
+        new XYChartBuilder()
+            .width(900)
+            .height(600)
+            .title("Issue #589 — each threshold line on its own Y-Axis group")
+            .xAxisTitle("Day")
+            .build();
+
+    chart.getStyler().setDefaultSeriesRenderStyle(XYSeriesRenderStyle.Line);
+    chart.getStyler().setLegendPosition(LegendPosition.InsideSW);
+    chart.getStyler().setAnnotationLineColor(Color.DARK_GRAY);
+
+    XYSeries tempSeries = chart.addSeries("Temperature (°C)", x, temperature);
+    tempSeries.setYAxisGroup(0);
+    tempSeries.setMarker(SeriesMarkers.NONE);
+    tempSeries.setLineColor(new Color(214, 39, 40)); // red
+
+    XYSeries pressureSeries = chart.addSeries("Pressure (hPa)", x, pressure);
+    pressureSeries.setYAxisGroup(1);
+    pressureSeries.setMarker(SeriesMarkers.NONE);
+    pressureSeries.setLineColor(new Color(44, 160, 44)); // green
+
+    chart.setYAxisGroupTitle(0, "°C");
+    chart.setYAxisGroupTitle(1, "hPa");
+    chart.getStyler().setYAxisGroupPosition(1, YAxisPosition.Right);
+
+    // ── The point of this demo ────────────────────────────────────────────
+    // Group 0 is the default, so this behaves exactly as it always has.
+    chart.addAnnotation(new AnnotationLine(TEMP_THRESHOLD, false, false));
+    chart.addAnnotation(
+        new AnnotationText(TEMP_THRESHOLD + " °C", 4.0, TEMP_THRESHOLD + 0.7, false));
+
+    // Group 1 is the new capability — without setYAxisGroup(1) this line would be
+    // interpreted on the temperature scale and land off the top of the plot.
+    chart.addAnnotation(new AnnotationLine(PRESSURE_THRESHOLD, false, false).setYAxisGroup(1));
+    chart.addAnnotation(
+        new AnnotationText(PRESSURE_THRESHOLD + " hPa", 26.0, PRESSURE_THRESHOLD + 1.0, false)
+            .setYAxisGroup(1));
+
+    return chart;
+  }
+
+  public static void main(String[] args) {
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/AnnotationImage.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationImage.java
@@ -55,15 +55,34 @@ public class AnnotationImage extends Annotation {
     bounds = new Rectangle2D.Double(xOffset, yOffset, image.getWidth(), image.getHeight());
   }
 
-  public void setImage(BufferedImage image) {
+  public AnnotationImage setImage(BufferedImage image) {
     this.image = image;
+    return this;
   }
 
-  public void setX(double x) {
+  public AnnotationImage setX(double x) {
     this.x = x;
+    return this;
   }
 
-  public void setY(double y) {
+  public AnnotationImage setY(double y) {
     this.y = y;
+    return this;
+  }
+
+  // Covariant overrides so base-class setters can appear anywhere in a chain
+
+  @Override
+  public AnnotationImage setYAxisGroup(int yAxisGroup) {
+
+    super.setYAxisGroup(yAxisGroup);
+    return this;
+  }
+
+  @Override
+  public AnnotationImage setVisible(boolean visible) {
+
+    super.setVisible(visible);
+    return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/AnnotationLine.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationLine.java
@@ -67,7 +67,24 @@ public class AnnotationLine extends Annotation {
         new Rectangle2D.Double(x1, y1, Math.max(x2 - x1, lineWidth), Math.max(y2 - y1, lineWidth));
   }
 
-  public void setValue(double value) {
+  public AnnotationLine setValue(double value) {
     this.value = value;
+    return this;
+  }
+
+  // Covariant overrides so base-class setters can appear anywhere in a chain
+
+  @Override
+  public AnnotationLine setYAxisGroup(int yAxisGroup) {
+
+    super.setYAxisGroup(yAxisGroup);
+    return this;
+  }
+
+  @Override
+  public AnnotationLine setVisible(boolean visible) {
+
+    super.setVisible(visible);
+    return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/AnnotationText.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationText.java
@@ -78,15 +78,34 @@ public class AnnotationText extends Annotation {
         new Rectangle2D.Double(xOffset, yOffset, textBounds.getWidth(), textBounds.getHeight());
   }
 
-  public void setText(String text) {
+  public AnnotationText setText(String text) {
     this.text = text;
+    return this;
   }
 
-  public void setX(double x) {
+  public AnnotationText setX(double x) {
     this.x = x;
+    return this;
   }
 
-  public void setY(double y) {
+  public AnnotationText setY(double y) {
     this.y = y;
+    return this;
+  }
+
+  // Covariant overrides so base-class setters can appear anywhere in a chain
+
+  @Override
+  public AnnotationText setYAxisGroup(int yAxisGroup) {
+
+    super.setYAxisGroup(yAxisGroup);
+    return this;
+  }
+
+  @Override
+  public AnnotationText setVisible(boolean visible) {
+
+    super.setVisible(visible);
+    return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/AnnotationTextPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/AnnotationTextPanel.java
@@ -148,15 +148,34 @@ public class AnnotationTextPanel extends Annotation {
     return textBounds;
   }
 
-  public void setLines(List<String> lines) {
+  public AnnotationTextPanel setLines(List<String> lines) {
     this.lines = lines;
+    return this;
   }
 
-  public void setX(double x) {
+  public AnnotationTextPanel setX(double x) {
     this.x = x;
+    return this;
   }
 
-  public void setY(double y) {
+  public AnnotationTextPanel setY(double y) {
     this.y = y;
+    return this;
+  }
+
+  // Covariant overrides so base-class setters can appear anywhere in a chain
+
+  @Override
+  public AnnotationTextPanel setYAxisGroup(int yAxisGroup) {
+
+    super.setYAxisGroup(yAxisGroup);
+    return this;
+  }
+
+  @Override
+  public AnnotationTextPanel setVisible(boolean visible) {
+
+    super.setVisible(visible);
+    return this;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Annotation.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Annotation.java
@@ -34,8 +34,10 @@ public abstract class Annotation implements ChartPart {
     return bounds;
   }
 
-  public void setVisible(boolean visible) {
+  public Annotation setVisible(boolean visible) {
+
     isVisible = visible;
+    return this;
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Annotation.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Annotation.java
@@ -8,6 +8,12 @@ public abstract class Annotation implements ChartPart {
   protected boolean isVisible = true;
   protected boolean isValueInScreenSpace;
 
+  /**
+   * The Y-Axis group this annotation's chart-space Y value is resolved against. Defaults to the
+   * primary group, {@code 0}, which matches the behavior before groups were supported.
+   */
+  protected int yAxisGroup = 0;
+
   protected AxesChart<?, ?> chart;
   protected Styler styler;
   protected Rectangle2D bounds;
@@ -32,12 +38,42 @@ public abstract class Annotation implements ChartPart {
     isVisible = visible;
   }
 
+  /**
+   * Sets the Y-Axis group whose scale this annotation's chart-space Y value is resolved against.
+   * Use this when the annotation belongs to a series placed on a secondary axis via {@code
+   * series.setYAxisGroup(int)}. Has no effect on annotations in screen space.
+   *
+   * @param yAxisGroup the Y-Axis group index; falls back to the primary axis if the group holds no
+   *     series
+   * @return this annotation, for chaining
+   */
+  public Annotation setYAxisGroup(int yAxisGroup) {
+
+    this.yAxisGroup = yAxisGroup;
+    return this;
+  }
+
+  public int getYAxisGroup() {
+
+    return yAxisGroup;
+  }
+
   protected int getXAxisScreenValue(double chartSpaceValue) {
     return (int) chart.getXAxis().getScreenValue(chartSpaceValue);
   }
 
   protected int getYAxisScreenValue(double chartSpaceValue) {
-    return (int) chart.getYAxis().getScreenValue(chartSpaceValue);
+    return (int) getYAxisForGroup().getScreenValue(chartSpaceValue);
+  }
+
+  /**
+   * Returns the Y-Axis for the configured group, or the primary Y-Axis when that group has no
+   * series and therefore no axis of its own.
+   */
+  private Axis_Y<?, ?> getYAxisForGroup() {
+
+    Axis_Y<?, ?> yAxis = chart.getYAxis(yAxisGroup);
+    return yAxis == null ? chart.getYAxis() : yAxis;
   }
 
   protected int getXAxisScreenValueForMax() {

--- a/xchart/src/test/java/org/knowm/xchart/AnnotationYAxisGroupTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/AnnotationYAxisGroupTest.java
@@ -1,0 +1,110 @@
+package org.knowm.xchart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
+
+/** Issue #589: annotations must be able to resolve their Y value against a secondary Y-Axis. */
+public class AnnotationYAxisGroupTest {
+
+  /** Group 0 spans 0..10, group 1 spans 0..1000, so the same value lands in different places. */
+  private XYChart buildTwoAxisChart() {
+
+    XYChart chart = new XYChartBuilder().width(800).height(600).build();
+    chart.addSeries("small", new double[] {0.0, 1.0, 2.0}, new double[] {0.0, 5.0, 10.0});
+    XYSeries big =
+        chart.addSeries("big", new double[] {0.0, 1.0, 2.0}, new double[] {0.0, 500.0, 1000.0});
+    big.setYAxisGroup(1);
+    chart.setYAxisGroupTitle(1, "big");
+    return chart;
+  }
+
+  private void render(XYChart chart) throws IOException {
+
+    OutputStream output = new ByteArrayOutputStream();
+    ChartEncoder.saveChart(chart, output, "png");
+  }
+
+  @Test
+  public void annotationLineHonorsYAxisGroup() throws IOException {
+
+    // given
+    XYChart chart = buildTwoAxisChart();
+    AnnotationLine onPrimary = new AnnotationLine(5.0, false, false);
+    AnnotationLine onSecondary = new AnnotationLine(5.0, false, false);
+    onSecondary.setYAxisGroup(1);
+    chart.addAnnotation(onPrimary);
+    chart.addAnnotation(onSecondary);
+
+    // when
+    render(chart);
+
+    // test - the value 5.0 is mid-range on group 0 but near the bottom on group 1
+    assertEquals(
+        (int) chart.getScreenYFromChart(5.0, 0), (int) onPrimary.getBounds().getY(), 1.0);
+    assertEquals(
+        (int) chart.getScreenYFromChart(5.0, 1), (int) onSecondary.getBounds().getY(), 1.0);
+    assertNotEquals(onPrimary.getBounds().getY(), onSecondary.getBounds().getY());
+  }
+
+  @Test
+  public void annotationTextHonorsYAxisGroup() throws IOException {
+
+    // given
+    XYChart chart = buildTwoAxisChart();
+    // same text, so any X difference would come from the axis lookup, not glyph widths
+    AnnotationText onPrimary = new AnnotationText("mark", 1.0, 5.0, false);
+    AnnotationText onSecondary = new AnnotationText("mark", 1.0, 5.0, false);
+    onSecondary.setYAxisGroup(1);
+    chart.addAnnotation(onPrimary);
+    chart.addAnnotation(onSecondary);
+
+    // when
+    render(chart);
+
+    // test
+    assertEquals(onPrimary.getBounds().getX(), onSecondary.getBounds().getX(), 0.001);
+    assertNotEquals(onPrimary.getBounds().getY(), onSecondary.getBounds().getY());
+  }
+
+  @Test
+  public void defaultsToPrimaryAxis() throws IOException {
+
+    // given
+    XYChart chart = buildTwoAxisChart();
+    AnnotationLine defaulted = new AnnotationLine(5.0, false, false);
+    AnnotationLine explicitPrimary = new AnnotationLine(5.0, false, false);
+    explicitPrimary.setYAxisGroup(0);
+    chart.addAnnotation(defaulted);
+    chart.addAnnotation(explicitPrimary);
+
+    // when
+    render(chart);
+
+    // test
+    assertEquals(0, defaulted.getYAxisGroup());
+    assertEquals(explicitPrimary.getBounds().getY(), defaulted.getBounds().getY(), 0.001);
+  }
+
+  @Test
+  public void unknownGroupFallsBackToPrimaryAxis() throws IOException {
+
+    // given
+    XYChart chart = buildTwoAxisChart();
+    AnnotationLine onPrimary = new AnnotationLine(5.0, false, false);
+    AnnotationLine onMissingGroup = new AnnotationLine(5.0, false, false);
+    onMissingGroup.setYAxisGroup(7); // no series uses group 7
+    chart.addAnnotation(onPrimary);
+    chart.addAnnotation(onMissingGroup);
+
+    // when
+    render(chart);
+
+    // test - no NPE, and it lands on the primary axis
+    assertEquals(onPrimary.getBounds().getY(), onMissingGroup.getBounds().getY(), 0.001);
+  }
+}

--- a/xchart/src/test/java/org/knowm/xchart/AnnotationYAxisGroupTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/AnnotationYAxisGroupTest.java
@@ -107,4 +107,25 @@ public class AnnotationYAxisGroupTest {
     // test - no NPE, and it lands on the primary axis
     assertEquals(onPrimary.getBounds().getY(), onMissingGroup.getBounds().getY(), 0.001);
   }
+
+  @Test
+  public void settersChainInEitherOrder() throws IOException {
+
+    // given - base-class setters before and after subclass-specific ones
+    XYChart chart = buildTwoAxisChart();
+    AnnotationLine a = new AnnotationLine(0.0, false, false).setYAxisGroup(1).setValue(5.0);
+    AnnotationLine b = new AnnotationLine(0.0, false, false).setValue(5.0).setYAxisGroup(1);
+    AnnotationText c = new AnnotationText("x", 1.0, 0.0, false).setVisible(true).setY(5.0);
+    chart.addAnnotation(a);
+    chart.addAnnotation(b);
+    chart.addAnnotation(c);
+
+    // when
+    render(chart);
+
+    // test
+    assertEquals(a.getBounds().getY(), b.getBounds().getY(), 0.001);
+    assertEquals(1, a.getYAxisGroup());
+    assertEquals(1, b.getYAxisGroup());
+  }
 }


### PR DESCRIPTION
Fixes #589.

## Problem

When a series is put on a secondary axis with `series.setYAxisGroup(2)`, there was no way to make an annotation resolve its value against that group. `Annotation.getYAxisScreenValue()` went through the no-arg `chart.getYAxis()`, which is hardwired to group 0, so the annotation's Y value was always interpreted in the primary axis' scale.

## Change

`Annotation` gains a `yAxisGroup` field with a fluent setter, defaulting to `0`:

```java
chart.addAnnotation(new AnnotationLine(1002.0, false, false).setYAxisGroup(1));
```

The lookup now goes through `chart.getYAxis(yAxisGroup)`. This benefits every annotation type that places a chart-space Y value — `AnnotationLine` (horizontal), `AnnotationText`, `AnnotationImage`, and `AnnotationTextPanel` — since they all share the base-class helper.

`AxisPair.getYAxis(int)` returns `null` for a group that holds no series, so the helper falls back to the primary axis instead of throwing an NPE.

## Chainable setters

Every setter on the annotation classes now returns the object instead of `void`, so calls can be chained. Subclass setters return the subclass type, and `setVisible`/`setYAxisGroup` have covariant overrides in each subclass, so base-class setters can appear anywhere in a chain:

```java
new AnnotationLine(0, false, false).setYAxisGroup(1).setValue(1002.0);
new AnnotationLine(0, false, false).setValue(1002.0).setYAxisGroup(1);
```

This changes the return type of the existing `setVisible`, `setValue`, `setText`, `setX`, `setY`, `setLines`, and `setImage`. Source-compatible, but not binary-compatible for pre-compiled callers — fine for a 4.0.x release.

## Compatibility

The `yAxisGroup` default of `0` reproduces the previous rendering exactly, so no existing chart changes and no deprecation cycle is needed.

## Demo

`TestForIssue589` in `xchart-demo` puts Temperature (group 0, left, 10–28 °C) and Barometric Pressure (group 1, right, 998–1022 hPa) on one chart and draws a threshold line on each at a value meaningful on its own axis. The `xchart-site` generator picks it up automatically and renders it on the fixes page.

The 22 °C line lands on the left scale and the 1002 hPa line on the right, well separated. Before the fix, the 1002 hPa line would have been resolved on the °C scale and flown off the top of the plot.

## Tests

New `AnnotationYAxisGroupTest` builds a chart with group 0 spanning 0..10 and group 1 spanning 0..1000, then asserts that the same value renders at different screen positions per group, that positions match `getScreenYFromChart(value, group)`, that the default is group 0, that an unknown group falls back without throwing, and that setters chain in either order. Full `xchart` suite passes (152 tests), and all modules build.

## Note for the reporter

The snippet in the issue, `new AnnotationLine(y, true, false)`, passes `isVertical=true`, which resolves the value on the **X** axis — that draws a vertical line at x=y. For a horizontal line at a Y value, pass `isVertical=false`. That's separate from the gap this PR closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)