### PR TITLE
Scope the xchart-demo test skip to the release build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,8 @@
                 <version>3.1.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <!-- activates the xchart-demo skip-demo-tests profile in the forked builds -->
+                    <arguments>-DskipDemoTests=true</arguments>
                 </configuration>
             </plugin>
             <plugin>

--- a/xchart-demo/pom.xml
+++ b/xchart-demo/pom.xml
@@ -13,10 +13,22 @@
     <name>XChart Demo</name>
     <description>A Swing App demonstration of various charts using XChart</description>
 
-    <properties>
-        <!-- skip test compilation during release:prepare's clean verify subprocess -->
-        <maven.test.skip>true</maven.test.skip>
-    </properties>
+    <profiles>
+        <!-- Skip test compilation during release:prepare's clean verify subprocess. The release
+             plugin passes -DskipDemoTests (see the root pom), so this stays scoped to the release
+             instead of disabling this module's tests for every build and for CI. -->
+        <profile>
+            <id>skip-demo-tests</id>
+            <activation>
+                <property>
+                    <name>skipDemoTests</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
     <dependencies>
         <dependency>
             <groupId>org.knowm.xchart</groupId>


### PR DESCRIPTION
Follow-up to #1013, which surfaced this. **Based on that branch — merge #1013 first**, and GitHub will retarget this to `develop` automatically.

## Problem

`xchart-demo/pom.xml` set `maven.test.skip=true` as a module-wide property. The intent (per the comment, added in f0936f86) was narrow: stop `release:prepare`'s `clean verify` subprocess from compiling tests. The effect was broad — the module's **81 tests never ran in any build, including CI**. Neither workflow overrides the property, so `mvn clean verify` on a PR silently skipped the whole module.

That is precisely how `DemoChartsTest` got to sit broken. It stopped compiling on 2026-05-22 when the `ToolTips` constructor gained parameters — one day *after* the skip landed. Nothing was there to catch it.

## Change

Move the skip into a profile activated by a property, and have the release plugin pass that property to its forked builds:

```xml
<!-- xchart-demo/pom.xml -->
<profile>
  <id>skip-demo-tests</id>
  <activation><property><name>skipDemoTests</name></property></activation>
  <properties><maven.test.skip>true</maven.test.skip></properties>
</profile>
```
```xml
<!-- pom.xml, maven-release-plugin -->
<arguments>-DskipDemoTests=true</arguments>
```

`release:prepare` behaves exactly as it does today. Every other build runs the tests.

I deliberately did **not** reach for `<arguments>-Dmaven.test.skip=true</arguments>` on its own, since that would skip the `xchart` module's 154 tests during release too — a weaker release gate than what's in place now.

## Verification

Both directions, plus the exact command CI runs:

```
mvn -pl xchart-demo test                      → Tests run: 81, Failures: 0, Errors: 0
mvn -pl xchart-demo test -DskipDemoTests=true → Tests are skipped.  BUILD SUCCESS

mvn clean verify -Dmaven.javadoc.skip=true -Dfmt.skip=true
  xchart      → Tests run: 154, Failures: 0, Errors: 0
  xchart-demo → Tests run: 81,  Failures: 0, Errors: 0
  BUILD SUCCESS
```

Since this newly exposes 80 rendering tests to CI, I also ran them under `-Djava.awt.headless=true`: all 81 pass. (`DateChart01` was already excluded in `SKIPPED_EXAMPLE_CHARTS` for headless reasons.)

One thing I could not verify: I have no way to run an actual `release:prepare` here, so the release path is reasoned from the plugin's `arguments` semantics and the property-activation test above rather than observed end to end. Worth a dry run before the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
