### PR TITLE
Issue #1006: JavaFX demo — embed chart in a VBox with other controls; fix Apple Silicon

### DIFF
--- a/xchart-demo/pom.xml
+++ b/xchart-demo/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <!-- skip test compilation during release:prepare's clean verify subprocess -->
         <maven.test.skip>true</maven.test.skip>
+        <javafx.version>17.0.20</javafx.version>
     </properties>
     <dependencies>
         <dependency>
@@ -49,15 +50,17 @@
             <artifactId>webp-imageio</artifactId>
             <version>0.11.0</version>
         </dependency>
+        <!-- JavaFX 17 is the newest LTS line that still runs on Java 11 (the minimum JDK only
+             rose to 17 with JavaFX 21) and the first with Apple Silicon (mac-aarch64) natives. -->
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-swing</artifactId>
-            <version>11.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>11.0.2</version>
+            <version>${javafx.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/JavaFXDemo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/JavaFXDemo.java
@@ -2,14 +2,22 @@ package org.knowm.xchart.standalone;
 
 import javafx.application.Application;
 import javafx.embed.swing.SwingNode;
+import javafx.geometry.Insets;
 import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
-import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.demo.charts.area.AreaChart01;
 
-/** Class showing how to integrate a chart into a JavaFX Stage */
+/**
+ * Class showing how to integrate a chart into a JavaFX Stage, embedded in a layout container
+ * (VBox) alongside other controls so that everything resizes with the window.
+ */
 public class JavaFXDemo extends Application {
 
   public static void main(String[] args) {
@@ -21,10 +29,24 @@ public class JavaFXDemo extends Application {
   public void start(Stage stage) {
 
     final SwingNode swingNode = new SwingNode();
-    JPanel chartPanel = new XChartPanel<>(new AreaChart01().getChart());
-    swingNode.setContent(chartPanel);
-    Scene scene = new Scene(new StackPane(swingNode), 640, 480);
-    stage.setScene(scene);
+    // Swing content must be created on the Swing Event Dispatch Thread
+    SwingUtilities.invokeLater(
+        () -> swingNode.setContent(new XChartPanel<>(new AreaChart01().getChart())));
+
+    // A VBox gives each child its preferred height only; wrap the SwingNode in a resizable pane
+    // and mark it to grow so the chart fills the space left over by the other controls.
+    StackPane chartHolder = new StackPane(swingNode);
+    VBox.setVgrow(chartHolder, Priority.ALWAYS);
+
+    Button closeButton = new Button("Close");
+    closeButton.setOnAction(event -> stage.close());
+    ButtonBar buttonBar = new ButtonBar();
+    buttonBar.getButtons().add(closeButton);
+
+    VBox root = new VBox(10, chartHolder, buttonBar);
+    root.setPadding(new Insets(10));
+
+    stage.setScene(new Scene(root, 640, 480));
     stage.show();
   }
 }


### PR DESCRIPTION
Addresses the question in #1006: how to embed an XChart inside a JavaFX layout container (e.g. a VBox with a ButtonBar) so everything resizes with the window.

## Changes

**JavaFXDemo.java** — now demonstrates the realistic embedding case from the issue:
- The chart's `SwingNode` is wrapped in a `StackPane` marked `VBox.setVgrow(..., Priority.ALWAYS)` — the key line, since a VBox only gives children their preferred height by default and `XChartPanel` reports a fixed preferred size.
- A `ButtonBar` with a Close button sits below the chart; the chart absorbs all resize space while the buttons keep their natural height.
- Swing content is now built on the EDT via `SwingUtilities.invokeLater`, as the SwingNode javadoc requires.

**xchart-demo/pom.xml** — JavaFX bumped 11.0.2 → 17.0.20 (demo module only):
- 11.0.2 ships x86_64-only macOS natives, so the demo crashed with `UnsatisfiedLinkError` on Apple Silicon; `mac-aarch64` artifacts start at 17.0.2.
- 17.x is the newest LTS line that still runs on Java 11 (JavaFX 21 raised the minimum JDK to 17), so this keeps the project's Java 11 baseline intact.

## Testing

Verified manually on an Apple Silicon Mac with `mvn javafx:run -pl xchart-demo`: window opens, chart fills the space above the button bar, and both resize correctly with the window.

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)