### PR TITLE
Issue #868: resolve styler locale at paint time in number formatting

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue868.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue868.java
@@ -1,0 +1,50 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Locale;
+import org.knowm.xchart.PieChart;
+import org.knowm.xchart.PieChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.PieStyler.LabelType;
+
+/**
+ * Demonstrates issue #868 — the locale set on the {@code PieStyler} now takes effect on slice
+ * labels and tooltips.
+ *
+ * <p>Previously, {@code PlotContent_Pie} captured the styler's locale in its constructor, which
+ * runs inside the {@code PieChart} constructor. Since {@code setLocale(...)} can only ever be
+ * called after the chart is constructed, it was effectively a no-op for pie charts and the decimal
+ * separator always followed the JVM default locale. The {@code DecimalFormat} is now built at paint
+ * time from the styler's current locale and decimal pattern, so both {@code setLocale(...)} and a
+ * custom localized pattern work.
+ *
+ * <p>This demo sets {@link Locale#GERMANY} after construction: the percentage labels should render
+ * with a comma decimal separator (e.g. "33,3%") regardless of the system locale.
+ */
+public class TestForIssue868 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static PieChart getChart() {
+
+    PieChart chart =
+        new PieChartBuilder()
+            .width(700)
+            .height(400)
+            .title("Issue #868 – Pie chart locale set after construction (de_DE)")
+            .build();
+
+    // Set after construction — the point of issue #868.
+    chart.getStyler().setLocale(Locale.GERMANY);
+    chart.getStyler().setLabelType(LabelType.Percentage);
+    chart.getStyler().setDecimalPattern("#0.0");
+
+    chart.addSeries("Gold", 24);
+    chart.addSeries("Silver", 21);
+    chart.addSeries("Platinum", 39);
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_HeatMap.java
@@ -11,6 +11,7 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.Format;
 import java.util.function.BiFunction;
 import org.knowm.xchart.HeatMapChart;
@@ -440,7 +441,9 @@ public class Legend_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeries>
     if (chart.getStyler().getHeatMapDecimalValueFormatter() != null) {
       format = new Formatter_Custom(chart.getStyler().getHeatMapDecimalValueFormatter());
     } else {
-      format = new DecimalFormat("");
+      // Build the format at paint time so that a locale set on the styler after chart construction
+      // is respected (issue #868).
+      format = new DecimalFormat("", new DecimalFormatSymbols(chart.getStyler().getLocale()));
       if (chart.getStyler().getHeatMapValueDecimalPattern() != null) {
         ((DecimalFormat) format).applyPattern(chart.getStyler().getHeatMapValueDecimalPattern());
       }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Dial.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Dial.java
@@ -8,6 +8,7 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Map;
 import org.knowm.xchart.DialSeries;
@@ -17,7 +18,7 @@ public class PlotContent_Dial<ST extends DialStyler, S extends DialSeries>
     extends PlotContent_<ST, S> {
 
   private final ST styler;
-  private final NumberFormat df = DecimalFormat.getPercentInstance();
+  private NumberFormat df;
   private double height_r;
 
   PlotContent_Dial(Chart<ST, S> chart) {
@@ -28,6 +29,10 @@ public class PlotContent_Dial<ST extends DialStyler, S extends DialSeries>
 
   @Override
   public void doPaint(Graphics2D g) {
+
+    // Build the format at paint time so that a locale set on the styler after chart construction
+    // is respected (issue #868).
+    df = NumberFormat.getPercentInstance(styler.getLocale());
 
     Rectangle2D pieBounds = getPieBounds();
 
@@ -175,7 +180,9 @@ public class PlotContent_Dial<ST extends DialStyler, S extends DialSeries>
         String label = series.getLabel();
         if (label == null) {
           if (styler.getDecimalPattern() != null) {
-            DecimalFormat df = new DecimalFormat(styler.getDecimalPattern());
+            DecimalFormat df =
+                new DecimalFormat(
+                    styler.getDecimalPattern(), new DecimalFormatSymbols(styler.getLocale()));
             label = df.format(value);
           } else {
             label = df.format(value);
@@ -227,7 +234,9 @@ public class PlotContent_Dial<ST extends DialStyler, S extends DialSeries>
         String label = series.getLabel();
         if (label == null) {
           if (styler.getDecimalPattern() != null) {
-            DecimalFormat df = new DecimalFormat(styler.getDecimalPattern());
+            DecimalFormat df =
+                new DecimalFormat(
+                    styler.getDecimalPattern(), new DecimalFormatSymbols(styler.getLocale()));
             label = df.format(value);
           } else {
             label = df.format(value);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_HeatMap.java
@@ -7,6 +7,7 @@ import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.List;
 import org.knowm.xchart.HeatMapChart;
 import org.knowm.xchart.HeatMapSeries;
@@ -18,7 +19,7 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
 
   private final ST heatMapStyler;
   private final AxesChart<ST, S> axesChart;
-  private final DecimalFormat df = new DecimalFormat("");
+  private DecimalFormat df;
 
   /**
    * Constructor
@@ -43,6 +44,9 @@ public class PlotContent_HeatMap<ST extends HeatMapStyler, S extends HeatMapSeri
     double yTickSpace = heatMapStyler.getPlotContentSize() * getBounds().getHeight();
     double yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
 
+    // Build the format at paint time so that a locale set on the styler after chart construction
+    // is respected (issue #868).
+    df = new DecimalFormat("", new DecimalFormatSymbols(heatMapStyler.getLocale()));
     if (heatMapStyler.getHeatMapValueDecimalPattern() != null) {
       df.applyPattern(heatMapStyler.getHeatMapValueDecimalPattern());
     }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -18,7 +18,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
     extends PlotContent_<ST, S> {
 
   private final ST pieStyler;
-  private final DecimalFormat df;
+  private DecimalFormat df;
 
   /**
    * Constructor
@@ -29,7 +29,6 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
 
     super(chart);
     pieStyler = chart.getStyler();
-    df = new DecimalFormat("#.0", new DecimalFormatSymbols(pieStyler.getLocale()));
   }
 
   // TODO get rid of this
@@ -79,10 +78,10 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
   @Override
   public void doPaint(Graphics2D g) {
 
-    // Apply the given pattern to decimalPattern if decimalPattern is not null
-    if (pieStyler.getDecimalPattern() != null) {
-      df.applyPattern(pieStyler.getDecimalPattern());
-    }
+    // Build the format at paint time so that a locale or pattern set on the styler after chart
+    // construction is respected (issue #868).
+    String pattern = pieStyler.getDecimalPattern() != null ? pieStyler.getDecimalPattern() : "#.0";
+    df = new DecimalFormat(pattern, new DecimalFormatSymbols(pieStyler.getLocale()));
 
     // pie getBounds()
     double pieFillPercentage = pieStyler.getPlotContentSize();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -272,11 +272,9 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
         String label = "";
         if (pieStyler.getLabelType() == LabelType.Value) {
 
-          if (pieStyler.getDecimalPattern() != null) {
-            label = df.format(y);
-          } else {
-            label = y.toString();
-          }
+          // Always format via df (not y.toString()) so the styler locale is respected and the
+          // label matches the tooltip, which also formats via df (issue #868).
+          label = df.format(y);
         } else if (pieStyler.getLabelType() == LabelType.Name) {
           label = series.getName();
         } else if (pieStyler.getLabelType() == LabelType.NameAndPercentage) {
@@ -286,11 +284,7 @@ public class PlotContent_Pie<ST extends PieStyler, S extends PieSeries>
           double percentage = y.doubleValue() / total * 100;
           label = df.format(percentage) + "%";
         } else if (pieStyler.getLabelType() == LabelType.NameAndValue) {
-          if (pieStyler.getDecimalPattern() != null) {
-            label = series.getName() + " (" + df.format(y) + ")";
-          } else {
-            label = series.getName() + " (" + y.toString() + ")";
-          }
+          label = series.getName() + " (" + df.format(y) + ")";
         } else if (pieStyler.getCustomSeriesLabelFunction() != null) {
           label = pieStyler.getCustomSeriesLabelFunction().apply(series);
         }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
@@ -10,6 +10,7 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Map;
 import org.knowm.xchart.RadarChart;
@@ -20,7 +21,6 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
     extends PlotContent_<ST, S> {
 
   private final RadarStyler styler;
-  private static final NumberFormat df = DecimalFormat.getPercentInstance();
 
   /**
    * Constructor
@@ -198,8 +198,13 @@ public class PlotContent_Radar<ST extends RadarStyler, S extends RadarSeries>
     }
 
     // series lines and markers and Tooltips
+    // Build the format at paint time so that a locale set on the styler after chart construction
+    // is respected (issue #868).
     NumberFormat decimalFormat =
-        (styler.getDecimalPattern() == null) ? df : new DecimalFormat(styler.getDecimalPattern());
+        (styler.getDecimalPattern() == null)
+            ? NumberFormat.getPercentInstance(styler.getLocale())
+            : new DecimalFormat(
+                styler.getDecimalPattern(), new DecimalFormatSymbols(styler.getLocale()));
     Map<String, S> map = chart.getSeriesMap();
     for (S series : map.values()) {
 

--- a/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue868.java
+++ b/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue868.java
@@ -1,0 +1,79 @@
+package org.knowm.xchart.regressiontests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.image.BufferedImage;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.PieChart;
+import org.knowm.xchart.PieChartBuilder;
+import org.knowm.xchart.style.PieStyler.LabelType;
+
+/**
+ * Regression test for <a href="https://github.com/knowm/XChart/issues/868">issue 868</a>: the pie
+ * chart froze its {@code DecimalFormat} symbols at chart construction time, so {@code
+ * setLocale(...)} on the styler — which can only ever be called after construction — had no effect
+ * on slice labels. The format is now built at paint time from the styler's current locale and
+ * decimal pattern.
+ */
+public class RegressionTestIssue868 {
+
+  @Test
+  public void localeSetAfterConstructionAffectsPieLabels() {
+
+    // Percentage labels always go through the DecimalFormat: "30,9%" vs "30.9%"
+    BufferedImage german = renderPie(Locale.GERMANY, null);
+    BufferedImage us = renderPie(Locale.US, null);
+
+    assertThat(imagesEqual(german, us)).isFalse();
+  }
+
+  @Test
+  public void customDecimalPatternUsesStylerLocaleSymbols() {
+
+    // "30,86%" vs "30.86%" in the slice labels, formatted with the custom pattern
+    BufferedImage german = renderPie(Locale.GERMANY, "#0.00");
+    BufferedImage us = renderPie(Locale.US, "#0.00");
+
+    assertThat(imagesEqual(german, us)).isFalse();
+  }
+
+  @Test
+  public void sameLocaleRendersIdentically() {
+
+    // Guards the two tests above against false positives from non-deterministic rendering.
+    BufferedImage a = renderPie(Locale.GERMANY, null);
+    BufferedImage b = renderPie(Locale.GERMANY, null);
+
+    assertThat(imagesEqual(a, b)).isTrue();
+  }
+
+  private static BufferedImage renderPie(Locale locale, String decimalPattern) {
+
+    PieChart chart = new PieChartBuilder().width(400).height(300).build();
+    // The point of issue #868: the locale can only be set after the chart is constructed.
+    chart.getStyler().setLocale(locale);
+    chart.getStyler().setLabelType(LabelType.Percentage);
+    chart.getStyler().setDecimalPattern(decimalPattern);
+    chart.getStyler().setLegendVisible(false);
+    chart.addSeries("a", 1234.5);
+    chart.addSeries("b", 2765.5);
+    return BitmapEncoder.getBufferedImage(chart);
+  }
+
+  private static boolean imagesEqual(BufferedImage a, BufferedImage b) {
+
+    if (a.getWidth() != b.getWidth() || a.getHeight() != b.getHeight()) {
+      return false;
+    }
+    for (int y = 0; y < a.getHeight(); y++) {
+      for (int x = 0; x < a.getWidth(); x++) {
+        if (a.getRGB(x, y) != b.getRGB(x, y)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue868.java
+++ b/xchart/src/test/java/org/knowm/xchart/regressiontests/RegressionTestIssue868.java
@@ -30,6 +30,17 @@ public class RegressionTestIssue868 {
   }
 
   @Test
+  public void valueLabelsWithoutPatternUseStylerLocale() {
+
+    // Value labels used to bypass the DecimalFormat via y.toString() when no decimal pattern was
+    // set; they now always go through the format: "1234,5" vs "1234.5"
+    BufferedImage german = renderPie(Locale.GERMANY, null, LabelType.Value);
+    BufferedImage us = renderPie(Locale.US, null, LabelType.Value);
+
+    assertThat(imagesEqual(german, us)).isFalse();
+  }
+
+  @Test
   public void customDecimalPatternUsesStylerLocaleSymbols() {
 
     // "30,86%" vs "30.86%" in the slice labels, formatted with the custom pattern
@@ -50,11 +61,16 @@ public class RegressionTestIssue868 {
   }
 
   private static BufferedImage renderPie(Locale locale, String decimalPattern) {
+    return renderPie(locale, decimalPattern, LabelType.Percentage);
+  }
+
+  private static BufferedImage renderPie(
+      Locale locale, String decimalPattern, LabelType labelType) {
 
     PieChart chart = new PieChartBuilder().width(400).height(300).build();
     // The point of issue #868: the locale can only be set after the chart is constructed.
     chart.getStyler().setLocale(locale);
-    chart.getStyler().setLabelType(LabelType.Percentage);
+    chart.getStyler().setLabelType(labelType);
     chart.getStyler().setDecimalPattern(decimalPattern);
     chart.getStyler().setLegendVisible(false);
     chart.addSeries("a", 1234.5);


### PR DESCRIPTION
## Summary

Fixes #868 — follow-up to the report in [this comment](https://github.com/knowm/XChart/issues/868#issuecomment-5130831871): `setLocale()` had no effect on pie charts because `PlotContent_Pie` froze its `DecimalFormat` symbols in the constructor, which runs inside the `PieChart` constructor — before the user ever gets a chance to call `setLocale()`.

## Changes

- **PlotContent_Pie**: build the `DecimalFormat` at paint time from the styler's current locale and decimal pattern (the axes charts already construct their formatters per repaint, so this brings Pie in line).
- **PlotContent_Pie**: `LabelType.Value` / `NameAndValue` labels used to bypass the formatter via `y.toString()` when no decimal pattern was set, so the locale had no effect on them and they could disagree with the tooltip (which always formats via the `DecimalFormat`). They now always go through the formatter. Note: this means integer-valued series render as `24.0` instead of `24` under the default `#.0` pattern, matching what the tooltip already showed.
- **PlotContent_Dial, PlotContent_Radar, PlotContent_HeatMap, Legend_HeatMap**: these ignored the styler locale entirely and used the JVM default; they now resolve the styler locale at paint time too. Behavior-preserving by default since `Styler`'s locale defaults to `Locale.getDefault()`.

This also addresses the commenter's second point — a custom decimal pattern (`setDecimalPattern`) is now interpreted with the styler locale's symbols, so localized patterns work.

## Tests

- `RegressionTestIssue868`: renders a pie chart with German vs US locale set **after** construction and asserts the images differ — percentage labels, value labels without a pattern, and custom-pattern labels — plus a determinism guard. Fails on the old code, passes with the fix. Headless-safe (renders via `BitmapEncoder`).
- Demo: `TestForIssue868` in `xchart-demo/.../standalone/issues` showing `de_DE` percentage labels set post-construction.

Full `xchart` + `xchart-demo` test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)