### PR TITLE
Issue #594: fix demo chart scan when the project path contains a space

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/DemoChartsUtil.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/DemoChartsUtil.java
@@ -1,7 +1,6 @@
 package org.knowm.xchart.demo;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,17 +20,24 @@ public class DemoChartsUtil {
 
   public static List<ExampleChart<Chart<Styler, Series>>> getAllDemoCharts() {
 
-    List<ExampleChart<Chart<Styler, Series>>> demoCharts = null;
     String packagePath = DEMO_CHARTS_PACKAGE.replace(".", "/");
     ClassLoader loader = Thread.currentThread().getContextClassLoader();
     URL url = loader.getResource(packagePath);
 
-    if (url != null) {
-      try {
-        demoCharts = getAllDemoCharts(url);
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+    if (url == null) {
+      throw new IllegalStateException(
+          "Could not find the demo charts package on the classpath: " + DEMO_CHARTS_PACKAGE);
+    }
+
+    List<ExampleChart<Chart<Styler, Series>>> demoCharts;
+    try {
+      demoCharts = getAllDemoCharts(url);
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not load the demo charts from: " + url, e);
+    }
+
+    if (demoCharts.isEmpty()) {
+      throw new IllegalStateException("No demo charts were found at: " + url);
     }
 
     return demoCharts;
@@ -61,16 +67,17 @@ public class DemoChartsUtil {
     return demoCharts;
   }
 
-  private static List<Class<?>> getAllAssignedClasses(URL url)
-      throws ClassNotFoundException, IOException {
+  private static List<Class<?>> getAllAssignedClasses(URL url) throws Exception {
 
     List<Class<?>> classes = null;
 
+    // Note: go through URI rather than URL.getFile(), which hands back a percent-encoded path and
+    // so resolves to a non-existent directory whenever the project path contains a space.
     String type = url.getProtocol();
     if ("file".equals(type)) {
-      classes = getClassesByFile(new File(url.getFile()), DEMO_CHARTS_PACKAGE);
+      classes = getClassesByFile(new File(url.toURI()), DEMO_CHARTS_PACKAGE);
     } else if ("jar".equals(type)) {
-      classes = getClassesByJar(url.getPath());
+      classes = getClassesByJar(url);
     }
     List<Class<?>> allAssignedClasses = new ArrayList<>();
     if (classes != null) {
@@ -91,8 +98,13 @@ public class DemoChartsUtil {
       return classes;
     }
 
+    File[] files = dir.listFiles();
+    if (files == null) {
+      return classes;
+    }
+
     String fileName = "";
-    for (File f : dir.listFiles()) {
+    for (File f : files) {
       fileName = f.getName();
       if (f.isDirectory()) {
         classes.addAll(getClassesByFile(f, pk + "." + fileName));
@@ -105,24 +117,26 @@ public class DemoChartsUtil {
     return classes;
   }
 
-  @SuppressWarnings("resource")
-  private static List<Class<?>> getClassesByJar(String jarPath)
-      throws IOException, ClassNotFoundException {
+  private static List<Class<?>> getClassesByJar(URL url) throws Exception {
 
     List<Class<?>> classes = new ArrayList<>();
-    String[] jarInfo = jarPath.split("!");
-    String jarFilePath = jarInfo[0].substring(jarInfo[0].indexOf("/"));
+    String[] jarInfo = url.getPath().split("!");
+    // the jar part is itself a URL, so let File decode it rather than chopping off the scheme by
+    // hand - that keeps paths containing spaces (and Windows drive letters) intact
+    File jarFilePath = new File(new URL(jarInfo[0]).toURI());
     String packagePath = jarInfo[1].substring(1);
-    Enumeration<JarEntry> entrys = new JarFile(jarFilePath).entries();
-    JarEntry jarEntry = null;
-    String entryName = "";
-    String className = "";
-    while (entrys.hasMoreElements()) {
-      jarEntry = entrys.nextElement();
-      entryName = jarEntry.getName();
-      if (entryName.endsWith(".class") && entryName.startsWith(packagePath)) {
-        className = entryName.replace("/", ".").substring(0, entryName.lastIndexOf("."));
-        classes.add(Class.forName(className));
+    try (JarFile jarFile = new JarFile(jarFilePath)) {
+      Enumeration<JarEntry> entrys = jarFile.entries();
+      JarEntry jarEntry = null;
+      String entryName = "";
+      String className = "";
+      while (entrys.hasMoreElements()) {
+        jarEntry = entrys.nextElement();
+        entryName = jarEntry.getName();
+        if (entryName.endsWith(".class") && entryName.startsWith(packagePath)) {
+          className = entryName.replace("/", ".").substring(0, entryName.lastIndexOf("."));
+          classes.add(Class.forName(className));
+        }
       }
     }
     return classes;

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartDemo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartDemo.java
@@ -82,8 +82,9 @@ public class XChartDemo extends JPanel implements TreeSelectionListener {
     }
 
     Object nodeInfo = node.getUserObject();
-    // tree leaf
-    if (node.isLeaf()) {
+    // tree leaf. Category and root nodes carry a String rather than a ChartInfo, and either can be
+    // a leaf if no charts were found, so check the type instead of assuming leaf == chart.
+    if (node.isLeaf() && nodeInfo instanceof ChartInfo) {
       ChartInfo chartInfo = (ChartInfo) nodeInfo;
       // displayURL(chartInfo.bookURL);
       ExampleChart<?> exampleChart = chartInfo.getExampleChart();

--- a/xchart-demo/src/test/java/org/knowm/xchart/DemoChartsTest.java
+++ b/xchart-demo/src/test/java/org/knowm/xchart/DemoChartsTest.java
@@ -47,7 +47,7 @@ public class DemoChartsTest {
   }
 
   private void configureInteractiveFeatures(Chart chart) {
-    new ToolTips(chart);
+    new ToolTips(chart, false, ToolTipType.xAndYLabels);
     if (chart instanceof XYChart && chart.getStyler() instanceof XYStyler) {
       new Cursor(chart);
     }

--- a/xchart-demo/src/test/java/org/knowm/xchart/DemoChartsUtilTest.java
+++ b/xchart-demo/src/test/java/org/knowm/xchart/DemoChartsUtilTest.java
@@ -1,0 +1,84 @@
+package org.knowm.xchart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.demo.DemoChartsUtil;
+
+/**
+ * Regression test for <a href="https://github.com/knowm/XChart/issues/594">issue #594</a>: the demo
+ * chart scan silently found nothing when the project path contained a space, because it resolved
+ * the package directory from the percent-encoded {@code URL.getFile()}.
+ */
+public class DemoChartsUtilTest {
+
+  private static final String DEMO_CHARTS_PACKAGE_PATH = "org/knowm/xchart/demo/charts";
+
+  @Test
+  public void shouldFindDemoChartsWhenClasspathContainsASpace() throws Exception {
+
+    Path classesRoot = Files.createTempDirectory("xchart demo classes");
+    ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      assertThat(classesRoot.toString()).contains(" ");
+      copyDemoChartClasses(classesRoot.resolve(DEMO_CHARTS_PACKAGE_PATH));
+
+      // a null parent stops the lookup delegating back to the real, space-free classpath
+      URLClassLoader classLoader =
+          new URLClassLoader(new URL[] {classesRoot.toUri().toURL()}, null);
+      Thread.currentThread().setContextClassLoader(classLoader);
+
+      assertThat(DemoChartsUtil.getAllDemoCharts()).isNotEmpty();
+
+      classLoader.close();
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+      deleteRecursively(classesRoot);
+    }
+  }
+
+  /**
+   * Copies the compiled demo chart classes to {@code target} so they can be discovered through a
+   * path containing a space. The classes are only ever <em>found</em> there - loading them still
+   * goes through the class loader that owns this test.
+   */
+  private void copyDemoChartClasses(Path target) throws Exception {
+
+    URL url =
+        Thread.currentThread().getContextClassLoader().getResource(DEMO_CHARTS_PACKAGE_PATH);
+    assertThat(url).isNotNull();
+    // only meaningful when the demo classes sit in a directory, as they do during a build
+    assumeTrue("file".equals(url.getProtocol()));
+
+    Path source = new File(url.toURI()).toPath();
+    Files.createDirectories(target);
+    try (Stream<Path> sources = Files.walk(source)) {
+      for (Path path : (Iterable<Path>) sources::iterator) {
+        Path destination = target.resolve(source.relativize(path).toString());
+        if (Files.isDirectory(path)) {
+          Files.createDirectories(destination);
+        } else {
+          Files.copy(path, destination);
+        }
+      }
+    }
+  }
+
+  private void deleteRecursively(Path path) throws IOException {
+
+    try (Stream<Path> paths = Files.walk(path)) {
+      for (Path each : (Iterable<Path>) paths.sorted(Comparator.reverseOrder())::iterator) {
+        Files.deleteIfExists(each);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #594.

## The bug

The reporter's classpath was `E:\FEE\2nd Term\XChart\...` — note the space in `2nd Term`. That space is the whole story:

1. `DemoChartsUtil` resolved the chart package directory with `new File(url.getFile())`. `URL.getFile()` returns a **percent-encoded** path, so the space came back as `%20` and the `File` pointed at a directory that does not exist.
2. `getClassesByFile` returned an empty list on `!dir.exists()` — silently. No charts discovered.
3. `XChartDemo.createNodes` therefore built a tree with no children, leaving the root node `"XChart Example Charts"` (a `String` user object) as a leaf.
4. Clicking it hit `valueChanged`, which casts *any* leaf's user object to `ChartInfo` → `ClassCastException: String cannot be cast to ChartInfo`.

Verified directly:

```
url                              = file:/tmp/2nd%20Term/foo/
new File(url.getFile()).exists() = false
new File(url.toURI()).exists()   = true
```

This also explains the issue title — the tree looks empty, so users see no "file explorer".

## Changes

- **Resolve through `URI`, not `getFile()`** — for both the `file` and `jar` branches. The jar path is itself a URL, so it goes through `new File(new URL(...).toURI())` rather than being chopped at the first `/`, which keeps spaces *and* Windows drive letters intact. The `JarFile` is now closed via try-with-resources (dropping the `@SuppressWarnings("resource")`).
- **Fail loudly** — `getAllDemoCharts()` used to return `null` when the package was missing (an NPE waiting to happen in `createNodes`) and an empty list when nothing was found. Both now throw `IllegalStateException` with the offending URL, so this is diagnosable instead of mysterious.
- **Guard the cast** — `valueChanged` now checks `nodeInfo instanceof ChartInfo`. Category and root nodes carry a `String`, and either can be a leaf; that should not kill the EDT.
- Null-guard on `dir.listFiles()`.

## Test

`DemoChartsUtilTest` copies the compiled demo classes into a temp directory whose name contains a space, points a parent-less `URLClassLoader` at it, and asserts the scan still finds charts. Confirmed red before the fix and green after:

```
# before
java.lang.IllegalStateException: No demo charts were found at:
  file:/var/folders/.../xchart%20demo%20classes.../org/knowm/xchart/demo/charts
# after
Tests run: 81, Failures: 0, Errors: 0, Skipped: 0
```

## Two things worth flagging

- `DemoChartsTest` had stopped compiling — it calls `new ToolTips(chart)`, but that constructor now takes `(Chart, boolean, ToolTipType)`. Repaired here as a one-liner, since it blocked running any test in this module.
- The reason nobody noticed is that **`xchart-demo` sets `<maven.test.skip>true</maven.test.skip>`** in its pom and CI never overrides it, so none of this module's tests — including the new one — run in CI. I left that alone as out of scope for this issue, but it's worth deciding on separately: the comment says it exists to skip test compilation during `release:prepare`, which a release-profile-scoped setting could handle without disabling the tests everywhere.

Verified locally with `mvn -pl xchart-demo test -Dmaven.test.skip=false`: 81 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
