### PR TITLE
Fix x-axis line hidden by plot area with OutsideS legend

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue1024.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue1024.java
@@ -1,0 +1,59 @@
+package org.knowm.xchart.standalone.issues;
+
+import java.util.Locale;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.style.Styler.LegendLayout;
+import org.knowm.xchart.style.Styler.LegendPosition;
+import org.knowm.xchart.style.colors.ChartColor;
+
+/**
+ * Demonstrates issue #1024 — after upgrading from 3.8.8 to 4.0.4 the x-axis line disappeared on
+ * charts with a {@code LegendPosition.OutsideS} legend.
+ *
+ * <p>{@code Axis_X.preparePaint()} subtracted the legend height from the top of the x-axis bounds
+ * even though the y-axis (whose bottom defines the plot bottom) had already reserved that space, so
+ * with an {@code OutsideS} legend the x-axis bounds started a legend-height <em>inside</em> the plot
+ * area. That was harmless while the axis line was positioned from the painted tick label geometry,
+ * but 4.0.4 anchors the line and tick marks to the top of the x-axis bounds — placing them under
+ * the plot, which is painted afterwards and covers them. The light grey plot background from the
+ * original report makes the missing black line obvious.
+ *
+ * <p>Run this and look below the plot: the x-axis line and tick marks sit plotMargin under the grey
+ * plot area, exactly as in 3.8.8.
+ */
+public class TestForIssue1024 {
+
+  public static void main(String[] args) {
+
+    new SwingWrapper<>(getChart()).displayChart();
+  }
+
+  /** Constructs and returns the chart without launching a window (headless-safe). */
+  public static XYChart getChart() {
+
+    XYChart chart = new XYChartBuilder().width(261).height(268).build();
+
+    // styler settings verbatim from the issue report
+    chart.getStyler().setPlotGridLinesColor(ChartColor.WHITE.getColor());
+
+    chart
+        .getStyler()
+        .setLocale(Locale.GERMANY)
+        .setChartTitleVisible(true)
+        .setPlotBorderVisible(false)
+        .setLegendBorderColor(null)
+        .setPlotBackgroundColor(ChartColor.LIGHT_GREY.getColor())
+        .setChartBackgroundColor(ChartColor.WHITE.getColor())
+        .setLegendPadding(5)
+        .setLegendPosition(LegendPosition.OutsideS)
+        .setLegendLayout(LegendLayout.Horizontal);
+
+    // two points sloping from 2 down to 1, x around 30000 so the German locale renders the
+    // "30.000" tick label seen in the report's screenshots
+    chart.addSeries("0", new double[] {30000, 31000}, new double[] {2, 1});
+
+    return chart;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis_X.java
@@ -61,7 +61,7 @@ public class Axis_X<ST extends AxesChartStyler, S extends AxesChartSeries> exten
             leftYAxisBounds.getY() + leftYAxisBounds.getHeight(),
             rightYAxisBounds.getY() + rightYAxisBounds.getHeight());
     double xOffset = leftYAxisBounds.getWidth() + leftYAxisBounds.getX();
-    double yOffset = maxYAxisY + axesChartStyler.getPlotMargin() - legendHeightOffset;
+    double yOffset = maxYAxisY + axesChartStyler.getPlotMargin();
 
     double legendWidth = 0;
     if (axesChartStyler.getLegendPosition() == LegendPosition.OutsideE
@@ -85,7 +85,8 @@ public class Axis_X<ST extends AxesChartStyler, S extends AxesChartSeries> exten
         chart.getHeight()
             - maxYAxisY
             - axesChartStyler.getChartPadding()
-            - axesChartStyler.getPlotMargin();
+            - axesChartStyler.getPlotMargin()
+            - legendHeightOffset;
 
     bounds.setRect(xOffset, yOffset, width, height);
   }

--- a/xchart/src/test/java/org/knowm/xchart/internal/chartpart/AxisLinePlotMarginTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/internal/chartpart/AxisLinePlotMarginTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.knowm.xchart.BitmapEncoder;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.style.Styler.LegendLayout;
+import org.knowm.xchart.style.Styler.LegendPosition;
 
 // The axis tick lines that hug the plot area must sit at the same distance (plotMargin) from the
 // plot on both the y-axis and x-axis sides. Historically the y-axis line was positioned from the
@@ -21,13 +23,38 @@ class AxisLinePlotMarginTest {
   @Test
   void axisLinesSitAtPlotMarginOnBothSides() throws Exception {
 
+    XYChart chart = buildChart();
+    chart.getStyler().setLegendVisible(false);
+
+    assertAxisLinesAtPlotMargin(chart);
+  }
+
+  // Issue #1024: Axis_X.preparePaint() subtracted the OutsideS legend height from the top of the
+  // x-axis bounds even though the y-axis (whose bottom defines the plot bottom) had already
+  // reserved that space, so the x-axis line — anchored to that top — was drawn inside the plot
+  // area and painted over by the plot background.
+  @Test
+  void axisLinesSitAtPlotMarginWithOutsideSLegend() throws Exception {
+
+    XYChart chart = buildChart();
+    chart.getStyler().setLegendPosition(LegendPosition.OutsideS);
+    chart.getStyler().setLegendLayout(LegendLayout.Horizontal);
+
+    assertAxisLinesAtPlotMargin(chart);
+  }
+
+  private static XYChart buildChart() {
+
     XYChart chart = new XYChartBuilder().width(800).height(600).title("t").build();
     chart.addSeries("s", new double[] {1, 2, 3}, new double[] {10, 20, 30});
-    chart.getStyler().setLegendVisible(false);
     chart.getStyler().setPlotGridLinesVisible(false);
     chart.getStyler().setPlotBackgroundColor(Color.YELLOW);
     chart.getStyler().setPlotBorderVisible(true);
     chart.getStyler().setPlotBorderColor(Color.RED);
+    return chart;
+  }
+
+  private static void assertAxisLinesAtPlotMargin(XYChart chart) throws Exception {
 
     BufferedImage img = BitmapEncoder.getBufferedImage(chart);
 


### PR DESCRIPTION
Fixes #1024.

## Root cause

`Axis_X.preparePaint()` subtracted the `OutsideS` legend height from the **top** of the x-axis bounds even though `Axis_Y.preparePaint()` had already reserved that space when computing the y-axis height — and the y-axis bottom is what defines the plot bottom. With a visible `OutsideS` legend, the x-axis bounds therefore started a legend-height *inside* the plot area. The bounds height did not subtract the legend, so only the top edge was wrong.

This double-subtraction dates back to at least 3.8.8 but was latent: the axis line used to be positioned bottom-up from the painted tick label geometry. Since #1023 (4.0.4) the x-axis line and tick marks are anchored to the top of the x-axis bounds — placing them inside the plot area, which is painted afterwards and covers them. Measured on a 400×400 chart: plot bottom 351.7, correct line y 355.7, actual bounds top 337.4.

## Fix

Move the legend height subtraction from the bounds' y-offset to the bounds' height. The bottom edge is unchanged (`chartHeight - chartPadding - legendHeight`, same as before), so the bottom-anchored x-axis title and tick label positioning is unaffected; only the line/marks anchor moves back to `plotBottom + plotMargin`.

## Tests / demo

- `AxisLinePlotMarginTest` gains an `OutsideS`-legend variant of the existing pixel-scanning margin check (headless, no `XChartPanel`). It fails without the fix ("x-axis line must be found below the plot") and passes with it.
- `TestForIssue1024` demo added, reproducing the reported chart (grey plot, white grid lines, `OutsideS` horizontal legend, German-locale labels).
- Full xchart suite: 169 tests, 0 failures.

| before (4.0.4) | after |
|---|---|
| x-axis line hidden under plot | line + tick marks at plotMargin below plot, as in 3.8.8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)